### PR TITLE
fix: 팝업 랭킹 Redis 캐시 역직렬화 실패 - record 타입 타입 정보 누락 수정

### DIFF
--- a/popup-service/src/main/java/com/t1/popcon/popup/config/RedisConfig.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/config/RedisConfig.java
@@ -9,13 +9,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 @Configuration
@@ -24,24 +25,21 @@ public class RedisConfig {
 
 	@Bean
 	public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-		// 1. ObjectMapper 설정 (클래스 타입 정보 포함, 시간 타입 지원)
+		// WRAPPER_ARRAY 방식: ["className", {...}] 형태로 타입 정보 저장
+		// EVERYTHING: record(암묵적 final) 포함 모든 타입에 타입 정보 적용
 		ObjectMapper objectMapper = new ObjectMapper()
 			.registerModule(new JavaTimeModule())
 			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 			.activateDefaultTyping(
-				BasicPolymorphicTypeValidator.builder()
-					.allowIfSubType("com.t1.popcon")
-					.allowIfSubType("java.util")
-					.build(),
-				ObjectMapper.DefaultTyping.NON_FINAL
+					LaissezFaireSubTypeValidator.instance,
+					ObjectMapper.DefaultTyping.EVERYTHING,
+					JsonTypeInfo.As.WRAPPER_ARRAY
 			);
 
-		// 2. 시리얼라이저 생성
-		Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(objectMapper, Object.class);
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
-		// 3. 캐시 설정
 		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-			.entryTtl(Duration.ofMinutes(10)) // 랭킹 캐시 수명 10분
+			.entryTtl(Duration.ofMinutes(10))
 			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
 			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #165
> Related to #161, #162

## 📝 작업 내용
**변경 파일:** `popup-service/.../config/RedisConfig.java`
### 문제
`PopupSectionResponse`가 Java `record` 타입으로 암묵적으로 `final`
→ `NON_FINAL` 설정은 `final` 클래스를 제외하여 Redis 저장 시 타입 정보가 누락됨
→ 캐시 hit 시 역직렬화 불가 → 500 에러

### 변경 사항
항목 | 변경 전 | 변경 후
-- | -- | --
직렬화기 | `Jackson2JsonRedisSerializer` | `GenericJackson2JsonRedisSerializer`
타입 검증기 | `BasicPolymorphicTypeValidator` | `LaissezFaireSubTypeValidator`
DefaultTyping | `NON_FINAL` | `EVERYTHING`
타입 포맷 | 미지정 (기본값) | `WRAPPER_ARRAY`


- `EVERYTHING` : `record`(암묵적 `final`) 포함 모든 타입에 타입 정보 포함
- `WRAPPER_ARRAY` : `["ClassName", {...}]` 형태로 객체/배열 모두 일관되게 타입 래핑
- `GenericJackson2JsonRedisSerializer`: 커스텀 ObjectMapper를 그대로 사용하는 범용 직렬화



## ✅ 테스트 결과

- `/popups/rankings` 첫 번째 호출 → DB 조회 후 정상 응답, Redis에 타입 정보 포함하여 캐시 저장 확인
<img width="1069" height="80" alt="image" src="https://github.com/user-attachments/assets/bed4066b-9d6a-4567-8057-066c4e9a03bd" />

- `/popups/rankings` 두 번째 호출 → 캐시 hit, 역직렬화 성공, 정상 응답 확인
<img width="425" height="187" alt="image" src="https://github.com/user-attachments/assets/e76397de-8d29-46a6-a336-43beb7b41dee" />