### PR TITLE
bug : auth application.properties 수정

### DIFF
--- a/auction-service/src/main/resources/application-staging.yml
+++ b/auction-service/src/main/resources/application-staging.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create   # TODO : 소스코드 어느정도 나오면 update로 변경할 것
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:
@@ -23,7 +23,7 @@ spring:
         enabled: true
 
 server:
-  port: 8083
+  port: 8080
   shutdown: graceful
 
 logging:

--- a/auth-service/src/main/resources/application-staging.yml
+++ b/auth-service/src/main/resources/application-staging.yml
@@ -42,7 +42,7 @@ services:
 
 spring:
   datasource:
-    url: ${DB_URL}
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}


### PR DESCRIPTION
## #️⃣ 관련 이슈
x

## 📝 작업 내용

> 현재 auth-service가 정상적으로 기동되지 않는 문제가 발생했습니다. 애플리케이션 실행 중 DB 연결 단계에서 실패하며, Spring Boot가 초기화되지 못하고 종료됩니다.

원인 : Kubernetes 환경에 DB_URL 환경변수가 정의되지 않아 치환이 되지 않음. 그 결과 ${DB_URL} 값이 그대로 들어가면서 DB 연결 실패

서버에서는 다음과 같이 환경변수 조합방식으로 db url을 구성해서 사용중입니다.
`url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8`

또한 서버에서는 모든 서비스가 동일하게 8080 포트를 사용하도록 구성되어 있습니다.

## 📷 스크린샷 (선택)
x

## 💬 리뷰 요구사항(선택)
x