### PR TITLE
fix: user-service의 portone 관련 설정을 모든 환경에서 공유하도록 수정

### DIFF
--- a/user-service/src/main/resources/application-local.yml
+++ b/user-service/src/main/resources/application-local.yml
@@ -41,9 +41,3 @@ jwt:
 server:
   port: 8081
   shutdown: graceful
-
-portone:
-  api:
-    secret: ${PORTONE_API_SECRET}
-    store-id: ${PORTONE_STORE_ID}
-  url: "https://api.portone.io"

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -18,3 +18,9 @@ spring:
         format_sql: true
         show_sql: true
     defer-datasource-initialization: true
+
+portone:
+  api:
+    secret: ${PORTONE_API_SECRET}
+    store-id: ${PORTONE_STORE_ID}
+  url: "https://api.portone.io"


### PR DESCRIPTION
## #️⃣ 관련 이슈

#59

## 📝 작업 내용

portone 관련 설정을 local 및 staging 환경 모두 사용할 수 있도록 application.yaml 쪽으로 변경

## 💬 리뷰 요구사항(선택)

<img width="1335" height="780" alt="image" src="https://github.com/user-attachments/assets/f9916abf-d584-4a03-89d2-9ff32f8eae0b" />
#68 배포 후 서버에서 portone 관련 변수를 찾지 못하는 문제가 있었습니다.
확인해 보니 local 환경에서만 사용 가능하도록 작업해 두신 것 같아 staging 환경에서도 참조할 수 있도록 공통 설정으로 옮겼습니다.

또, 해당 부분에서 환경 변수가 새로 추가된 것을 확인했습니다(PORTONE_API_SECRET, PORTONE_STORE_ID).
백엔드 환경 변수 추가 시 서버에도 새로 등록을 해야 하니 환경 변수 관련 변경 사항이 생기면 클라우드 팀에도 꼭 고지 부탁드립니다.