### PR TITLE
fix: prod profile에서 Swagger 접근 가능 및 Docker 빌드 전략 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
 
 # 소스 코드 복사 및 실행 가능한 jar 파일 빌드
 COPY src src
-RUN ./gradlew bootJar -x test --no-daemon && rm -f build/libs/*-plain.jar
+RUN ./gradlew clean build --no-daemon \
+    && rm -f build/libs/*-plain.jar
 
 # 2. 실행 단계 (Run Stage)
 FROM eclipse-temurin:21-jre-jammy

--- a/src/main/java/com/t1/popcon/common/config/SwaggerConfig.java
+++ b/src/main/java/com/t1/popcon/common/config/SwaggerConfig.java
@@ -6,7 +6,7 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@Profile({"default", "local"})
+@Profile({"default", "local", "prod"})
 public class SwaggerConfig implements WebMvcConfigurer {
 
 	@Override


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #23 


## 📝 작업 내용

* SwaggerConfig에 prod profile 추가
→ prod profile에서도 /swagger-ui/ 리소스 매핑 활성화

>SwaggerConfig 를 확인해보니 local profile에서만 활성화되도록 설정되어 있었습니다.
현재 Dev 서버가 prod profile로 실행되고 있어 Swagger UI 접근이 불가능할 것 같습니다.! 우선 prod profile도 허용하도록 수정했습니다. 한번 확인 부탁드립니다  🙌 

* Dockerfile 빌드 전략 수정
→ bootJar -x test 제거
→ clean build 실행하도록 변경

## ✅ 테스트 결과 (선택)
로컬에서는 스웨거 접속이 잘되는거 확인했습니다!

## 📷 스크린샷 (선택)
x

## 💬 리뷰 요구사항(선택)
x