### PR TITLE
chore: PR CI 워크플로우 추가 (테스트/문서/도커빌드)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,7 +2,7 @@ name: CI(PR) - Test + Docs + Docker Build
 
 on:
   pull_request:
-    branches: [ "dev" ]
+    branches: ["dev"]
 
 permissions:
   contents: read
@@ -10,46 +10,8 @@ permissions:
 jobs:
   test-and-docs:
     runs-on: ubuntu-latest
-
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_DATABASE: popcon
-          MYSQL_USER: popcon
-          MYSQL_PASSWORD: popcon
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=20
-
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd="redis-cli ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=20
-
     env:
-      # application-prod.yml 기반으로 환경변수 주입
-      SPRING_PROFILES_ACTIVE: prod
-
-      DB_HOST: 127.0.0.1
-      DB_PORT: 3306
-      DB_NAME: popcon
-      DB_USERNAME: popcon
-      DB_PASSWORD: popcon
-
-      REDIS_HOST: 127.0.0.1
-      REDIS_PORT: 6379
-      REDIS_PASSWORD: ""
+      SPRING_PROFILES_ACTIVE: test
 
     steps:
       - name: Checkout
@@ -68,44 +30,36 @@ jobs:
       - name: Ensure swagger-ui dir exists
         run: mkdir -p src/main/resources/static/swagger-ui
 
-      - name: Install redis-cli & mysql client
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y redis-tools mysql-client
+      # test 프로필로 단위 테스트 + 문서 복사
+      - name: Test + Docs (OpenAPI copy)
+        run: ./gradlew --no-daemon clean test copyOasToSwagger
 
-      - name: Wait for Redis
-        run: |
-          for i in {1..30}; do
-            if redis-cli -h 127.0.0.1 -p 6379 ping | grep -q PONG; then
-              echo "Redis OK"; exit 0
-            fi
-            echo "Waiting for Redis..."; sleep 2
-          done
-          echo "Redis NOT ready"; exit 1
-
-      - name: Wait for MySQL
-        run: |
-          for i in {1..30}; do
-            if mysqladmin ping -h 127.0.0.1 -uroot -proot --silent; then
-              echo "MySQL OK"; exit 0
-            fi
-            echo "Waiting for MySQL..."; sleep 2
-          done
-          echo "MySQL NOT ready"; exit 1
-
-      - name: Test + Docs (OpenAPI 생성/merge/복사)
-        run: ./gradlew clean test copyOasToSwagger
+      # job 간 공유를 위해 swagger-ui 산출물 전달
+      - name: Upload swagger-ui artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: swagger-ui
+          path: src/main/resources/static/swagger-ui
+          if-no-files-found: warn
 
   docker-build:
     runs-on: ubuntu-latest
     needs: test-and-docs
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download swagger-ui artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: swagger-ui
+          path: src/main/resources/static/swagger-ui
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # PR에서는 빌드만 검증 (push 없음)
       - name: Docker build (no push)
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
## #️⃣ 관련 이슈

> (없음)

## 📝 작업 내용

> PR 머지 전에 품질을 검증할 수 있도록 PR 전용 CI 워크플로우를 추가했습니다.
- `dev` 브랜치 대상 PR 생성/업데이트 시 CI 자동 실행
- 테스트 실행 프로필을 `test`로 고정하여 외부 인프라(예: Redis/Redisson) 의존으로 인한 CI 실패 방지
- `./gradlew clean test copyOasToSwagger`로 테스트 + OpenAPI 문서 복사까지 검증
- 잡 분리로 인한 결과물 누락 방지를 위해 swagger-ui 디렉토리를 artifact로 업/다운로드
- Docker 이미지 빌드 가능 여부 확인 (푸시 없음)

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

>