### PR TITLE
bug: auth redis TLS 설정 추가

### DIFF
--- a/auth-service/src/main/resources/application-staging.yml
+++ b/auth-service/src/main/resources/application-staging.yml
@@ -60,6 +60,8 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
+      ssl:
+        enabled: true
 
 logging:
   level:


### PR DESCRIPTION
## #️⃣ 관련 이슈
x

## 📝 작업 내용

> 현재 auth service가 Redis 연결 실패로 인해 기동되지 않는 문제가 있습니다.

확인해보니 기존에 적용되어 있던 Redis SSL 설정(`ssl.enabled: true`)이 어느 시점 커밋에서 제거된 것 같습니다. 그로 인해 AUTH timeout이 발생한 것으로 확인되었습니다.

누락된 SSL 설정 다시 추가했습니다


## 💬 리뷰 요구사항(선택)

x