### PR TITLE
feat: 팝업 섹션/카드 응답 DTO 추가

### DIFF
--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/OverlayType.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/OverlayType.java
@@ -1,0 +1,7 @@
+package com.t1.popcon.popup.dto.card;
+
+public enum OverlayType {
+    RANK,
+    AUCTION_OPEN_AT,
+    DRAW_OPEN_AT
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PhaseStatus.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PhaseStatus.java
@@ -1,0 +1,7 @@
+package com.t1.popcon.popup.dto.card;
+
+public enum PhaseStatus {
+    UPCOMING,
+    OPEN,
+    CLOSED
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PhaseType.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PhaseType.java
@@ -1,0 +1,6 @@
+package com.t1.popcon.popup.dto.card;
+
+public enum PhaseType {
+    AUCTION,
+    DRAW
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupCardDto.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupCardDto.java
@@ -1,0 +1,36 @@
+package com.t1.popcon.popup.dto.card;
+
+import java.time.OffsetDateTime;
+
+public record PopupCardDto(
+    Long popupId,
+    String title,
+    String supportingText,
+    String subText,
+    String caption,
+    String thumbnailUrl,
+    Boolean liked,
+    StatsDto stats,
+    OverlayDto overlay,
+    PhaseDto phase
+) {
+    public record StatsDto(
+        long likeCount,
+        long viewCount
+    ) {
+    }
+
+    public record OverlayDto(
+        OverlayType type,
+        Integer rank
+    ) {
+    }
+
+    public record PhaseDto(
+        PhaseType type,
+        PhaseStatus status,
+        OffsetDateTime openAt,
+        OffsetDateTime closeAt
+    ) {
+    }
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/section/PopupSectionResponse.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/section/PopupSectionResponse.java
@@ -1,0 +1,11 @@
+package com.t1.popcon.popup.dto.section;
+
+import com.t1.popcon.popup.dto.card.PopupCardDto;
+import java.util.List;
+
+public record PopupSectionResponse<T>(
+    SectionKey sectionKey,
+    int itemCount,
+    List<T> items
+) {
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/section/SectionKey.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/section/SectionKey.java
@@ -1,0 +1,14 @@
+package com.t1.popcon.popup.dto.section;
+
+public enum SectionKey {
+    // Home
+    BANNERS,
+    RECOMMENDED,
+    RANKINGS_WEEKLY,
+    AUCTIONS,
+    DRAWS_OPEN,
+    DRAWS_UPCOMING,
+    FEATURED,
+    ENDING_SOON,
+    MAGAZINES
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #39 

## 📝 작업 내용

- `PopupSectionResponse<T>` DTO 추가
  - 제네릭 구조로 작성하여 팝업 카드와 매거진 카드 섹션을 모두 지원하도록 구성
- `PopupCardDto` 정의
- 카드 내부 DTO (Stats, Overlay, Phase) 구성
- 섹션/카드 관련 enum 정의

### 패키지 구조
```
com.t1.popcon.popup
└─ dto
   ├─ section
   │  ├─ PopupSectionResponse.java
   │  └─ SectionKey.java
   └─ card
     ├─ PopupCardDto.java
     ├─ OverlayType.java
     ├─ PhaseType.java
     └─ PhaseStatus.java
```

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)
