### PR TITLE
fix: 스테이징/운영 환경에서 redis tls 설정

### DIFF
--- a/anti-macro-service/src/config/redis.ts
+++ b/anti-macro-service/src/config/redis.ts
@@ -1,10 +1,13 @@
-import Redis from 'ioredis';
-import { env } from './env';
+import Redis from "ioredis";
+import { env } from "./env";
+
+const isTlsRequired = env.REDIS_HOST.includes("amazonaws.com");
 
 export const redis = new Redis({
   host: env.REDIS_HOST,
   port: env.REDIS_PORT,
   password: env.REDIS_PASSWORD,
+  tls: isTlsRequired ? {} : undefined,
   maxRetriesPerRequest: 3,
   enableOfflineQueue: false,
   connectTimeout: 5000,
@@ -14,14 +17,14 @@ export const redis = new Redis({
   },
 });
 
-redis.on('connect', () => console.log('[redis] 연결 성공'));
-redis.on('error', (err) => console.error('[redis] 연결 에러:', err.message));
+redis.on("connect", () => console.log("[redis] 연결 성공"));
+redis.on("error", (err) => console.error("[redis] 연결 에러:", err.message));
 
 /** Redis 연결 완료 대기 */
 export function waitForRedis(): Promise<void> {
-  if (redis.status === 'ready') return Promise.resolve();
+  if (redis.status === "ready") return Promise.resolve();
   return new Promise((resolve, reject) => {
-    redis.once('ready', resolve);
-    redis.once('error', reject);
+    redis.once("ready", resolve);
+    redis.once("error", reject);
   });
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

https://github.com/kt-cloud-TECHUP-T1/pop-con-backend/pull/118

## 📝 작업 내용

스테이징/운영 환경에서 Elasticache 접근 시 tls 설정이 되어있지 않아 연결되지 않는 문제 수정
(anti-macro 브랜치에 푸쉬했었는데 staging쪽 PR에서는 누락된 것 같아 추가했습니다)