### PR TITLE
fix: argoCD health check를 위한 security filter 설정

### DIFF
--- a/popup-service/src/main/java/com/t1/popcon/config/PopupSecurityConfig.java
+++ b/popup-service/src/main/java/com/t1/popcon/config/PopupSecurityConfig.java
@@ -31,7 +31,7 @@ public class PopupSecurityConfig extends CommonSecurityConfig {
 				"/health",
 				"/v3/api-docs/**",
 				"/swagger-ui/**",
-				"/actuator/**",
+				"/actuator/**"
 			).permitAll()
 			.anyRequest().authenticated()
 		);


### PR DESCRIPTION
## #️⃣ 관련 이슈

X

## 📝 작업 내용

k3s 배포 시 health check api를 통해 서버가 정상적으로 떴는지 검증합니다.
이 과정에서 인증 문제로 health check가 실패하는 현상이 있어 security filter 쪽에 health check 엔드포인트를 추가했습니다.
추후 다른 서비스 작업 시에도 해당 부분 한번 확인 부탁드립니다.


## 💬 리뷰 요구사항(선택)

auth 및 user 서비스에는 저희가 배포 테스트 해보면서 작업해 두었습니다
https://github.com/kt-cloud-TECHUP-T1/pop-con-backend/pull/65

추가적으로, k3s 라우팅 설정 문제로 swagger 사용 시 경로 지정할 때 상대경로로 지정해주셔야 정상적으로 페이지가 뜨는 문제가 있었습니다.
이 부분도 저희가 수정해두고 개발팀에는 미처 공유하지 못한 것 같아 추가적으로 언급드립니다.
https://github.com/kt-cloud-TECHUP-T1/pop-con-backend/pull/66
해당 PR 확인해주시고 다른 서비스에 swagger 작업 시 경로 확인 부탁드립니다😄