### PR TITLE
feat: 약관동의 및 가입완료 구현

### DIFF
--- a/src/main/java/com/t1/popcon/auth/controller/AuthController.java
+++ b/src/main/java/com/t1/popcon/auth/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.t1.popcon.auth.controller;
+
+import com.t1.popcon.auth.dto.AuthRequest;
+import com.t1.popcon.auth.dto.AuthResponse;
+import com.t1.popcon.auth.service.AuthService;
+import com.t1.popcon.common.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse<AuthResponse.Signup>> signup(
+		@Valid @RequestBody AuthRequest.Signup request
+	) {
+		// @AuthenticationPrincipal Long userId
+		Long dummyUserId = 1L;
+
+		AuthResponse.Signup response = authService.signup(dummyUserId, request);
+
+		return ResponseEntity.ok(ApiResponse.ok("약관 동의 및 회원가입이 완료되었습니다.", response));
+	}
+}

--- a/src/main/java/com/t1/popcon/auth/dto/AuthRequest.java
+++ b/src/main/java/com/t1/popcon/auth/dto/AuthRequest.java
@@ -1,0 +1,33 @@
+package com.t1.popcon.auth.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+public class AuthRequest {
+
+	public record Signup(
+		@Valid
+		@NotNull(message = "약관 동의 정보가 필요합니다.")
+		Agreements agreements
+	) {
+	}
+
+	public record Agreements(
+		@NotNull(message = "필수 약관 항목이 누락되었습니다.")
+		@AssertTrue(message = "필수 동의 항목입니다.")
+		Boolean isPrivacyPolicyAgreed,
+
+		@NotNull(message = "필수 약관 항목이 누락되었습니다.")
+		@AssertTrue(message = "필수 동의 항목입니다.")
+		Boolean isIdentifierPolicyAgreed,
+
+		@NotNull(message = "필수 약관 항목이 누락되었습니다.")
+		@AssertTrue(message = "필수 동의 항목입니다.")
+		Boolean isServicePolicyAgreed,
+
+		@NotNull(message = "선택 약관 항목이 누락되었습니다.")
+		Boolean isMarketingAgreed
+	) {
+	}
+}

--- a/src/main/java/com/t1/popcon/auth/dto/AuthResponse.java
+++ b/src/main/java/com/t1/popcon/auth/dto/AuthResponse.java
@@ -1,0 +1,43 @@
+package com.t1.popcon.auth.dto;
+
+import java.time.LocalDateTime;
+
+public class AuthResponse {
+
+	public record Signup(
+		Long userId,
+		String name,
+		String accessToken,
+		String refreshToken,
+		LocalDateTime joinedAt
+	) {
+
+		// 임시 팩토리 메서드 (User 엔티티 완성 전까지 사용하는 가짜 데이터용)
+		public static Signup mockOf() {
+			return new Signup(
+				999L,
+				"임시유저",
+				"mock_access_token_123",
+				"mock_refresh_token_456",
+				LocalDateTime.now()
+			);
+		}
+
+		/*
+
+		TODO: 나중에 User 엔티티 완성되면 주석 해제하고 사용
+
+        public static Signup of(User user, String accessToken, String refreshToken) {
+            return new Signup(
+                user.getId(),
+                user.getName(),
+                accessToken,
+                refreshToken,
+                user.getJoinedAt()
+            );
+        }
+
+  	*/
+
+	}
+}

--- a/src/main/java/com/t1/popcon/auth/service/AuthService.java
+++ b/src/main/java/com/t1/popcon/auth/service/AuthService.java
@@ -1,0 +1,20 @@
+package com.t1.popcon.auth.service;
+
+import com.t1.popcon.auth.dto.AuthRequest;
+import com.t1.popcon.auth.dto.AuthResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	public AuthResponse.Signup signup(Long userId, AuthRequest.Signup request) {
+
+		log.info("회원가입 요청 도달 - userId: {}, request: {}", userId, request);
+
+		return AuthResponse.Signup.mockOf();
+	}
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #7

## 📝 작업 내용

* `auth` 패키지 생성 및 하위에 약관동의 및 가입완료 기능 구현
  * `AuthRequest`, `AuthResponse` 파일 생성, DTO 구현
     *   `AuthResponse` : `User` 구현 시 수정 필요
  * `AuthController` 파일 생성
     * `Security` 필터 구현 이후 수정 필요 
  * `AuthService` 파일 생성 
     * `User` 구현 이후 실제 로직 구현 및 수정 필요 (현재는 mock 데이터로 실행) 
 

## ✅ 테스트 결과 (선택)

>
<img width="1149" height="729" alt="스크린샷 2026-02-20 오후 9 22 01" src="https://github.com/user-attachments/assets/1536b186-6a57-4873-8254-2df66bc826c6" />


## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> 포스트맨 실행 결과 응답은 잘 나오지만 API 명세에 작성한 형식에 맞춰
> `code, message, data` 순으로 출력하려면
> `ApiResponse` 파일에 `@JsonPropertyOrder({"code", "message", "data"})` 추가해주면 좋을것 같네요