### PR TITLE
fix : Swagger OpenAPI 경로 상대경로로 수정

### DIFF
--- a/auth-service/src/main/resources/static/swagger-ui/swagger-initializer.js
+++ b/auth-service/src/main/resources/static/swagger-ui/swagger-initializer.js
@@ -3,7 +3,7 @@ window.onload = function() {
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: "/swagger-ui/auth/openapi3.yaml",
+    url: "./auth/openapi3.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #이슈번호
> x

## 📝 작업 내용

> Ingress 경로 prefix(/auth) 환경에서 Swagger UI가 /openapi3.yaml을 잘못된 절대경로로 요청하여 404가 발생하던 문제 수정.


Swagger initializer의 spec 경로를 상대경로(./auth/openapi3.yaml)로 변경하여 OpenAPI 문서를 로드하도록 수정.
