### PR TITLE
feat: JPA 공통 엔티티(BaseEntity) 계층 구조 적용

### DIFF
--- a/src/main/java/com/t1/popcon/common/entity/BaseAuditEntity.java
+++ b/src/main/java/com/t1/popcon/common/entity/BaseAuditEntity.java
@@ -1,0 +1,16 @@
+package com.t1.popcon.common.entity;
+
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseAuditEntity extends BaseTimeEntity {
+	@CreatedBy
+	protected Long createdBy;
+
+	@LastModifiedBy
+	protected Long updatedBy;
+}

--- a/src/main/java/com/t1/popcon/common/entity/BaseIdEntity.java
+++ b/src/main/java/com/t1/popcon/common/entity/BaseIdEntity.java
@@ -1,0 +1,15 @@
+package com.t1.popcon.common.entity;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseIdEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	protected Long id;
+}

--- a/src/main/java/com/t1/popcon/common/entity/BaseSoftDeleteEntity.java
+++ b/src/main/java/com/t1/popcon/common/entity/BaseSoftDeleteEntity.java
@@ -1,0 +1,25 @@
+package com.t1.popcon.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseSoftDeleteEntity extends BaseAuditEntity {
+
+	@Column(nullable = false)
+	protected boolean deleted = false;
+
+	protected LocalDateTime deletedAt;
+
+	protected Long deletedBy;
+
+	public void markDeleted(Long deleterId) {
+		this.deleted = true;
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = deleterId;
+	}
+}

--- a/src/main/java/com/t1/popcon/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/t1/popcon/common/entity/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.t1.popcon.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity extends BaseIdEntity {
+	@CreatedDate
+	protected LocalDateTime createdAt;
+
+	@LastModifiedDate
+	protected LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #2 

## 📝 작업 내용

- `common.entity` 패키지에 4가지 BaseEntity 구현
  - BaseIdEntity: PK 자동 생성
  - BaseTimeEntity: 생성일/수정일 자동화
  - BaseAuditEntity: 생성자/수정자 필드 추가 (Security 연동 예정)
  - BaseSoftDeleteEntity: 논리적 삭제 지원

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> AuditEntity의 createdBy는 추후 SecurityContextHolder 설정 후 작동합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 백엔드 기반 구조 개선으로 감사 추적 및 소프트 삭제 기능을 지원하는 엔티티 계층 강화
  * 시스템 안정성 및 데이터 관리 기능 향상

---

**참고:** 이 업데이트는 내부 기술 개선사항으로, 사용자에게 직접 보이는 새로운 기능은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->