### PR TITLE
fix: 경매 상세 조회와 SSE 구독 조회 같은 응답 사용하도록 수정

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/dto/response/AuctionDetailResponse.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/dto/response/AuctionDetailResponse.java
@@ -24,6 +24,7 @@ public record AuctionDetailResponse(
         Integer priceDropUnit,
         Integer priceDropIntervalSeconds,
         Long secondsUntilNextDrop,
+        Long displaySecondsUntilNextDrop,
         Integer maxPurchaseQuantityPerRound,
         Boolean canParticipate,
         String buttonStatus
@@ -38,6 +39,7 @@ public record AuctionDetailResponse(
             Integer nextPrice,
             Integer discountAmount,
             Long secondsUntilNextDrop,
+            Long displaySecondsUntilNextDrop,
             Boolean canParticipate,
             AuctionButtonStatus buttonStatus
     ) {
@@ -57,6 +59,7 @@ public record AuctionDetailResponse(
                 .priceDropUnit(auction.getPriceDropUnit())
                 .priceDropIntervalSeconds(auction.getPriceDropIntervalSeconds())
                 .secondsUntilNextDrop(secondsUntilNextDrop)
+                .displaySecondsUntilNextDrop(displaySecondsUntilNextDrop)
                 .maxPurchaseQuantityPerRound(auction.getStockPerOption())
                 .canParticipate(canParticipate)
                 .buttonStatus(buttonStatus.name())

--- a/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionQueryService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionQueryService.java
@@ -49,6 +49,12 @@ public class AuctionQueryService {
                 now,
                 priceAnchor.restockAnchorAt()
         );
+        Long displaySecondsUntilNextDrop = auctionPriceService.calculateDisplaySecondsUntilNextDrop(
+                auction,
+                auctionStatus,
+                now,
+                priceAnchor.restockAnchorAt()
+        );
 
         Boolean canParticipate = auctionPriceService.canParticipate(auctionStatus);
         AuctionButtonStatus buttonStatus = auctionPriceService.calculateButtonStatus(auctionStatus);
@@ -63,6 +69,7 @@ public class AuctionQueryService {
                 nextPrice,
                 discountAmount,
                 secondsUntilNextDrop,
+                displaySecondsUntilNextDrop,
                 canParticipate,
                 buttonStatus
         );


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #137 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 경매 상세 조회 API와 SSE 구독 API의 응답 data payload를 동일한 형태로 맞췄습니다.
- 경매 상세 조회 응답에 displaySecondsUntilNextDrop 필드를 추가했습니다.
- 상세 조회에서도 SSE와 동일한 정책으로 displaySecondsUntilNextDrop를 계산하도록 수정했습니다.
- 이로 인해 프론트는 초기 렌더링용 상세 조회 응답과 이후 실시간 SSE 응답을 같은 화면 모델로 처리할 수 있게 되었습니다.

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?