### PR TITLE
refactor: 비회원 상세조회 가능 설정 (Security 설정 변경)

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
@@ -10,6 +10,7 @@ import com.t1.popcon.common.queue.QuizPassedTokenValidator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -58,7 +59,7 @@ public class AuctionSecurityConfig extends CommonSecurityConfig {
           .securityMatcher("/auctions/**", "/bids/**", "/admin/auctions/**", "/internal/**")
           .authorizeHttpRequests(auth -> auth
             .requestMatchers("/internal/**").permitAll()
-            .requestMatchers("/auctions/\\d+").authenticated() // 상세 조회는 인증만
+            .requestMatchers(HttpMethod.GET,"/auctions/{auctionId}").permitAll()
             .requestMatchers("/auctions/**", "/bids/**").authenticated() // 나머지는 퀴즈 토큰 필요
             .anyRequest().authenticated()
           )

--- a/draw-service/src/main/java/com/t1/popcon/draw/config/DrawSecurityConfig.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/config/DrawSecurityConfig.java
@@ -74,7 +74,7 @@ public class DrawSecurityConfig extends CommonSecurityConfig {
                         "/actuator/**"
                 ).permitAll()
                 .requestMatchers("/internal/**").permitAll()
-                .requestMatchers(HttpMethod.GET, "/draws/{drawId}").authenticated()
+                .requestMatchers(HttpMethod.GET, "/draws/{drawId}").permitAll()
                 .requestMatchers("/draws/**").authenticated()
                 .anyRequest().authenticated()
         );


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #167 

## 📝 작업 내용

> 비회원도 드로우와 경매 상세조회에 접근 가능하게 Security 설정 변경했습니다.
- `AuctionSecurityConfig.java` 수정
- `DrawSecurityConfig.java` 수정

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

>