### PR TITLE
feat: 공통 예외 처리 및 응답 포맷 적용

### DIFF
--- a/src/main/java/com/t1/popcon/common/exception/CustomException.java
+++ b/src/main/java/com/t1/popcon/common/exception/CustomException.java
@@ -1,0 +1,34 @@
+package com.t1.popcon.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final Object data;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.data = null;
+    }
+
+    public CustomException(ErrorCode errorCode, String overrideMessage) {
+        super(overrideMessage);
+        this.errorCode = errorCode;
+        this.data = null;
+    }
+
+    public CustomException(ErrorCode errorCode, Object data) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.data = data;
+    }
+
+    public CustomException(ErrorCode errorCode, String overrideMessage, Object data) {
+        super(overrideMessage);
+        this.errorCode = errorCode;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/t1/popcon/common/exception/ErrorCode.java
+++ b/src/main/java/com/t1/popcon/common/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.t1.popcon.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Auth
+
+    // Client
+    INVALID_INPUT("C001", HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+
+    // System
+    ERROR_SYSTEM("S001", HttpStatus.INTERNAL_SERVER_ERROR, "처리 중 오류가 발생했습니다. 다시 시도해주세요.");
+
+    private final String code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/t1/popcon/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/t1/popcon/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,74 @@
+package com.t1.popcon.common.exception;
+
+import com.t1.popcon.common.response.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * CustomException 처리
+     */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustom(CustomException e) {
+        ErrorCode ec = e.getErrorCode();
+
+        if (e.getData() != null) {
+            return ResponseEntity.status(ec.getStatus())
+                .body(ApiResponse.fail(ec, e.getData()));
+        }
+
+        return ResponseEntity.status(ec.getStatus())
+            .body(ApiResponse.fail(ec));
+    }
+
+    /**
+     * DTO 검증 실패 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+
+        for (FieldError fe : e.getBindingResult().getFieldErrors()) {
+            String key = fe.getField();
+            String msg = fe.getDefaultMessage() == null ? "입력값이 올바르지 않습니다." : fe.getDefaultMessage();
+            fieldErrors.putIfAbsent(key, msg);
+        }
+
+        ErrorCode ec = ErrorCode.INVALID_INPUT;
+        return ResponseEntity.status(ec.getStatus())
+            .body(ApiResponse.fail(ec, fieldErrors));
+    }
+
+    /**
+     * 파라미터 검증 실패 처리
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolation(ConstraintViolationException e) {
+        ErrorCode ec = ErrorCode.INVALID_INPUT;
+        return ResponseEntity.status(ec.getStatus())
+            .body(ApiResponse.fail(ec));
+    }
+
+    /**
+     * 기타 서버 오류 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+
+        ErrorCode ec = ErrorCode.ERROR_SYSTEM;
+        return ResponseEntity.status(ec.getStatus())
+            .body(ApiResponse.fail(ec));
+    }
+}

--- a/src/main/java/com/t1/popcon/common/response/ApiResponse.java
+++ b/src/main/java/com/t1/popcon/common/response/ApiResponse.java
@@ -1,0 +1,51 @@
+package com.t1.popcon.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.t1.popcon.common.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    private static final String SUCCESS = "SUCCESS";
+    private static final String DEFAULT_SUCCESS_MESSAGE = "성공하였습니다.";
+
+    private final String code;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T data;
+
+    // ====== 성공 응답 ======
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return new ApiResponse<>(SUCCESS, message, data);
+    }
+
+    public static ApiResponse<Void> ok(String message) {
+        return new ApiResponse<>(SUCCESS, message, null);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(SUCCESS, DEFAULT_SUCCESS_MESSAGE, data);
+    }
+
+    // ====== 실패 응답 ======
+    public static ApiResponse<Void> fail(String code, String message) {
+        return new ApiResponse<>(code, message, null);
+    }
+
+    public static <T> ApiResponse<T> fail(String code, String message, T data) {
+        return new ApiResponse<>(code, message, data);
+    }
+
+    public static ApiResponse<Void> fail(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, T data) {
+        return new ApiResponse<>(errorCode.getCode(), errorCode.getMessage(), data);
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
> Closes #4

## 📝 작업 내용
* `common` 패키지 하위에 `response`, `exception` 패키지 구성
* `ApiResponse`(공통 성공/실패 응답 포맷: `code`, `message`, `data`) 구현
* `ErrorCode`(HTTP 상태, 내부 코드, 메시지) 정의
*  `CustomException`(서비스 레벨 표준 예외) 구현
* `GlobalExceptionHandler`(전역 예외 처리기) 구현

  * `CustomException` 처리
  * `@Valid` 요청 검증 실패 처리(`MethodArgumentNotValidException` → 필드별 메시지 Map)
  * 파라미터 검증 실패 처리(`ConstraintViolationException`)
  * 기타 예외 처리(`Exception` → 시스템 오류)

## ✅ 테스트 결과 (선택)


## 📷 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 표준화된 예외 처리 및 API 응답 체계를 도입했습니다. 일관된 오류 메시지와 HTTP 상태 코드를 통해 API 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->