### PR TITLE
feat: 찜 추가/해제, 마이페이지 찜 목록 조회 기능 구현

### DIFF
--- a/popup-service/src/main/java/com/t1/popcon/config/PopupSecurityConfig.java
+++ b/popup-service/src/main/java/com/t1/popcon/config/PopupSecurityConfig.java
@@ -6,6 +6,7 @@ import com.t1.popcon.common.auth.handler.JwtAccessDeniedHandler;
 import com.t1.popcon.common.auth.handler.JwtAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -37,10 +38,10 @@ public class PopupSecurityConfig extends CommonSecurityConfig {
 				"/v3/api-docs/**",
 				"/popup/swagger-ui/**",
 				"/actuator/**",
-				"/popups/**",
 				"/internal/**",
 				"/magazines"
 			).permitAll()
+			.requestMatchers(HttpMethod.GET, "/popups/**").permitAll()
 			.anyRequest().authenticated()
 		)
 		.addFilterBefore(internalApiAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/popup-service/src/main/java/com/t1/popcon/popup/banners/controller/PopupBannersController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/banners/controller/PopupBannersController.java
@@ -1,12 +1,17 @@
 package com.t1.popcon.popup.banners.controller;
 
+import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.response.ApiResponse;
-import com.t1.popcon.popup.dto.card.*;
-import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.banners.service.PopupBannersService;
+import com.t1.popcon.popup.dto.card.PopupCardDto;
+import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,9 +22,11 @@ public class PopupBannersController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<PopupSectionResponse<PopupCardDto>>> getBanners(
+        @AuthenticationPrincipal AuthUser authUser,
         @RequestParam(defaultValue = "5") int limit
     ) {
-        PopupSectionResponse<PopupCardDto> data = popupBannersService.getBanners(limit);
+        PopupSectionResponse<PopupCardDto> data =
+                popupBannersService.getBanners(authUser != null ? authUser.id() : null, limit);
         return ResponseEntity.ok(ApiResponse.ok("배너 섹션 조회를 성공했습니다.", data));
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/banners/service/PopupBannersService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/banners/service/PopupBannersService.java
@@ -5,9 +5,8 @@ import com.t1.popcon.common.exception.ErrorCode;
 import com.t1.popcon.popup.banners.entity.Banner;
 import com.t1.popcon.popup.banners.repository.BannerRepository;
 import com.t1.popcon.popup.detail.entity.Popup;
-import com.t1.popcon.popup.dto.card.PhaseStatus;
-import com.t1.popcon.popup.dto.card.PhaseType;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
+import com.t1.popcon.popup.dto.card.PopupMapper;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
 import com.t1.popcon.popup.likes.service.PopupLikeReadService;
@@ -36,68 +35,42 @@ public class PopupBannersService {
         if (limit < 1 || limit > 5) {
             Map<String, Object> errors = new LinkedHashMap<>();
             errors.put("limit", "limit는 1 이상 5 이하여야 합니다.");
-            // CustomException이 Map을 인자로 받지 못하는 경우를 대비해 ErrorCode만 넘기거나 확인 필요
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 
         List<Banner> banners = bannerRepository.findActiveBannersWithPopup(PageRequest.of(0, limit));
         Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
-                userId,
-                banners.stream().map(banner -> banner.getPopup().getId()).toList()
+            userId,
+            banners.stream().map(banner -> banner.getPopup().getId()).toList()
         );
 
         List<PopupCardDto> items = banners.stream()
-                .map(banner -> toPopupCardDto(banner, likedPopupIds.contains(banner.getPopup().getId())))
-                .toList();
+            .map(banner -> toPopupCardDto(banner, likedPopupIds.contains(banner.getPopup().getId())))
+            .toList();
 
         return new PopupSectionResponse<>(SectionKey.BANNERS, items.size(), items);
     }
 
     private PopupCardDto toPopupCardDto(Banner banner, boolean liked) {
         Popup popup = banner.getPopup();
-        LocalDateTime now = LocalDateTime.now(KST_ZONE);
-
-        PhaseType phaseType = determinePhaseType(popup, now);
-        LocalDateTime openAt = (phaseType == PhaseType.AUCTION) ? popup.getAuctionOpenAt() : popup.getDrawOpenAt();
-        LocalDateTime closeAt = (phaseType == PhaseType.AUCTION) ? popup.getAuctionCloseAt() : popup.getDrawCloseAt();
+        PopupMapper.PhaseInfo phaseInfo = PopupMapper.resolvePhase(popup, LocalDateTime.now(KST_ZONE));
 
         return new PopupCardDto(
-                popup.getId(),
-                popup.getTitle(),
-                banner.getSupportingText(),
-                popup.getSubText(),
-                popup.getCaption(),
-                popup.getVThumbUrl(),
-                liked,
-                new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
-                null,
-                new PopupCardDto.PhaseDto(
-                        phaseType,
-                        calculatePhaseStatus(openAt, closeAt, now),
-                        openAt.atZone(KST_ZONE).toOffsetDateTime(),
-                        closeAt.atZone(KST_ZONE).toOffsetDateTime()
-                )
+            popup.getId(),
+            popup.getTitle(),
+            banner.getSupportingText(),
+            popup.getSubText(),
+            popup.getCaption(),
+            popup.getVThumbUrl(),
+            liked,
+            new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
+            null,
+            new PopupCardDto.PhaseDto(
+                phaseInfo.type(),
+                phaseInfo.status(),
+                phaseInfo.openAt().atZone(KST_ZONE).toOffsetDateTime(),
+                phaseInfo.closeAt().atZone(KST_ZONE).toOffsetDateTime()
+            )
         );
-    }
-
-    private PhaseType determinePhaseType(Popup popup, LocalDateTime now) {
-        PhaseStatus auctionStatus = calculatePhaseStatus(popup.getAuctionOpenAt(), popup.getAuctionCloseAt(), now);
-        PhaseStatus drawStatus = calculatePhaseStatus(popup.getDrawOpenAt(), popup.getDrawCloseAt(), now);
-
-        if (auctionStatus == PhaseStatus.OPEN) return PhaseType.AUCTION;
-        if (drawStatus == PhaseStatus.OPEN) return PhaseType.DRAW;
-        if (auctionStatus == PhaseStatus.UPCOMING && drawStatus != PhaseStatus.UPCOMING) return PhaseType.AUCTION;
-        if (drawStatus == PhaseStatus.UPCOMING && auctionStatus != PhaseStatus.UPCOMING) return PhaseType.DRAW;
-        if (auctionStatus == PhaseStatus.UPCOMING) {
-            return popup.getAuctionOpenAt().isBefore(popup.getDrawOpenAt()) ? PhaseType.AUCTION : PhaseType.DRAW;
-        }
-        return popup.getAuctionCloseAt().isAfter(popup.getDrawCloseAt()) ? PhaseType.AUCTION : PhaseType.DRAW;
-    }
-
-    private PhaseStatus calculatePhaseStatus(LocalDateTime openAt, LocalDateTime closeAt, LocalDateTime now) {
-        if (openAt == null || closeAt == null) return PhaseStatus.CLOSED;
-        if (now.isBefore(openAt)) return PhaseStatus.UPCOMING;
-        if (now.isAfter(closeAt)) return PhaseStatus.CLOSED;
-        return PhaseStatus.OPEN;
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/banners/service/PopupBannersService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/banners/service/PopupBannersService.java
@@ -35,7 +35,6 @@ public class PopupBannersService {
         if (limit < 1 || limit > 5) {
             Map<String, Object> errors = new LinkedHashMap<>();
             errors.put("limit", "limit는 1 이상 5 이하여야 합니다.");
-            // CustomException이 Map을 인자로 받지 못하는 경우를 대비해 ErrorCode만 넘기거나 확인 필요
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 
@@ -56,11 +55,6 @@ public class PopupBannersService {
         Popup popup = banner.getPopup();
         PopupMapper.PhaseInfo phaseInfo = PopupMapper.resolvePhase(popup, LocalDateTime.now(KST_ZONE));
 
-        LocalDateTime now = LocalDateTime.now(KST_ZONE);
-
-        PopupMapper.PhaseInfo phaseInfo = PopupMapper.resolvePhase(popup, now);
-
-        // 팝업 카드 DTO 생성 (생성자 파라미터 순서 및 타입 주의)
         return new PopupCardDto(
             popup.getId(),
             popup.getTitle(),
@@ -77,21 +71,6 @@ public class PopupBannersService {
                 phaseInfo.openAt().atZone(KST_ZONE).toOffsetDateTime(),
                 phaseInfo.closeAt().atZone(KST_ZONE).toOffsetDateTime()
             )
-                popup.getId(),
-                popup.getTitle(),
-                banner.getSupportingText(),
-                popup.getSubText(),
-                popup.getCaption(),
-                popup.getVThumbUrl(),
-                false, // isLiked 기본값
-                new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
-                null,  // location 등 추가 필드
-                new PopupCardDto.PhaseDto(
-                        phaseInfo.type(),
-                        phaseInfo.status(),
-                        phaseInfo.openAt().atZone(KST_ZONE).toOffsetDateTime(),
-                        phaseInfo.closeAt().atZone(KST_ZONE).toOffsetDateTime()
-                )
         );
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/banners/service/PopupBannersService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/banners/service/PopupBannersService.java
@@ -10,16 +10,17 @@ import com.t1.popcon.popup.dto.card.PhaseType;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.t1.popcon.popup.likes.service.PopupLikeReadService;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,10 +29,10 @@ public class PopupBannersService {
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     private final BannerRepository bannerRepository;
+    private final PopupLikeReadService popupLikeReadService;
 
     @Transactional(readOnly = true)
-    public PopupSectionResponse<PopupCardDto> getBanners(int limit) {
-        // 유효성 검사 로직
+    public PopupSectionResponse<PopupCardDto> getBanners(Long userId, int limit) {
         if (limit < 1 || limit > 5) {
             Map<String, Object> errors = new LinkedHashMap<>();
             errors.put("limit", "limit는 1 이상 5 이하여야 합니다.");
@@ -39,26 +40,27 @@ public class PopupBannersService {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 
-        List<PopupCardDto> items = bannerRepository.findActiveBannersWithPopup(PageRequest.of(0, limit))
-                .stream()
-                .map(this::toPopupCardDto)
+        List<Banner> banners = bannerRepository.findActiveBannersWithPopup(PageRequest.of(0, limit));
+        Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
+                userId,
+                banners.stream().map(banner -> banner.getPopup().getId()).toList()
+        );
+
+        List<PopupCardDto> items = banners.stream()
+                .map(banner -> toPopupCardDto(banner, likedPopupIds.contains(banner.getPopup().getId())))
                 .toList();
 
         return new PopupSectionResponse<>(SectionKey.BANNERS, items.size(), items);
     }
 
-    private PopupCardDto toPopupCardDto(Banner banner) {
+    private PopupCardDto toPopupCardDto(Banner banner, boolean liked) {
         Popup popup = banner.getPopup();
         LocalDateTime now = LocalDateTime.now(KST_ZONE);
 
-        // 페이즈 타입 결정
         PhaseType phaseType = determinePhaseType(popup, now);
-
-        // 결정된 타입에 따른 시간 설정
         LocalDateTime openAt = (phaseType == PhaseType.AUCTION) ? popup.getAuctionOpenAt() : popup.getDrawOpenAt();
         LocalDateTime closeAt = (phaseType == PhaseType.AUCTION) ? popup.getAuctionCloseAt() : popup.getDrawCloseAt();
 
-        // 팝업 카드 DTO 생성 (생성자 파라미터 순서 및 타입 주의)
         return new PopupCardDto(
                 popup.getId(),
                 popup.getTitle(),
@@ -66,9 +68,9 @@ public class PopupBannersService {
                 popup.getSubText(),
                 popup.getCaption(),
                 popup.getVThumbUrl(),
-                false, // isLiked 기본값
+                liked,
                 new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
-                null,  // location 등 추가 필드
+                null,
                 new PopupCardDto.PhaseDto(
                         phaseType,
                         calculatePhaseStatus(openAt, closeAt, now),
@@ -82,25 +84,18 @@ public class PopupBannersService {
         PhaseStatus auctionStatus = calculatePhaseStatus(popup.getAuctionOpenAt(), popup.getAuctionCloseAt(), now);
         PhaseStatus drawStatus = calculatePhaseStatus(popup.getDrawOpenAt(), popup.getDrawCloseAt(), now);
 
-        // 1. 진행 중인 것 우선
         if (auctionStatus == PhaseStatus.OPEN) return PhaseType.AUCTION;
         if (drawStatus == PhaseStatus.OPEN) return PhaseType.DRAW;
-
-        // 2. 오픈 예정인 것 우선
         if (auctionStatus == PhaseStatus.UPCOMING && drawStatus != PhaseStatus.UPCOMING) return PhaseType.AUCTION;
         if (drawStatus == PhaseStatus.UPCOMING && auctionStatus != PhaseStatus.UPCOMING) return PhaseType.DRAW;
-
-        // 3. 둘 다 예정이면 더 빨리 열리는 것
         if (auctionStatus == PhaseStatus.UPCOMING) {
             return popup.getAuctionOpenAt().isBefore(popup.getDrawOpenAt()) ? PhaseType.AUCTION : PhaseType.DRAW;
         }
-
-        // 4. 둘 다 종료면 더 나중에 닫힌 것
         return popup.getAuctionCloseAt().isAfter(popup.getDrawCloseAt()) ? PhaseType.AUCTION : PhaseType.DRAW;
     }
 
     private PhaseStatus calculatePhaseStatus(LocalDateTime openAt, LocalDateTime closeAt, LocalDateTime now) {
-        if (openAt == null || closeAt == null) return PhaseStatus.CLOSED; // null 방어 코드
+        if (openAt == null || closeAt == null) return PhaseStatus.CLOSED;
         if (now.isBefore(openAt)) return PhaseStatus.UPCOMING;
         if (now.isAfter(closeAt)) return PhaseStatus.CLOSED;
         return PhaseStatus.OPEN;

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/controller/InternalPopupController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/controller/InternalPopupController.java
@@ -3,6 +3,9 @@ package com.t1.popcon.popup.detail.controller;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.popup.detail.dto.InternalPopupResponse;
 import com.t1.popcon.popup.detail.service.PopupDetailService;
+import com.t1.popcon.popup.dto.card.PopupCardDto;
+import com.t1.popcon.popup.likes.dto.SliceResponse;
+import com.t1.popcon.popup.likes.service.PopupLikeQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,6 +17,7 @@ import java.util.List;
 public class InternalPopupController {
 
     private final PopupDetailService popupDetailService;
+    private final PopupLikeQueryService popupLikeQueryService;
 
     @GetMapping("/{popupId}")
     public ApiResponse<InternalPopupResponse> getPopupInternal(@PathVariable Long popupId) {
@@ -23,5 +27,14 @@ public class InternalPopupController {
     @GetMapping("/bulk")
     public ApiResponse<List<InternalPopupResponse>> getPopupsByBulkIds(@RequestParam List<Long> popupIds) {
         return ApiResponse.ok(popupDetailService.getPopupsByBulkIds(popupIds));
+    }
+
+    @GetMapping("/likes")
+    public ApiResponse<SliceResponse<PopupCardDto>> getLikedPopups(
+        @RequestParam Long userId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "12") int size
+    ) {
+        return ApiResponse.ok(popupLikeQueryService.getLikedPopups(userId, page, size));
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/controller/PopupDetailController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/controller/PopupDetailController.java
@@ -1,16 +1,16 @@
 package com.t1.popcon.popup.detail.controller;
 
+import com.t1.popcon.common.auth.domain.AuthUser;
+import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.popup.detail.dto.PopupDetailResponse;
+import com.t1.popcon.popup.detail.service.PopupDetailService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.t1.popcon.common.response.ApiResponse;
-import com.t1.popcon.popup.detail.dto.PopupDetailResponse;
-import com.t1.popcon.popup.detail.service.PopupDetailService;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/popups")
@@ -20,8 +20,14 @@ public class PopupDetailController {
 	private final PopupDetailService popupDetailService;
 
 	@GetMapping("/{popupId}")
-	public ResponseEntity<ApiResponse<PopupDetailResponse>> popupDetail(@PathVariable Long popupId) {
-		PopupDetailResponse response = popupDetailService.getPopupDetail(popupId);
+	public ResponseEntity<ApiResponse<PopupDetailResponse>> popupDetail(
+		@PathVariable Long popupId,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		PopupDetailResponse response = popupDetailService.getPopupDetail(
+			popupId,
+			authUser != null ? authUser.id() : null
+		);
 		return ResponseEntity.ok(ApiResponse.ok("팝업스토어 조회를 성공했습니다.", response));
 	}
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/entity/Popup.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/entity/Popup.java
@@ -94,4 +94,19 @@ public class Popup extends BaseSoftDeleteEntity {
 
     @Column(name = "review_count", nullable = false)
     private Long reviewCount;
+
+    public void increaseLikeCount() {
+        if (likeCount == null) {
+            likeCount = 0L;
+        }
+        likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (likeCount == null || likeCount <= 0) {
+            likeCount = 0L;
+            return;
+        }
+        likeCount--;
+    }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/entity/Popup.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/entity/Popup.java
@@ -95,18 +95,4 @@ public class Popup extends BaseSoftDeleteEntity {
     @Column(name = "review_count", nullable = false)
     private Long reviewCount;
 
-    public void increaseLikeCount() {
-        if (likeCount == null) {
-            likeCount = 0L;
-        }
-        likeCount++;
-    }
-
-    public void decreaseLikeCount() {
-        if (likeCount == null || likeCount <= 0) {
-            likeCount = 0L;
-            return;
-        }
-        likeCount--;
-    }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/repository/PopupRepository.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/repository/PopupRepository.java
@@ -1,10 +1,32 @@
 package com.t1.popcon.popup.detail.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import com.t1.popcon.popup.detail.entity.Popup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PopupRepository extends JpaRepository<Popup, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Popup popup
+        set popup.likeCount = coalesce(popup.likeCount, 0) + 1
+        where popup.id = :popupId
+        """)
+    int incrementLikeCountById(@Param("popupId") Long popupId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Popup popup
+        set popup.likeCount =
+            case
+                when coalesce(popup.likeCount, 0) > 0 then popup.likeCount - 1
+                else 0
+            end
+        where popup.id = :popupId
+        """)
+    int decrementLikeCountById(@Param("popupId") Long popupId);
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/service/PopupDetailService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/service/PopupDetailService.java
@@ -9,14 +9,12 @@ import com.t1.popcon.popup.detail.repository.PopupRepository;
 import com.t1.popcon.popup.dto.card.PhaseType;
 import com.t1.popcon.popup.dto.card.PopupMapper;
 import com.t1.popcon.popup.likes.service.PopupLikeReadService;
-import com.t1.popcon.popup.dto.card.PopupMapper;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/service/PopupDetailService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/service/PopupDetailService.java
@@ -7,16 +7,14 @@ import com.t1.popcon.popup.detail.dto.PopupDetailResponse;
 import com.t1.popcon.popup.detail.entity.Popup;
 import com.t1.popcon.popup.detail.repository.PopupRepository;
 import com.t1.popcon.popup.dto.card.PhaseType;
+import com.t1.popcon.popup.dto.card.PopupMapper;
 import com.t1.popcon.popup.likes.service.PopupLikeReadService;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -30,78 +28,54 @@ public class PopupDetailService {
 
     public PopupDetailResponse getPopupDetail(Long popupId, Long userId) {
         Popup popup = popupRepository.findById(popupId)
-                .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
 
         boolean liked = popupLikeReadService.isLiked(popupId, userId);
-        PhaseType phaseType = resolvePhaseType(popup, LocalDateTime.now(KST_ZONE));
+        PhaseType phaseType = PopupMapper.resolvePhase(popup, LocalDateTime.now(KST_ZONE)).type();
 
         return PopupDetailResponse.builder()
-                .phaseType(phaseType)
-                .auctionId(popup.getAuctionId())
-                .drawId(popup.getDrawId())
-                .popupId(popup.getId())
-                .liked(liked)
-                .thumbnailUrl(phaseType == PhaseType.AUCTION ? popup.getHThumbUrl() : popup.getVThumbUrl())
-                .title(popup.getTitle())
-                .subtitle(popup.getSubtitle())
-                .viewCount(popup.getViewCount())
-                .likeCount(popup.getLikeCount())
-                .description(popup.getDescription())
-                .location(popup.getLocation())
-                .reviewCount(popup.getReviewCount())
-                .openAt(popup.getOpenAt())
-                .closeAt(popup.getCloseAt())
-                .weekdayOpen(popup.getWeekdayOpen())
-                .weekdayClose(popup.getWeekdayClose())
-                .weekendOpen(popup.getWeekendOpen())
-                .weekendClose(popup.getWeekendClose())
-                .build();
+            .phaseType(phaseType)
+            .auctionId(popup.getAuctionId())
+            .drawId(popup.getDrawId())
+            .popupId(popup.getId())
+            .liked(liked)
+            .thumbnailUrl(phaseType == PhaseType.AUCTION ? popup.getHThumbUrl() : popup.getVThumbUrl())
+            .title(popup.getTitle())
+            .subtitle(popup.getSubtitle())
+            .viewCount(popup.getViewCount())
+            .likeCount(popup.getLikeCount())
+            .description(popup.getDescription())
+            .location(popup.getLocation())
+            .reviewCount(popup.getReviewCount())
+            .openAt(popup.getOpenAt())
+            .closeAt(popup.getCloseAt())
+            .weekdayOpen(popup.getWeekdayOpen())
+            .weekdayClose(popup.getWeekdayClose())
+            .weekendOpen(popup.getWeekendOpen())
+            .weekendClose(popup.getWeekendClose())
+            .build();
     }
 
     public InternalPopupResponse getPopupInternal(Long popupId) {
         Popup popup = popupRepository.findById(popupId)
-                .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
 
         return InternalPopupResponse.builder()
-                .popupId(popup.getId())
-                .title(popup.getTitle())
-                .location(popup.getLocation())
-                .vThumbnailUrl(popup.getVThumbUrl())
-                .build();
+            .popupId(popup.getId())
+            .title(popup.getTitle())
+            .location(popup.getLocation())
+            .vThumbnailUrl(popup.getVThumbUrl())
+            .build();
     }
 
     public List<InternalPopupResponse> getPopupsByBulkIds(List<Long> popupIds) {
         return popupRepository.findAllById(popupIds).stream()
-                .map(popup -> InternalPopupResponse.builder()
-                        .popupId(popup.getId())
-                        .title(popup.getTitle())
-                        .location(popup.getLocation())
-                        .vThumbnailUrl(popup.getVThumbUrl())
-                        .build())
-                .toList();
-    }
-
-    private PhaseType resolvePhaseType(Popup popup, LocalDateTime now) {
-        boolean auctionActive = popup.getAuctionId() != null
-                && popup.getAuctionOpenAt() != null
-                && popup.getAuctionCloseAt() != null
-                && !now.isBefore(popup.getAuctionOpenAt())
-                && now.isBefore(popup.getAuctionCloseAt());
-
-        boolean drawActive = popup.getDrawId() != null
-                && popup.getDrawOpenAt() != null
-                && popup.getDrawCloseAt() != null
-                && !now.isBefore(popup.getDrawOpenAt())
-                && now.isBefore(popup.getDrawCloseAt());
-
-        if (auctionActive) {
-            return PhaseType.AUCTION;
-        }
-
-        if (drawActive) {
-            return PhaseType.DRAW;
-        }
-
-        return null;
+            .map(popup -> InternalPopupResponse.builder()
+                .popupId(popup.getId())
+                .title(popup.getTitle())
+                .location(popup.getLocation())
+                .vThumbnailUrl(popup.getVThumbUrl())
+                .build())
+            .toList();
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/service/PopupDetailService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/service/PopupDetailService.java
@@ -7,12 +7,12 @@ import com.t1.popcon.popup.detail.dto.PopupDetailResponse;
 import com.t1.popcon.popup.detail.entity.Popup;
 import com.t1.popcon.popup.detail.repository.PopupRepository;
 import com.t1.popcon.popup.dto.card.PhaseType;
+import com.t1.popcon.popup.likes.service.PopupLikeReadService;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -20,20 +20,21 @@ import java.util.List;
 public class PopupDetailService {
 
     private final PopupRepository popupRepository;
+    private final PopupLikeReadService popupLikeReadService;
 
-    public PopupDetailResponse getPopupDetail(Long popupId) {
+    public PopupDetailResponse getPopupDetail(Long popupId, Long userId) {
         Popup popup = popupRepository.findById(popupId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
 
         PhaseType phaseType = resolvePhaseType(popup, LocalDateTime.now());
+        boolean liked = popupLikeReadService.isLiked(popupId, userId);
 
         return PopupDetailResponse.builder()
                 .phaseType(phaseType)
                 .auctionId(popup.getAuctionId())
                 .drawId(popup.getDrawId())
                 .popupId(popup.getId())
-                // TODO: popup_like 서비스/레포지토리 구현 후 현재 사용자 기준 좋아요 여부로 교체 필요
-                .liked(false)
+                .liked(liked)
                 .thumbnailUrl(phaseType == PhaseType.AUCTION ? popup.getHThumbUrl() : popup.getVThumbUrl())
                 .title(popup.getTitle())
                 .subtitle(popup.getSubtitle())

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
@@ -6,104 +6,102 @@ import java.time.ZoneId;
 
 public class PopupMapper {
 
-	private static final ZoneId TIME_ZONE = ZoneId.of("Asia/Seoul");
+    private static final ZoneId TIME_ZONE = ZoneId.of("Asia/Seoul");
 
-	private PopupMapper() {
-	}
+    private PopupMapper() {
+    }
 
-	public static PopupCardDto toCardDto(Popup popup, Integer rank, boolean liked) {
-		LocalDateTime now = LocalDateTime.now(TIME_ZONE);
-		PhaseType type;
-		PhaseStatus status;
-		LocalDateTime openAt;
-		LocalDateTime closeAt;
+    public record PhaseInfo(
+        PhaseType type,
+        PhaseStatus status,
+        LocalDateTime openAt,
+        LocalDateTime closeAt
+    ) {
+    }
 
-		if (now.isBefore(popup.getAuctionCloseAt())) {
-			type = PhaseType.AUCTION;
-			if (now.isBefore(popup.getAuctionOpenAt())) {
-				status = PhaseStatus.UPCOMING;
-			} else {
-				status = PhaseStatus.OPEN;
-			}
-			openAt = popup.getAuctionOpenAt();
-			closeAt = popup.getAuctionCloseAt();
-		} else {
-			type = PhaseType.DRAW;
-			if (now.isBefore(popup.getDrawOpenAt())) {
-				status = PhaseStatus.UPCOMING;
-			} else if (now.isBefore(popup.getDrawCloseAt())) {
-				status = PhaseStatus.OPEN;
-			} else {
-				status = PhaseStatus.CLOSED;
-			}
-			openAt = popup.getDrawOpenAt();
-			closeAt = popup.getDrawCloseAt();
-		}
+    public static PhaseInfo resolvePhase(Popup popup, LocalDateTime now) {
+        if (now.isBefore(popup.getAuctionCloseAt())) {
+            PhaseStatus status = now.isBefore(popup.getAuctionOpenAt()) ? PhaseStatus.UPCOMING : PhaseStatus.OPEN;
+            return new PhaseInfo(PhaseType.AUCTION, status, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
+        }
 
-		return toCardDto(
-			popup,
-			popup.getSubtitle(),
-			popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
-			popup.getVThumbUrl(),
-			liked,
-			rank != null ? new PopupCardDto.OverlayDto(OverlayType.RANK, rank) : null,
-			type,
-			status,
-			openAt,
-			closeAt
-		);
-	}
+        PhaseStatus status;
+        if (now.isBefore(popup.getDrawOpenAt())) {
+            status = PhaseStatus.UPCOMING;
+        } else if (now.isBefore(popup.getDrawCloseAt())) {
+            status = PhaseStatus.OPEN;
+        } else {
+            status = PhaseStatus.CLOSED;
+        }
+        return new PhaseInfo(PhaseType.DRAW, status, popup.getDrawOpenAt(), popup.getDrawCloseAt());
+    }
 
-	public static PopupCardDto toCardDto(
-		Popup popup,
-		boolean liked,
-		PhaseType phaseType,
-		PhaseStatus phaseStatus,
-		LocalDateTime openAt,
-		LocalDateTime closeAt
-	) {
-		return toCardDto(
-			popup,
-			popup.getSubtitle(),
-			popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
-			popup.getVThumbUrl(),
-			liked,
-			null,
-			phaseType,
-			phaseStatus,
-			openAt,
-			closeAt
-		);
-	}
+    public static PopupCardDto toCardDto(Popup popup, Integer rank, boolean liked) {
+        PhaseInfo phaseInfo = resolvePhase(popup, LocalDateTime.now(TIME_ZONE));
+        return toCardDto(
+            popup,
+            popup.getSubtitle(),
+            popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
+            popup.getVThumbUrl(),
+            liked,
+            rank != null ? new PopupCardDto.OverlayDto(OverlayType.RANK, rank) : null,
+            phaseInfo.type(),
+            phaseInfo.status(),
+            phaseInfo.openAt(),
+            phaseInfo.closeAt()
+        );
+    }
 
-	private static PopupCardDto toCardDto(
-		Popup popup,
-		String supportingText,
-		String subText,
-		String thumbnailUrl,
-		boolean liked,
-		PopupCardDto.OverlayDto overlay,
-		PhaseType phaseType,
-		PhaseStatus phaseStatus,
-		LocalDateTime openAt,
-		LocalDateTime closeAt
-	) {
-		return new PopupCardDto(
-			popup.getId(),
-			popup.getTitle(),
-			supportingText,
-			subText,
-			popup.getCaption(),
-			thumbnailUrl,
-			liked,
-			new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
-			overlay,
-			new PopupCardDto.PhaseDto(
-				phaseType,
-				phaseStatus,
-				openAt.atZone(TIME_ZONE).toOffsetDateTime(),
-				closeAt.atZone(TIME_ZONE).toOffsetDateTime()
-			)
-		);
-	}
+    public static PopupCardDto toCardDto(
+        Popup popup,
+        boolean liked,
+        PhaseType phaseType,
+        PhaseStatus phaseStatus,
+        LocalDateTime openAt,
+        LocalDateTime closeAt
+    ) {
+        return toCardDto(
+            popup,
+            popup.getSubtitle(),
+            popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
+            popup.getVThumbUrl(),
+            liked,
+            null,
+            phaseType,
+            phaseStatus,
+            openAt,
+            closeAt
+        );
+    }
+
+    private static PopupCardDto toCardDto(
+        Popup popup,
+        String supportingText,
+        String subText,
+        String thumbnailUrl,
+        boolean liked,
+        PopupCardDto.OverlayDto overlay,
+        PhaseType phaseType,
+        PhaseStatus phaseStatus,
+        LocalDateTime openAt,
+        LocalDateTime closeAt
+    ) {
+        return new PopupCardDto(
+            popup.getId(),
+            popup.getTitle(),
+            supportingText,
+            subText,
+            popup.getCaption(),
+            thumbnailUrl,
+            liked,
+            new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
+            overlay,
+            new PopupCardDto.PhaseDto(
+                phaseType,
+                phaseStatus,
+                openAt.atZone(TIME_ZONE).toOffsetDateTime(),
+                closeAt.atZone(TIME_ZONE).toOffsetDateTime()
+            )
+        );
+    }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
@@ -1,24 +1,21 @@
 package com.t1.popcon.popup.dto.card;
 
+import com.t1.popcon.popup.detail.entity.Popup;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-
-import com.t1.popcon.popup.detail.entity.Popup;
 
 public class PopupMapper {
 
 	private static final ZoneId TIME_ZONE = ZoneId.of("Asia/Seoul");
 
-	public static PopupCardDto toCardDto(Popup popup, Integer rank) {
+	public static PopupCardDto toCardDto(Popup popup, Integer rank, boolean liked) {
 		LocalDateTime now = LocalDateTime.now(TIME_ZONE);
 		PhaseType type;
 		PhaseStatus status;
 		LocalDateTime openAt;
 		LocalDateTime closeAt;
 
-		// 1. 현재 시간에 따른 PhaseType 및 PhaseStatus 결정 로직
 		if (now.isBefore(popup.getAuctionCloseAt())) {
-			// 경매 종료 전 -> AUCTION 단계
 			type = PhaseType.AUCTION;
 			if (now.isBefore(popup.getAuctionOpenAt())) {
 				status = PhaseStatus.UPCOMING;
@@ -28,7 +25,6 @@ public class PopupMapper {
 			openAt = popup.getAuctionOpenAt();
 			closeAt = popup.getAuctionCloseAt();
 		} else {
-			// 경매 종료 후 -> DRAW 단계
 			type = PhaseType.DRAW;
 			if (now.isBefore(popup.getDrawOpenAt())) {
 				status = PhaseStatus.UPCOMING;
@@ -48,7 +44,7 @@ public class PopupMapper {
 			popup.getSubText(),
 			popup.getCaption(),
 			popup.getVThumbUrl(),
-			false,
+			liked,
 			new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
 			rank != null ? new PopupCardDto.OverlayDto(OverlayType.RANK, rank) : null,
 			new PopupCardDto.PhaseDto(
@@ -58,6 +54,5 @@ public class PopupMapper {
 				closeAt.atZone(TIME_ZONE).toOffsetDateTime()
 			)
 		);
-
 	}
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
@@ -40,19 +40,67 @@ public class PopupMapper {
 			closeAt = popup.getDrawCloseAt();
 		}
 
+		return toCardDto(
+			popup,
+			popup.getSubtitle(),
+			popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
+			popup.getVThumbUrl(),
+			liked,
+			rank != null ? new PopupCardDto.OverlayDto(OverlayType.RANK, rank) : null,
+			type,
+			status,
+			openAt,
+			closeAt
+		);
+	}
+
+	public static PopupCardDto toCardDto(
+		Popup popup,
+		boolean liked,
+		PhaseType phaseType,
+		PhaseStatus phaseStatus,
+		LocalDateTime openAt,
+		LocalDateTime closeAt
+	) {
+		return toCardDto(
+			popup,
+			popup.getSubtitle(),
+			popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
+			popup.getVThumbUrl(),
+			liked,
+			null,
+			phaseType,
+			phaseStatus,
+			openAt,
+			closeAt
+		);
+	}
+
+	private static PopupCardDto toCardDto(
+		Popup popup,
+		String supportingText,
+		String subText,
+		String thumbnailUrl,
+		boolean liked,
+		PopupCardDto.OverlayDto overlay,
+		PhaseType phaseType,
+		PhaseStatus phaseStatus,
+		LocalDateTime openAt,
+		LocalDateTime closeAt
+	) {
 		return new PopupCardDto(
 			popup.getId(),
 			popup.getTitle(),
-			null,
-			popup.getSubText(),
+			supportingText,
+			subText,
 			popup.getCaption(),
-			popup.getVThumbUrl(),
+			thumbnailUrl,
 			liked,
 			new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
-			rank != null ? new PopupCardDto.OverlayDto(OverlayType.RANK, rank) : null,
+			overlay,
 			new PopupCardDto.PhaseDto(
-				type,
-				status,
+				phaseType,
+				phaseStatus,
 				openAt.atZone(TIME_ZONE).toOffsetDateTime(),
 				closeAt.atZone(TIME_ZONE).toOffsetDateTime()
 			)

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
@@ -10,37 +10,6 @@ public class PopupMapper {
 
     private PopupMapper() {
     }
-	public record PhaseInfo(
-		PhaseType type,
-		PhaseStatus status,
-		LocalDateTime openAt,
-		LocalDateTime closeAt
-	) {
-	}
-
-	public static PhaseInfo resolvePhase(Popup popup, LocalDateTime now) {
-		if (now.isBefore(popup.getAuctionCloseAt())) {
-			PhaseStatus status = now.isBefore(popup.getAuctionOpenAt()) ? PhaseStatus.UPCOMING : PhaseStatus.OPEN;
-			return new PhaseInfo(PhaseType.AUCTION, status, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
-		} else {
-			PhaseStatus status;
-			if (now.isBefore(popup.getDrawOpenAt())) {
-				status = PhaseStatus.UPCOMING;
-			} else if (now.isBefore(popup.getDrawCloseAt())) {
-				status = PhaseStatus.OPEN;
-			} else {
-				status = PhaseStatus.CLOSED;
-			}
-			return new PhaseInfo(PhaseType.DRAW, status, popup.getDrawOpenAt(), popup.getDrawCloseAt());
-		}
-	}
-
-	public static PopupCardDto toCardDto(Popup popup, Integer rank) {
-		LocalDateTime now = LocalDateTime.now(TIME_ZONE);
-		PhaseType type;
-		PhaseStatus status;
-		LocalDateTime openAt;
-		LocalDateTime closeAt;
 
     public record PhaseInfo(
         PhaseType type,

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/card/PopupMapper.java
@@ -8,6 +8,9 @@ public class PopupMapper {
 
 	private static final ZoneId TIME_ZONE = ZoneId.of("Asia/Seoul");
 
+	private PopupMapper() {
+	}
+
 	public static PopupCardDto toCardDto(Popup popup, Integer rank, boolean liked) {
 		LocalDateTime now = LocalDateTime.now(TIME_ZONE);
 		PhaseType type;

--- a/popup-service/src/main/java/com/t1/popcon/popup/endingsoon/controller/PopupEndingSoonController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/endingsoon/controller/PopupEndingSoonController.java
@@ -1,5 +1,6 @@
 package com.t1.popcon.popup.endingsoon.controller;
 
+import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
@@ -7,6 +8,7 @@ import com.t1.popcon.popup.endingsoon.service.PopupEndingSoonService;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,11 +25,13 @@ public class PopupEndingSoonController {
 
     @GetMapping("/ending-soon")
     public ResponseEntity<ApiResponse<PopupSectionResponse<PopupCardDto>>> getEndingSoonPopups(
+            @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(defaultValue = "10")
             @Min(value = 1, message = "limit는 1 이상이어야 합니다.")
             int limit
     ) {
-        PopupSectionResponse<PopupCardDto> response = popupEndingSoonService.getEndingSoonPopups(limit);
-        return ResponseEntity.ok(ApiResponse.ok("곧 종료되는 팝업 조회 성공", response));
+        PopupSectionResponse<PopupCardDto> response =
+                popupEndingSoonService.getEndingSoonPopups(authUser != null ? authUser.id() : null, limit);
+        return ResponseEntity.ok(ApiResponse.ok("곧 종료되는 팝업 조회를 성공했습니다.", response));
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/endingsoon/service/PopupEndingSoonService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/endingsoon/service/PopupEndingSoonService.java
@@ -7,14 +7,15 @@ import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
 import com.t1.popcon.popup.endingsoon.repository.PopupEndingSoonRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
-
+import com.t1.popcon.popup.likes.service.PopupLikeReadService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -23,23 +24,27 @@ public class PopupEndingSoonService {
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     private final PopupEndingSoonRepository popupEndingSoonRepository;
+    private final PopupLikeReadService popupLikeReadService;
 
-    public PopupSectionResponse<PopupCardDto> getEndingSoonPopups(int limit) {
+    public PopupSectionResponse<PopupCardDto> getEndingSoonPopups(Long userId, int limit) {
         LocalDate now = LocalDate.now(KST_ZONE);
         LocalDate deadline = now.plusDays(3);
 
-        List<PopupCardDto> items = popupEndingSoonRepository.findEndingSoonPopups(
-                        now,
-                        deadline,
-                        PageRequest.of(0, limit)
-                ).stream()
-                .map(this::toPopupCardDto)
+        List<Popup> popups = popupEndingSoonRepository.findEndingSoonPopups(
+                now,
+                deadline,
+                PageRequest.of(0, limit)
+        );
+        Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(userId, popups.stream().map(Popup::getId).toList());
+
+        List<PopupCardDto> items = popups.stream()
+                .map(popup -> toPopupCardDto(popup, likedPopupIds.contains(popup.getId())))
                 .toList();
 
         return new PopupSectionResponse<>(SectionKey.ENDING_SOON, items.size(), items);
     }
 
-    private PopupCardDto toPopupCardDto(Popup popup) {
+    private PopupCardDto toPopupCardDto(Popup popup, boolean liked) {
         PhaseInfo phaseInfo = resolvePhaseInfo(popup);
 
         return new PopupCardDto(
@@ -49,7 +54,7 @@ public class PopupEndingSoonService {
                 popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
                 popup.getCaption(),
                 popup.getVThumbUrl(),
-                false,
+                liked,
                 new PopupCardDto.StatsDto(
                         popup.getLikeCount(),
                         popup.getViewCount()
@@ -84,19 +89,11 @@ public class PopupEndingSoonService {
                 && now.isBefore(popup.getDrawCloseAt());
 
         if (auctionActive) {
-            return new PhaseInfo(
-                    PhaseType.AUCTION,
-                    popup.getAuctionOpenAt(),
-                    popup.getAuctionCloseAt()
-            );
+            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
         }
 
         if (drawActive) {
-            return new PhaseInfo(
-                    PhaseType.DRAW,
-                    popup.getDrawOpenAt(),
-                    popup.getDrawCloseAt()
-            );
+            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
         }
 
         if (auctionExists && drawExists) {
@@ -106,19 +103,11 @@ public class PopupEndingSoonService {
         }
 
         if (auctionExists) {
-            return new PhaseInfo(
-                    PhaseType.AUCTION,
-                    popup.getAuctionOpenAt(),
-                    popup.getAuctionCloseAt()
-            );
+            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
         }
 
         if (drawExists) {
-            return new PhaseInfo(
-                    PhaseType.DRAW,
-                    popup.getDrawOpenAt(),
-                    popup.getDrawCloseAt()
-            );
+            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
         }
 
         throw new IllegalStateException("Popup phase information is missing. popupId=" + popup.getId());

--- a/popup-service/src/main/java/com/t1/popcon/popup/featured/controller/PopupFeaturedController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/featured/controller/PopupFeaturedController.java
@@ -1,5 +1,6 @@
 package com.t1.popcon.popup.featured.controller;
 
+import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
@@ -7,6 +8,7 @@ import com.t1.popcon.popup.featured.service.PopupFeaturedService;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,11 +25,13 @@ public class PopupFeaturedController {
 
     @GetMapping("/featured")
     public ResponseEntity<ApiResponse<PopupSectionResponse<PopupCardDto>>> getFeaturedPopups(
+            @AuthenticationPrincipal AuthUser authUser,
             @RequestParam(defaultValue = "10")
             @Min(value = 1, message = "limit는 1 이상이어야 합니다.")
             int limit
     ) {
-        PopupSectionResponse<PopupCardDto> response = popupFeaturedService.getFeaturedPopups(limit);
-        return ResponseEntity.ok(ApiResponse.ok("주목할만한 팝업 조회 성공", response));
+        PopupSectionResponse<PopupCardDto> response =
+                popupFeaturedService.getFeaturedPopups(authUser != null ? authUser.id() : null, limit);
+        return ResponseEntity.ok(ApiResponse.ok("주목할 만한 팝업 조회를 성공했습니다.", response));
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/featured/service/PopupFeaturedService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/featured/service/PopupFeaturedService.java
@@ -1,8 +1,6 @@
 package com.t1.popcon.popup.featured.service;
 
 import com.t1.popcon.popup.detail.entity.Popup;
-import com.t1.popcon.popup.dto.card.PhaseStatus;
-import com.t1.popcon.popup.dto.card.PhaseType;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.card.PopupMapper;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
@@ -29,85 +27,30 @@ public class PopupFeaturedService {
 
     public PopupSectionResponse<PopupCardDto> getFeaturedPopups(Long userId, int limit) {
         List<Popup> popups = popupFeaturedRepository.findFeaturedPopups(
-                LIKE_WEIGHT,
-                PageRequest.of(0, limit)
+            LIKE_WEIGHT,
+            PageRequest.of(0, limit)
         );
-        Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(userId, popups.stream().map(Popup::getId).toList());
+        Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
+            userId,
+            popups.stream().map(Popup::getId).toList()
+        );
 
         List<PopupCardDto> items = popups.stream()
-                .map(popup -> toPopupCardDto(popup, likedPopupIds.contains(popup.getId())))
-                .toList();
+            .map(popup -> toPopupCardDto(popup, likedPopupIds.contains(popup.getId())))
+            .toList();
 
         return new PopupSectionResponse<>(SectionKey.FEATURED, items.size(), items);
     }
 
     private PopupCardDto toPopupCardDto(Popup popup, boolean liked) {
-        PhaseInfo phaseInfo = resolvePhaseInfo(popup);
+        PopupMapper.PhaseInfo phaseInfo = PopupMapper.resolvePhase(popup, LocalDateTime.now(KST_ZONE));
         return PopupMapper.toCardDto(
-                popup,
-                liked,
-                phaseInfo.phaseType(),
-                calculatePhaseStatus(phaseInfo.openAt(), phaseInfo.closeAt()),
-                phaseInfo.openAt(),
-                phaseInfo.closeAt()
+            popup,
+            liked,
+            phaseInfo.type(),
+            phaseInfo.status(),
+            phaseInfo.openAt(),
+            phaseInfo.closeAt()
         );
-    }
-
-    private PhaseInfo resolvePhaseInfo(Popup popup) {
-        LocalDateTime now = LocalDateTime.now(KST_ZONE);
-
-        boolean auctionExists = popup.getAuctionId() != null
-                && popup.getAuctionOpenAt() != null
-                && popup.getAuctionCloseAt() != null;
-
-        boolean drawExists = popup.getDrawId() != null
-                && popup.getDrawOpenAt() != null
-                && popup.getDrawCloseAt() != null;
-
-        boolean auctionActive = auctionExists
-                && !now.isBefore(popup.getAuctionOpenAt())
-                && now.isBefore(popup.getAuctionCloseAt());
-
-        boolean drawActive = drawExists
-                && !now.isBefore(popup.getDrawOpenAt())
-                && now.isBefore(popup.getDrawCloseAt());
-
-        if (auctionActive) {
-            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
-        }
-
-        if (drawActive) {
-            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
-        }
-
-        if (auctionExists && drawExists) {
-            return popup.getAuctionOpenAt().isBefore(popup.getDrawOpenAt())
-                    ? new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt())
-                    : new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
-        }
-
-        if (auctionExists) {
-            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
-        }
-
-        if (drawExists) {
-            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
-        }
-
-        throw new IllegalStateException("Popup phase information is missing. popupId=" + popup.getId());
-    }
-
-    private PhaseStatus calculatePhaseStatus(LocalDateTime openAt, LocalDateTime closeAt) {
-        LocalDateTime now = LocalDateTime.now(KST_ZONE);
-        if (now.isBefore(openAt)) return PhaseStatus.UPCOMING;
-        if (!now.isBefore(closeAt)) return PhaseStatus.CLOSED;
-        return PhaseStatus.OPEN;
-    }
-
-    private record PhaseInfo(
-            PhaseType phaseType,
-            LocalDateTime openAt,
-            LocalDateTime closeAt
-    ) {
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/featured/service/PopupFeaturedService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/featured/service/PopupFeaturedService.java
@@ -7,13 +7,14 @@ import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
 import com.t1.popcon.popup.featured.repository.PopupFeaturedRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
-
+import com.t1.popcon.popup.likes.service.PopupLikeReadService;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -23,19 +24,23 @@ public class PopupFeaturedService {
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     private final PopupFeaturedRepository popupFeaturedRepository;
+    private final PopupLikeReadService popupLikeReadService;
 
-    public PopupSectionResponse<PopupCardDto> getFeaturedPopups(int limit) {
-        List<PopupCardDto> items = popupFeaturedRepository.findFeaturedPopups(
-                        LIKE_WEIGHT,
-                        PageRequest.of(0, limit)
-                ).stream()
-                .map(this::toPopupCardDto)
+    public PopupSectionResponse<PopupCardDto> getFeaturedPopups(Long userId, int limit) {
+        List<Popup> popups = popupFeaturedRepository.findFeaturedPopups(
+                LIKE_WEIGHT,
+                PageRequest.of(0, limit)
+        );
+        Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(userId, popups.stream().map(Popup::getId).toList());
+
+        List<PopupCardDto> items = popups.stream()
+                .map(popup -> toPopupCardDto(popup, likedPopupIds.contains(popup.getId())))
                 .toList();
 
         return new PopupSectionResponse<>(SectionKey.FEATURED, items.size(), items);
     }
 
-    private PopupCardDto toPopupCardDto(Popup popup) {
+    private PopupCardDto toPopupCardDto(Popup popup, boolean liked) {
         PhaseInfo phaseInfo = resolvePhaseInfo(popup);
 
         return new PopupCardDto(
@@ -45,7 +50,7 @@ public class PopupFeaturedService {
                 popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
                 popup.getCaption(),
                 popup.getVThumbUrl(),
-                false,
+                liked,
                 new PopupCardDto.StatsDto(
                         popup.getLikeCount(),
                         popup.getViewCount()
@@ -80,19 +85,11 @@ public class PopupFeaturedService {
                 && now.isBefore(popup.getDrawCloseAt());
 
         if (auctionActive) {
-            return new PhaseInfo(
-                    PhaseType.AUCTION,
-                    popup.getAuctionOpenAt(),
-                    popup.getAuctionCloseAt()
-            );
+            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
         }
 
         if (drawActive) {
-            return new PhaseInfo(
-                    PhaseType.DRAW,
-                    popup.getDrawOpenAt(),
-                    popup.getDrawCloseAt()
-            );
+            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
         }
 
         if (auctionExists && drawExists) {
@@ -102,19 +99,11 @@ public class PopupFeaturedService {
         }
 
         if (auctionExists) {
-            return new PhaseInfo(
-                    PhaseType.AUCTION,
-                    popup.getAuctionOpenAt(),
-                    popup.getAuctionCloseAt()
-            );
+            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
         }
 
         if (drawExists) {
-            return new PhaseInfo(
-                    PhaseType.DRAW,
-                    popup.getDrawOpenAt(),
-                    popup.getDrawCloseAt()
-            );
+            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
         }
 
         throw new IllegalStateException("Popup phase information is missing. popupId=" + popup.getId());

--- a/popup-service/src/main/java/com/t1/popcon/popup/featured/service/PopupFeaturedService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/featured/service/PopupFeaturedService.java
@@ -4,6 +4,7 @@ import com.t1.popcon.popup.detail.entity.Popup;
 import com.t1.popcon.popup.dto.card.PhaseStatus;
 import com.t1.popcon.popup.dto.card.PhaseType;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
+import com.t1.popcon.popup.dto.card.PopupMapper;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
 import com.t1.popcon.popup.featured.repository.PopupFeaturedRepository;
@@ -42,26 +43,13 @@ public class PopupFeaturedService {
 
     private PopupCardDto toPopupCardDto(Popup popup, boolean liked) {
         PhaseInfo phaseInfo = resolvePhaseInfo(popup);
-
-        return new PopupCardDto(
-                popup.getId(),
-                popup.getTitle(),
-                popup.getSubtitle(),
-                popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
-                popup.getCaption(),
-                popup.getVThumbUrl(),
+        return PopupMapper.toCardDto(
+                popup,
                 liked,
-                new PopupCardDto.StatsDto(
-                        popup.getLikeCount(),
-                        popup.getViewCount()
-                ),
-                null,
-                new PopupCardDto.PhaseDto(
-                        phaseInfo.phaseType(),
-                        calculatePhaseStatus(phaseInfo.openAt(), phaseInfo.closeAt()),
-                        phaseInfo.openAt().atZone(KST_ZONE).toOffsetDateTime(),
-                        phaseInfo.closeAt().atZone(KST_ZONE).toOffsetDateTime()
-                )
+                phaseInfo.phaseType(),
+                calculatePhaseStatus(phaseInfo.openAt(), phaseInfo.closeAt()),
+                phaseInfo.openAt(),
+                phaseInfo.closeAt()
         );
     }
 

--- a/popup-service/src/main/java/com/t1/popcon/popup/featured/service/PopupFeaturedService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/featured/service/PopupFeaturedService.java
@@ -42,28 +42,6 @@ public class PopupFeaturedService {
         return new PopupSectionResponse<>(SectionKey.FEATURED, items.size(), items);
     }
 
-    private PopupCardDto toPopupCardDto(Popup popup) {
-        PopupMapper.PhaseInfo phaseInfo = PopupMapper.resolvePhase(popup, LocalDateTime.now(KST_ZONE));
-
-        return new PopupCardDto(
-                popup.getId(),
-                popup.getTitle(),
-                popup.getSubtitle(),
-                popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
-                popup.getCaption(),
-                popup.getVThumbUrl(),
-                false,
-                new PopupCardDto.StatsDto(
-                        popup.getLikeCount(),
-                        popup.getViewCount()
-                ),
-                null,
-                new PopupCardDto.PhaseDto(
-                        phaseInfo.type(),
-                        phaseInfo.status(),
-                        phaseInfo.openAt().atZone(KST_ZONE).toOffsetDateTime(),
-                        phaseInfo.closeAt().atZone(KST_ZONE).toOffsetDateTime()
-                )
     private PopupCardDto toPopupCardDto(Popup popup, boolean liked) {
         PopupMapper.PhaseInfo phaseInfo = PopupMapper.resolvePhase(popup, LocalDateTime.now(KST_ZONE));
         return PopupMapper.toCardDto(

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/controller/PopupLikeController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/controller/PopupLikeController.java
@@ -1,0 +1,39 @@
+package com.t1.popcon.popup.likes.controller;
+
+import com.t1.popcon.common.auth.domain.AuthUser;
+import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.popup.likes.service.PopupLikeCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/popups/{popupId}/likes")
+public class PopupLikeController {
+
+    private final PopupLikeCommandService popupLikeCommandService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> likePopup(
+        @PathVariable Long popupId,
+        @AuthenticationPrincipal AuthUser authUser
+    ) {
+        popupLikeCommandService.likePopup(popupId, authUser.id());
+        return ResponseEntity.ok(ApiResponse.ok("팝업 찜 추가를 성공했습니다."));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> unlikePopup(
+        @PathVariable Long popupId,
+        @AuthenticationPrincipal AuthUser authUser
+    ) {
+        popupLikeCommandService.unlikePopup(popupId, authUser.id());
+        return ResponseEntity.ok(ApiResponse.ok("팝업 찜 해제를 성공했습니다."));
+    }
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/dto/SliceResponse.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/dto/SliceResponse.java
@@ -1,0 +1,21 @@
+package com.t1.popcon.popup.likes.dto;
+
+import java.util.List;
+
+public record SliceResponse<T>(
+    List<T> content,
+    boolean first,
+    boolean last,
+    int numberOfElements,
+    boolean empty
+) {
+    public static <T> SliceResponse<T> from(org.springframework.data.domain.Slice<T> slice) {
+        return new SliceResponse<>(
+            slice.getContent(),
+            slice.isFirst(),
+            slice.isLast(),
+            slice.getNumberOfElements(),
+            slice.isEmpty()
+        );
+    }
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/repository/PopupLikeRepository.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/repository/PopupLikeRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PopupLikeRepository extends JpaRepository<PopupLike, Long> {
 
@@ -25,5 +26,5 @@ public interface PopupLikeRepository extends JpaRepository<PopupLike, Long> {
         where pl.userId = :userId
           and pl.popup.id in :popupIds
     """)
-    Set<Long> findLikedPopupIds(Long userId, Collection<Long> popupIds);
+    Set<Long> findLikedPopupIds(@Param("userId") Long userId, @Param("popupIds") Collection<Long> popupIds);
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/repository/PopupLikeRepository.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/repository/PopupLikeRepository.java
@@ -1,0 +1,13 @@
+package com.t1.popcon.popup.likes.repository;
+
+import com.t1.popcon.popup.detail.entity.PopupLike;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PopupLikeRepository extends JpaRepository<PopupLike, Long> {
+
+    @EntityGraph(attributePaths = "popup")
+    Slice<PopupLike> findByUserIdOrderByCreatedAtDescIdDesc(Long userId, Pageable pageable);
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/repository/PopupLikeRepository.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/repository/PopupLikeRepository.java
@@ -1,6 +1,7 @@
 package com.t1.popcon.popup.likes.repository;
 
 import com.t1.popcon.popup.detail.entity.PopupLike;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -10,4 +11,8 @@ public interface PopupLikeRepository extends JpaRepository<PopupLike, Long> {
 
     @EntityGraph(attributePaths = "popup")
     Slice<PopupLike> findByUserIdOrderByCreatedAtDescIdDesc(Long userId, Pageable pageable);
+
+    boolean existsByPopup_IdAndUserId(Long popupId, Long userId);
+
+    Optional<PopupLike> findByPopup_IdAndUserId(Long popupId, Long userId);
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/repository/PopupLikeRepository.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/repository/PopupLikeRepository.java
@@ -1,11 +1,14 @@
 package com.t1.popcon.popup.likes.repository;
 
 import com.t1.popcon.popup.detail.entity.PopupLike;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PopupLikeRepository extends JpaRepository<PopupLike, Long> {
 
@@ -15,4 +18,12 @@ public interface PopupLikeRepository extends JpaRepository<PopupLike, Long> {
     boolean existsByPopup_IdAndUserId(Long popupId, Long userId);
 
     Optional<PopupLike> findByPopup_IdAndUserId(Long popupId, Long userId);
+
+    @Query("""
+        select pl.popup.id
+        from PopupLike pl
+        where pl.userId = :userId
+          and pl.popup.id in :popupIds
+    """)
+    Set<Long> findLikedPopupIds(Long userId, Collection<Long> popupIds);
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeCommandService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeCommandService.java
@@ -21,6 +21,7 @@ public class PopupLikeCommandService {
 
     public void likePopup(Long popupId, Long userId) {
         validateUserId(userId);
+        validatePopupId(popupId);
 
         Popup popup = popupRepository.findById(popupId)
             .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
@@ -31,7 +32,7 @@ public class PopupLikeCommandService {
 
         try {
             popupLikeRepository.save(PopupLike.create(popup, userId));
-            popup.increaseLikeCount();
+            popupRepository.incrementLikeCountById(popupId);
         } catch (DataIntegrityViolationException e) {
             // Unique constraint race: another request created the like first.
         }
@@ -39,6 +40,7 @@ public class PopupLikeCommandService {
 
     public void unlikePopup(Long popupId, Long userId) {
         validateUserId(userId);
+        validatePopupId(popupId);
 
         popupRepository.findById(popupId)
             .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
@@ -46,12 +48,18 @@ public class PopupLikeCommandService {
         popupLikeRepository.findByPopup_IdAndUserId(popupId, userId)
             .ifPresent(popupLike -> {
                 popupLikeRepository.delete(popupLike);
-                popupLike.getPopup().decreaseLikeCount();
+                popupRepository.decrementLikeCountById(popupId);
             });
     }
 
     private void validateUserId(Long userId) {
         if (userId == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void validatePopupId(Long popupId) {
+        if (popupId == null) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
     }

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeCommandService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeCommandService.java
@@ -7,6 +7,8 @@ import com.t1.popcon.popup.detail.entity.PopupLike;
 import com.t1.popcon.popup.detail.repository.PopupRepository;
 import com.t1.popcon.popup.likes.repository.PopupLikeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,7 @@ public class PopupLikeCommandService {
 
     private final PopupRepository popupRepository;
     private final PopupLikeRepository popupLikeRepository;
+    private final CacheManager cacheManager;
 
     public void likePopup(Long popupId, Long userId) {
         validateUserId(userId);
@@ -33,6 +36,7 @@ public class PopupLikeCommandService {
         try {
             popupLikeRepository.save(PopupLike.create(popup, userId));
             popupRepository.incrementLikeCountById(popupId);
+            evictPopularRankingsCache();
         } catch (DataIntegrityViolationException e) {
             // Unique constraint race: another request created the like first.
         }
@@ -49,6 +53,7 @@ public class PopupLikeCommandService {
             .ifPresent(popupLike -> {
                 popupLikeRepository.delete(popupLike);
                 popupRepository.decrementLikeCountById(popupId);
+                evictPopularRankingsCache();
             });
     }
 
@@ -61,6 +66,13 @@ public class PopupLikeCommandService {
     private void validatePopupId(Long popupId) {
         if (popupId == null) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void evictPopularRankingsCache() {
+        Cache cache = cacheManager.getCache("popularRankings");
+        if (cache != null) {
+            cache.clear();
         }
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeCommandService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeCommandService.java
@@ -7,6 +7,7 @@ import com.t1.popcon.popup.detail.entity.PopupLike;
 import com.t1.popcon.popup.detail.repository.PopupRepository;
 import com.t1.popcon.popup.likes.repository.PopupLikeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,8 +29,12 @@ public class PopupLikeCommandService {
             return;
         }
 
-        popupLikeRepository.save(PopupLike.create(popup, userId));
-        popup.increaseLikeCount();
+        try {
+            popupLikeRepository.save(PopupLike.create(popup, userId));
+            popup.increaseLikeCount();
+        } catch (DataIntegrityViolationException e) {
+            // Unique constraint race: another request created the like first.
+        }
     }
 
     public void unlikePopup(Long popupId, Long userId) {

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeCommandService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeCommandService.java
@@ -1,0 +1,53 @@
+package com.t1.popcon.popup.likes.service;
+
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.popup.detail.entity.Popup;
+import com.t1.popcon.popup.detail.entity.PopupLike;
+import com.t1.popcon.popup.detail.repository.PopupRepository;
+import com.t1.popcon.popup.likes.repository.PopupLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PopupLikeCommandService {
+
+    private final PopupRepository popupRepository;
+    private final PopupLikeRepository popupLikeRepository;
+
+    public void likePopup(Long popupId, Long userId) {
+        validateUserId(userId);
+
+        Popup popup = popupRepository.findById(popupId)
+            .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
+
+        if (popupLikeRepository.existsByPopup_IdAndUserId(popupId, userId)) {
+            return;
+        }
+
+        popupLikeRepository.save(PopupLike.create(popup, userId));
+        popup.increaseLikeCount();
+    }
+
+    public void unlikePopup(Long popupId, Long userId) {
+        validateUserId(userId);
+
+        popupRepository.findById(popupId)
+            .orElseThrow(() -> new CustomException(ErrorCode.POPUP_NOT_FOUND));
+
+        popupLikeRepository.findByPopup_IdAndUserId(popupId, userId)
+            .ifPresent(popupLike -> {
+                popupLikeRepository.delete(popupLike);
+                popupLike.getPopup().decreaseLikeCount();
+            });
+    }
+
+    private void validateUserId(Long userId) {
+        if (userId == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeQueryService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeQueryService.java
@@ -26,6 +26,7 @@ public class PopupLikeQueryService {
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
     private static final int DEFAULT_PAGE = 0;
     private static final int DEFAULT_SIZE = 12;
+    private static final int MAX_PAGE_SIZE = 100;
 
     private final PopupLikeRepository popupLikeRepository;
 
@@ -48,14 +49,24 @@ public class PopupLikeQueryService {
     }
 
     private void validatePageRequest(int page, int size) {
-        if (page < 0 || size < 1) {
+        if (page < 0 || size < 1 || size > MAX_PAGE_SIZE) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
     }
 
     private PopupCardDto toPopupCardDto(Popup popup) {
         PhaseInfo phaseInfo = resolvePhaseInfo(popup);
-        PhaseStatus status = calculatePhaseStatus(phaseInfo.openAt(), phaseInfo.closeAt());
+        PhaseStatus status = phaseInfo == null
+            ? PhaseStatus.CLOSED
+            : calculatePhaseStatus(phaseInfo.openAt(), phaseInfo.closeAt());
+        PopupCardDto.PhaseDto phaseDto = phaseInfo == null
+            ? null
+            : new PopupCardDto.PhaseDto(
+                phaseInfo.phaseType(),
+                status,
+                toOffsetDateTime(phaseInfo.openAt()),
+                toOffsetDateTime(phaseInfo.closeAt())
+            );
 
         return new PopupCardDto(
             popup.getId(),
@@ -63,16 +74,11 @@ public class PopupLikeQueryService {
             popup.getSubtitle(),
             popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
             popup.getCaption(),
-            phaseInfo.phaseType() == PhaseType.AUCTION ? popup.getHThumbUrl() : popup.getVThumbUrl(),
+            phaseInfo != null && phaseInfo.phaseType() == PhaseType.AUCTION ? popup.getHThumbUrl() : popup.getVThumbUrl(),
             true,
             new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
-            resolveOverlay(phaseInfo.phaseType(), status),
-            new PopupCardDto.PhaseDto(
-                phaseInfo.phaseType(),
-                status,
-                phaseInfo.openAt().atZone(KST_ZONE).toOffsetDateTime(),
-                phaseInfo.closeAt().atZone(KST_ZONE).toOffsetDateTime()
-            )
+            phaseInfo == null ? null : resolveOverlay(phaseInfo.phaseType(), status),
+            phaseDto
         );
     }
 
@@ -102,6 +108,18 @@ public class PopupLikeQueryService {
             return auctionFirst
                 ? new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt())
                 : new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
+        }
+
+        if (popup.getAuctionCloseAt() == null && popup.getDrawCloseAt() == null) {
+            return null;
+        }
+
+        if (popup.getAuctionCloseAt() == null) {
+            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
+        }
+
+        if (popup.getDrawCloseAt() == null) {
+            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
         }
 
         boolean auctionLast = popup.getAuctionCloseAt().isAfter(popup.getDrawCloseAt());
@@ -142,6 +160,10 @@ public class PopupLikeQueryService {
         }
 
         return null;
+    }
+
+    private java.time.OffsetDateTime toOffsetDateTime(LocalDateTime dateTime) {
+        return dateTime == null ? null : dateTime.atZone(KST_ZONE).toOffsetDateTime();
     }
 
     private record PhaseInfo(

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeQueryService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeQueryService.java
@@ -1,0 +1,153 @@
+package com.t1.popcon.popup.likes.service;
+
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.popup.detail.entity.Popup;
+import com.t1.popcon.popup.detail.entity.PopupLike;
+import com.t1.popcon.popup.dto.card.OverlayType;
+import com.t1.popcon.popup.dto.card.PhaseStatus;
+import com.t1.popcon.popup.dto.card.PhaseType;
+import com.t1.popcon.popup.dto.card.PopupCardDto;
+import com.t1.popcon.popup.likes.dto.SliceResponse;
+import com.t1.popcon.popup.likes.repository.PopupLikeRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PopupLikeQueryService {
+
+    private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 12;
+
+    private final PopupLikeRepository popupLikeRepository;
+
+    public SliceResponse<PopupCardDto> getLikedPopups(Long userId, Integer page, Integer size) {
+        if (userId == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        int validatedPage = page == null ? DEFAULT_PAGE : page;
+        int validatedSize = size == null ? DEFAULT_SIZE : size;
+        validatePageRequest(validatedPage, validatedSize);
+
+        Slice<PopupLike> likeSlice = popupLikeRepository.findByUserIdOrderByCreatedAtDescIdDesc(
+            userId,
+            PageRequest.of(validatedPage, validatedSize)
+        );
+
+        Slice<PopupCardDto> cardSlice = likeSlice.map(popupLike -> toPopupCardDto(popupLike.getPopup()));
+        return SliceResponse.from(cardSlice);
+    }
+
+    private void validatePageRequest(int page, int size) {
+        if (page < 0 || size < 1) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private PopupCardDto toPopupCardDto(Popup popup) {
+        PhaseInfo phaseInfo = resolvePhaseInfo(popup);
+        PhaseStatus status = calculatePhaseStatus(phaseInfo.openAt(), phaseInfo.closeAt());
+
+        return new PopupCardDto(
+            popup.getId(),
+            popup.getTitle(),
+            popup.getSubtitle(),
+            popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
+            popup.getCaption(),
+            phaseInfo.phaseType() == PhaseType.AUCTION ? popup.getHThumbUrl() : popup.getVThumbUrl(),
+            true,
+            new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
+            resolveOverlay(phaseInfo.phaseType(), status),
+            new PopupCardDto.PhaseDto(
+                phaseInfo.phaseType(),
+                status,
+                phaseInfo.openAt().atZone(KST_ZONE).toOffsetDateTime(),
+                phaseInfo.closeAt().atZone(KST_ZONE).toOffsetDateTime()
+            )
+        );
+    }
+
+    private PhaseInfo resolvePhaseInfo(Popup popup) {
+        LocalDateTime now = LocalDateTime.now(KST_ZONE);
+        PhaseStatus auctionStatus = calculatePhaseStatus(popup.getAuctionOpenAt(), popup.getAuctionCloseAt(), now);
+        PhaseStatus drawStatus = calculatePhaseStatus(popup.getDrawOpenAt(), popup.getDrawCloseAt(), now);
+
+        if (auctionStatus == PhaseStatus.OPEN) {
+            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
+        }
+
+        if (drawStatus == PhaseStatus.OPEN) {
+            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
+        }
+
+        if (auctionStatus == PhaseStatus.UPCOMING && drawStatus != PhaseStatus.UPCOMING) {
+            return new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt());
+        }
+
+        if (drawStatus == PhaseStatus.UPCOMING && auctionStatus != PhaseStatus.UPCOMING) {
+            return new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
+        }
+
+        if (auctionStatus == PhaseStatus.UPCOMING) {
+            boolean auctionFirst = popup.getAuctionOpenAt().isBefore(popup.getDrawOpenAt());
+            return auctionFirst
+                ? new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt())
+                : new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
+        }
+
+        boolean auctionLast = popup.getAuctionCloseAt().isAfter(popup.getDrawCloseAt());
+        return auctionLast
+            ? new PhaseInfo(PhaseType.AUCTION, popup.getAuctionOpenAt(), popup.getAuctionCloseAt())
+            : new PhaseInfo(PhaseType.DRAW, popup.getDrawOpenAt(), popup.getDrawCloseAt());
+    }
+
+    private PhaseStatus calculatePhaseStatus(LocalDateTime openAt, LocalDateTime closeAt) {
+        return calculatePhaseStatus(openAt, closeAt, LocalDateTime.now(KST_ZONE));
+    }
+
+    private PhaseStatus calculatePhaseStatus(LocalDateTime openAt, LocalDateTime closeAt, LocalDateTime now) {
+        if (openAt == null || closeAt == null) {
+            return PhaseStatus.CLOSED;
+        }
+        if (now.isBefore(openAt)) {
+            return PhaseStatus.UPCOMING;
+        }
+        if (!now.isBefore(closeAt)) {
+            return PhaseStatus.CLOSED;
+        }
+        return PhaseStatus.OPEN;
+    }
+
+    private PopupCardDto.OverlayDto resolveOverlay(PhaseType phaseType, PhaseStatus status) {
+        if (phaseType == PhaseType.AUCTION) {
+            if (status == PhaseStatus.OPEN) {
+                return new PopupCardDto.OverlayDto(OverlayType.AUCTION_IN_PROGRESS, null);
+            }
+            if (status == PhaseStatus.UPCOMING) {
+                return new PopupCardDto.OverlayDto(OverlayType.AUCTION_OPEN_AT, null);
+            }
+        }
+
+        if (phaseType == PhaseType.DRAW && status == PhaseStatus.UPCOMING) {
+            return new PopupCardDto.OverlayDto(OverlayType.DRAW_OPEN_AT, null);
+        }
+
+        return null;
+    }
+
+    private record PhaseInfo(
+        PhaseType phaseType,
+        LocalDateTime openAt,
+        LocalDateTime closeAt
+    ) {
+    }
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeQueryService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeQueryService.java
@@ -4,7 +4,6 @@ import com.t1.popcon.common.exception.CustomException;
 import com.t1.popcon.common.exception.ErrorCode;
 import com.t1.popcon.popup.detail.entity.Popup;
 import com.t1.popcon.popup.detail.entity.PopupLike;
-import com.t1.popcon.popup.dto.card.OverlayType;
 import com.t1.popcon.popup.dto.card.PhaseStatus;
 import com.t1.popcon.popup.dto.card.PhaseType;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
@@ -77,7 +76,7 @@ public class PopupLikeQueryService {
             phaseInfo != null && phaseInfo.phaseType() == PhaseType.AUCTION ? popup.getHThumbUrl() : popup.getVThumbUrl(),
             true,
             new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
-            phaseInfo == null ? null : resolveOverlay(phaseInfo.phaseType(), status),
+            null,
             phaseDto
         );
     }
@@ -143,23 +142,6 @@ public class PopupLikeQueryService {
             return PhaseStatus.CLOSED;
         }
         return PhaseStatus.OPEN;
-    }
-
-    private PopupCardDto.OverlayDto resolveOverlay(PhaseType phaseType, PhaseStatus status) {
-        if (phaseType == PhaseType.AUCTION) {
-            if (status == PhaseStatus.OPEN) {
-                return new PopupCardDto.OverlayDto(OverlayType.AUCTION_IN_PROGRESS, null);
-            }
-            if (status == PhaseStatus.UPCOMING) {
-                return new PopupCardDto.OverlayDto(OverlayType.AUCTION_OPEN_AT, null);
-            }
-        }
-
-        if (phaseType == PhaseType.DRAW && status == PhaseStatus.UPCOMING) {
-            return new PopupCardDto.OverlayDto(OverlayType.DRAW_OPEN_AT, null);
-        }
-
-        return null;
     }
 
     private java.time.OffsetDateTime toOffsetDateTime(LocalDateTime dateTime) {

--- a/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeReadService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/likes/service/PopupLikeReadService.java
@@ -1,0 +1,31 @@
+package com.t1.popcon.popup.likes.service;
+
+import com.t1.popcon.popup.likes.repository.PopupLikeRepository;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PopupLikeReadService {
+
+    private final PopupLikeRepository popupLikeRepository;
+
+    public boolean isLiked(Long popupId, Long userId) {
+        if (popupId == null || userId == null) {
+            return false;
+        }
+        return popupLikeRepository.existsByPopup_IdAndUserId(popupId, userId);
+    }
+
+    public Set<Long> getLikedPopupIds(Long userId, Collection<Long> popupIds) {
+        if (userId == null || popupIds == null || popupIds.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return popupLikeRepository.findLikedPopupIds(userId, popupIds);
+    }
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/listings/controller/PopupListingsController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/listings/controller/PopupListingsController.java
@@ -1,5 +1,6 @@
 package com.t1.popcon.popup.listings.controller;
 
+import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.popup.dto.card.PhaseStatus;
 import com.t1.popcon.popup.dto.card.PhaseType;
@@ -7,14 +8,14 @@ import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.card.PopupSort;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.listings.service.PopupListingsService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,21 +24,24 @@ public class PopupListingsController {
 
     private final PopupListingsService popupListingsService;
 
-    /**
-     * 경매/드로우 목록 조회
-     */
     @GetMapping
     public ResponseEntity<ApiResponse<PopupSectionResponse<PopupCardDto>>> getPopups(
+        @AuthenticationPrincipal AuthUser authUser,
         @RequestParam(required = false) PhaseType phaseType,
         @RequestParam(required = false) List<PhaseStatus> phaseStatus,
         @RequestParam(required = false) PopupSort sort,
         @RequestParam(defaultValue = "10") int limit
     ) {
         PopupSectionResponse<PopupCardDto> data =
-            popupListingsService.getPopups(phaseType, phaseStatus, sort, limit);
+            popupListingsService.getPopups(
+                authUser != null ? authUser.id() : null,
+                phaseType,
+                phaseStatus,
+                sort,
+                limit
+            );
 
         String message = popupListingsService.getMessage(phaseType, phaseStatus);
-
         return ResponseEntity.ok(ApiResponse.ok(message, data));
     }
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/listings/service/PopupListingsService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/listings/service/PopupListingsService.java
@@ -10,16 +10,17 @@ import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.card.PopupSort;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
+import com.t1.popcon.popup.likes.service.PopupLikeReadService;
 import com.t1.popcon.popup.listings.repository.PopupListingsRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -28,8 +29,10 @@ public class PopupListingsService {
     private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     private final PopupListingsRepository popupListingsRepository;
+    private final PopupLikeReadService popupLikeReadService;
 
     public PopupSectionResponse<PopupCardDto> getPopups(
+        Long userId,
         PhaseType phaseType,
         List<PhaseStatus> statuses,
         PopupSort sort,
@@ -46,16 +49,12 @@ public class PopupListingsService {
         }
 
         SectionKey sectionKey = resolveSectionKey(phaseType, statuses);
-
-        // 현재 시각 기준으로 status 비교 (요청 단위로 1회 고정)
         LocalDateTime now = LocalDateTime.now(KST_ZONE);
 
-        // phaseStatus 목록을 boolean 플래그로 변환 → JPQL OR 조건에 전달
-        boolean openEnabled     = statuses.contains(PhaseStatus.OPEN);
+        boolean openEnabled = statuses.contains(PhaseStatus.OPEN);
         boolean upcomingEnabled = statuses.contains(PhaseStatus.UPCOMING);
-        boolean closedEnabled   = statuses.contains(PhaseStatus.CLOSED);
+        boolean closedEnabled = statuses.contains(PhaseStatus.CLOSED);
 
-        // phaseType에 따라 경매 또는 드로우 쿼리 분기
         List<Popup> popups;
         if (phaseType == PhaseType.AUCTION) {
             popups = popupListingsRepository.findAuctionPopups(
@@ -69,15 +68,16 @@ public class PopupListingsService {
             );
         }
 
+        Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
+            userId,
+            popups.stream().map(Popup::getId).toList()
+        );
+
         List<PopupCardDto> items = popups.stream()
-            .map(p -> toPopupCardDto(p, phaseType, now))
+            .map(p -> toPopupCardDto(p, phaseType, now, likedPopupIds.contains(p.getId())))
             .toList();
 
-        return new PopupSectionResponse<>(
-            sectionKey,
-            items.size(),
-            items
-        );
+        return new PopupSectionResponse<>(sectionKey, items.size(), items);
     }
 
     public String getMessage(PhaseType type, List<PhaseStatus> statuses) {
@@ -86,7 +86,7 @@ public class PopupListingsService {
         }
 
         if (type == PhaseType.AUCTION) {
-            return "더치 경매 섹션 조회를 성공했습니다.";
+            return "경매 섹션 조회를 성공했습니다.";
         }
 
         if (statuses.size() == 1 && statuses.contains(PhaseStatus.OPEN)) {
@@ -116,19 +116,15 @@ public class PopupListingsService {
         throw new CustomException(ErrorCode.INVALID_INPUT);
     }
 
-    /**
-     * Popup 엔티티를 카드 DTO로 변환
-     * - phaseType이 명시되므로 경매/드로우 시간 필드를 직접 선택
-     */
-    private PopupCardDto toPopupCardDto(Popup popup, PhaseType phaseType, LocalDateTime now) {
+    private PopupCardDto toPopupCardDto(Popup popup, PhaseType phaseType, LocalDateTime now, boolean liked) {
         LocalDateTime openAt;
         LocalDateTime closeAt;
 
         if (phaseType == PhaseType.AUCTION) {
-            openAt  = popup.getAuctionOpenAt();
+            openAt = popup.getAuctionOpenAt();
             closeAt = popup.getAuctionCloseAt();
         } else {
-            openAt  = popup.getDrawOpenAt();
+            openAt = popup.getDrawOpenAt();
             closeAt = popup.getDrawCloseAt();
         }
 
@@ -141,7 +137,7 @@ public class PopupListingsService {
                 popup.getSubText() != null ? popup.getSubText() : popup.getLocation(),
                 popup.getCaption(),
                 phaseType == PhaseType.AUCTION ? popup.getHThumbUrl() : popup.getVThumbUrl(),
-                false,
+                liked,
                 new PopupCardDto.StatsDto(popup.getLikeCount(), popup.getViewCount()),
                 resolveOverlay(phaseType, status),
                 new PopupCardDto.PhaseDto(
@@ -153,25 +149,15 @@ public class PopupListingsService {
         );
     }
 
-    /**
-     * 현재 시각 기준으로 phase 상태 계산
-     */
     private PhaseStatus calculatePhaseStatus(LocalDateTime openAt, LocalDateTime closeAt, LocalDateTime now) {
-        if (now.isBefore(openAt))   return PhaseStatus.UPCOMING;
+        if (now.isBefore(openAt)) return PhaseStatus.UPCOMING;
         if (!now.isBefore(closeAt)) return PhaseStatus.CLOSED;
         return PhaseStatus.OPEN;
     }
 
-    /**
-     * phase 타입 및 상태에 따른 오버레이 결정
-     * - 경매 진행 중 → AUCTION_IN_PROGRESS
-     * - 경매 오픈 예정 → AUCTION_OPEN_AT
-     * - 드로우 오픈 예정 → DRAW_OPEN_AT
-     * - 드로우 진행 중 / 종료 → 오버레이 없음
-     */
     private PopupCardDto.OverlayDto resolveOverlay(PhaseType phaseType, PhaseStatus status) {
         if (phaseType == PhaseType.AUCTION) {
-            if (status == PhaseStatus.OPEN)     return new PopupCardDto.OverlayDto(OverlayType.AUCTION_IN_PROGRESS, null);
+            if (status == PhaseStatus.OPEN) return new PopupCardDto.OverlayDto(OverlayType.AUCTION_IN_PROGRESS, null);
             if (status == PhaseStatus.UPCOMING) return new PopupCardDto.OverlayDto(OverlayType.AUCTION_OPEN_AT, null);
         }
         if (phaseType == PhaseType.DRAW && status == PhaseStatus.UPCOMING) {

--- a/popup-service/src/main/java/com/t1/popcon/popup/rankings/controller/PopupRankingsController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/rankings/controller/PopupRankingsController.java
@@ -1,16 +1,16 @@
 package com.t1.popcon.popup.rankings.controller;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.rankings.service.PopupRankingsService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/popups")
@@ -20,9 +20,12 @@ public class PopupRankingsController {
 	private final PopupRankingsService popupRankingsService;
 
 	@GetMapping("/rankings")
-	public ResponseEntity<ApiResponse<PopupSectionResponse<PopupCardDto>>> getPopularRankings() {
-		PopupSectionResponse<PopupCardDto> response = popupRankingsService.getPopularRankings();
+	public ResponseEntity<ApiResponse<PopupSectionResponse<PopupCardDto>>> getPopularRankings(
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		PopupSectionResponse<PopupCardDto> response =
+			popupRankingsService.getPopularRankings(authUser != null ? authUser.id() : null);
 
-		return ResponseEntity.ok(ApiResponse.ok("인기 랭킹 팝업스토어 조회에 성공했습니다.", response));
+		return ResponseEntity.ok(ApiResponse.ok("인기 랭킹 팝업스토어 조회를 성공했습니다.", response));
 	}
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/rankings/service/PopupRankingsService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/rankings/service/PopupRankingsService.java
@@ -1,37 +1,42 @@
 package com.t1.popcon.popup.rankings.service;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.List;
-import java.util.stream.IntStream;
-
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
-
-import com.t1.popcon.popup.rankings.repository.PopupRankingsRepository;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.card.PopupMapper;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
-
+import com.t1.popcon.popup.likes.service.PopupLikeReadService;
+import com.t1.popcon.popup.rankings.repository.PopupRankingsRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PopupRankingsService {
 
 	private final PopupRankingsRepository popupRankingsRepository;
+	private final PopupLikeReadService popupLikeReadService;
 	private static final ZoneId TIME_ZONE = ZoneId.of("Asia/Seoul");
 
-	@Cacheable(value = "popularRankings", key = "T(java.time.LocalDate).now(T(java.time.ZoneId).of('Asia/Seoul'))")
-	public PopupSectionResponse<PopupCardDto> getPopularRankings() {
-		// 1. 내부적으로 상위 10개만 조회하도록 고정
+	@Cacheable(
+		value = "popularRankings",
+		key = "T(java.time.LocalDate).now(T(java.time.ZoneId).of('Asia/Seoul')).toString() + ':' + (#userId == null ? 'guest' : #userId)"
+	)
+	public PopupSectionResponse<PopupCardDto> getPopularRankings(Long userId) {
 		var popups = popupRankingsRepository.findPopupsByWeightedScore(LocalDate.now(TIME_ZONE), PageRequest.of(0, 10));
+		Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
+			userId,
+			popups.stream().map(p -> p.getId()).toList()
+		);
 
-		// 2. 엔티티 -> DTO 변환 및 랭킹 번호 부여 (1~10)
 		List<PopupCardDto> rankingItems = IntStream.range(0, popups.size())
-			.mapToObj(i -> PopupMapper.toCardDto(popups.get(i), i + 1))
+			.mapToObj(i -> PopupMapper.toCardDto(popups.get(i), i + 1, likedPopupIds.contains(popups.get(i).getId())))
 			.toList();
 
 		return new PopupSectionResponse<>(

--- a/popup-service/src/main/java/com/t1/popcon/popup/rankings/service/PopupRankingsService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/rankings/service/PopupRankingsService.java
@@ -60,7 +60,8 @@ public class PopupRankingsService {
 	}
 
 	private PopupSectionResponse<PopupCardDto> getCachedPopularRankings() {
-		String cacheKey = LocalDate.now(TIME_ZONE).toString();
+		LocalDate currentDate = LocalDate.now(TIME_ZONE);
+		String cacheKey = currentDate.toString();
 		Cache cache = cacheManager.getCache("popularRankings");
 		if (cache != null) {
 			PopupSectionResponse<PopupCardDto> cached = cache.get(cacheKey, PopupSectionResponse.class);
@@ -69,7 +70,7 @@ public class PopupRankingsService {
 			}
 		}
 
-		var popups = popupRankingsRepository.findPopupsByWeightedScore(LocalDate.now(TIME_ZONE), PageRequest.of(0, 10));
+		var popups = popupRankingsRepository.findPopupsByWeightedScore(currentDate, PageRequest.of(0, 10));
 		Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
 			null,
 			popups.stream().map(p -> p.getId()).toList()

--- a/popup-service/src/main/java/com/t1/popcon/popup/rankings/service/PopupRankingsService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/rankings/service/PopupRankingsService.java
@@ -28,10 +28,12 @@ public class PopupRankingsService {
 
 	public PopupSectionResponse<PopupCardDto> getPopularRankings(Long userId) {
 		PopupSectionResponse<PopupCardDto> cachedResponse = getCachedPopularRankings();
-		Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
-			userId,
-			cachedResponse.items().stream().map(PopupCardDto::popupId).toList()
-		);
+		Set<Long> likedPopupIds = userId == null || cachedResponse.items().isEmpty()
+			? Set.of()
+			: popupLikeReadService.getLikedPopupIds(
+				userId,
+				cachedResponse.items().stream().map(PopupCardDto::popupId).toList()
+			);
 
 		if (likedPopupIds.isEmpty()) {
 			return cachedResponse;
@@ -71,10 +73,12 @@ public class PopupRankingsService {
 		}
 
 		var popups = popupRankingsRepository.findPopupsByWeightedScore(currentDate, PageRequest.of(0, 10));
-		Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
-			null,
-			popups.stream().map(p -> p.getId()).toList()
-		);
+		Set<Long> likedPopupIds = popups.isEmpty()
+			? Set.of()
+			: popupLikeReadService.getLikedPopupIds(
+				null,
+				popups.stream().map(p -> p.getId()).toList()
+			);
 
 		List<PopupCardDto> rankingItems = IntStream.range(0, popups.size())
 			.mapToObj(i -> PopupMapper.toCardDto(popups.get(i), i + 1, likedPopupIds.contains(popups.get(i).getId())))

--- a/popup-service/src/main/java/com/t1/popcon/popup/rankings/service/PopupRankingsService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/rankings/service/PopupRankingsService.java
@@ -12,7 +12,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
@@ -22,16 +23,55 @@ public class PopupRankingsService {
 
 	private final PopupRankingsRepository popupRankingsRepository;
 	private final PopupLikeReadService popupLikeReadService;
+	private final CacheManager cacheManager;
 	private static final ZoneId TIME_ZONE = ZoneId.of("Asia/Seoul");
 
-	@Cacheable(
-		value = "popularRankings",
-		key = "T(java.time.LocalDate).now(T(java.time.ZoneId).of('Asia/Seoul')).toString() + ':' + (#userId == null ? 'guest' : #userId)"
-	)
 	public PopupSectionResponse<PopupCardDto> getPopularRankings(Long userId) {
-		var popups = popupRankingsRepository.findPopupsByWeightedScore(LocalDate.now(TIME_ZONE), PageRequest.of(0, 10));
+		PopupSectionResponse<PopupCardDto> cachedResponse = getCachedPopularRankings();
 		Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
 			userId,
+			cachedResponse.items().stream().map(PopupCardDto::popupId).toList()
+		);
+
+		if (likedPopupIds.isEmpty()) {
+			return cachedResponse;
+		}
+
+		List<PopupCardDto> rankingItems = cachedResponse.items().stream()
+			.map(item -> new PopupCardDto(
+				item.popupId(),
+				item.title(),
+				item.supportingText(),
+				item.subText(),
+				item.caption(),
+				item.thumbnailUrl(),
+				likedPopupIds.contains(item.popupId()),
+				item.stats(),
+				item.overlay(),
+				item.phase()
+			))
+			.toList();
+
+		return new PopupSectionResponse<>(
+			cachedResponse.sectionKey(),
+			cachedResponse.itemCount(),
+			rankingItems
+		);
+	}
+
+	private PopupSectionResponse<PopupCardDto> getCachedPopularRankings() {
+		String cacheKey = LocalDate.now(TIME_ZONE).toString();
+		Cache cache = cacheManager.getCache("popularRankings");
+		if (cache != null) {
+			PopupSectionResponse<PopupCardDto> cached = cache.get(cacheKey, PopupSectionResponse.class);
+			if (cached != null) {
+				return cached;
+			}
+		}
+
+		var popups = popupRankingsRepository.findPopupsByWeightedScore(LocalDate.now(TIME_ZONE), PageRequest.of(0, 10));
+		Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
+			null,
 			popups.stream().map(p -> p.getId()).toList()
 		);
 
@@ -39,10 +79,14 @@ public class PopupRankingsService {
 			.mapToObj(i -> PopupMapper.toCardDto(popups.get(i), i + 1, likedPopupIds.contains(popups.get(i).getId())))
 			.toList();
 
-		return new PopupSectionResponse<>(
+		PopupSectionResponse<PopupCardDto> response = new PopupSectionResponse<>(
 			SectionKey.RANKINGS_WEEKLY,
 			rankingItems.size(),
 			rankingItems
 		);
+		if (cache != null) {
+			cache.put(cacheKey, response);
+		}
+		return response;
 	}
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/recommended/controller/PopupRecommendedController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/recommended/controller/PopupRecommendedController.java
@@ -1,16 +1,16 @@
 package com.t1.popcon.popup.recommended.controller;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.recommended.service.PopupRecommendedService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/popups")
@@ -19,8 +19,11 @@ public class PopupRecommendedController {
 	private final PopupRecommendedService popupRecommendedService;
 
 	@GetMapping("/recommended")
-	public ResponseEntity<ApiResponse<PopupSectionResponse<PopupCardDto>>> recommended() {
-		PopupSectionResponse<PopupCardDto> response = popupRecommendedService.recommended();
-		return ResponseEntity.ok(ApiResponse.ok("추천 팝업스토어 조회에 성공했습니다.", response));
+	public ResponseEntity<ApiResponse<PopupSectionResponse<PopupCardDto>>> recommended(
+		@AuthenticationPrincipal AuthUser authUser
+	) {
+		PopupSectionResponse<PopupCardDto> response =
+			popupRecommendedService.recommended(authUser != null ? authUser.id() : null);
+		return ResponseEntity.ok(ApiResponse.ok("추천 팝업스토어 조회를 성공했습니다.", response));
 	}
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/recommended/service/PopupRecommendedService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/recommended/service/PopupRecommendedService.java
@@ -1,45 +1,45 @@
 package com.t1.popcon.popup.recommended.service;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-
-import com.t1.popcon.popup.recommended.repository.PopupRecommendedRepository;
 import com.t1.popcon.popup.detail.entity.Popup;
 import com.t1.popcon.popup.dto.card.PopupCardDto;
 import com.t1.popcon.popup.dto.card.PopupMapper;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
-
+import com.t1.popcon.popup.likes.service.PopupLikeReadService;
+import com.t1.popcon.popup.recommended.repository.PopupRecommendedRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PopupRecommendedService {
 
 	private final PopupRecommendedRepository popupRecommendedRepository;
+	private final PopupLikeReadService popupLikeReadService;
 	private static final ZoneId TIME_ZONE = ZoneId.of("Asia/Seoul");
 
-	public PopupSectionResponse<PopupCardDto> recommended() {
-		// 1. 조건에 맞는 전체 팝업 조회
+	public PopupSectionResponse<PopupCardDto> recommended(Long userId) {
 		List<Popup> allPopups = popupRecommendedRepository.findAllByCloseAtAfter(LocalDate.now(TIME_ZONE));
-
-		// 2. 자바에서 리스트 복사 후 셔플 (원본 보존)
 		List<Popup> shuffledPopups = new ArrayList<>(allPopups);
 		Collections.shuffle(shuffledPopups);
 
-		// 3. 내부적으로 10개만 추출하도록 고정
 		List<Popup> randomPopups = shuffledPopups.stream()
 			.limit(10)
 			.toList();
 
-		// 4. 엔티티 -> DTO 변환
+		Set<Long> likedPopupIds = popupLikeReadService.getLikedPopupIds(
+			userId,
+			randomPopups.stream().map(Popup::getId).toList()
+		);
+
 		List<PopupCardDto> recommendedItems = randomPopups.stream()
-			.map(p -> PopupMapper.toCardDto(p, null))
+			.map(p -> PopupMapper.toCardDto(p, null, likedPopupIds.contains(p.getId())))
 			.toList();
 
 		return new PopupSectionResponse<>(

--- a/popup-service/src/test/java/com/t1/popcon/popup/banners/controller/PopupBannersControllerTest.java
+++ b/popup-service/src/test/java/com/t1/popcon/popup/banners/controller/PopupBannersControllerTest.java
@@ -1,5 +1,6 @@
 package com.t1.popcon.popup.banners.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -58,7 +59,7 @@ class PopupBannersControllerTest extends AbstractRestDocsTest {
             ApiResponse<PopupSectionResponse<PopupCardDto>> expectedResponse =
                 ApiResponse.ok("배너 섹션 조회를 성공했습니다.", responseDto);
 
-            given(popupBannersService.getBanners(anyInt()))
+            given(popupBannersService.getBanners(any(), anyInt()))
                 .willReturn(responseDto);
 
             performGet(SUCCESS_URL)
@@ -82,7 +83,7 @@ class PopupBannersControllerTest extends AbstractRestDocsTest {
             ApiResponse<?> expectedResponse =
                 invalidInput("limit", "limit는 1 이상 5 이하여야 합니다.");
 
-            given(popupBannersService.getBanners(anyInt()))
+            given(popupBannersService.getBanners(any(), anyInt()))
                 .willThrow(new CustomException(
                     ErrorCode.INVALID_INPUT,
                     Map.of("limit", "limit는 1 이상 5 이하여야 합니다.")
@@ -106,7 +107,7 @@ class PopupBannersControllerTest extends AbstractRestDocsTest {
         void 실패_서버_오류() throws Exception {
             ApiResponse<Void> expectedResponse = systemError();
 
-            given(popupBannersService.getBanners(anyInt()))
+            given(popupBannersService.getBanners(any(), anyInt()))
                 .willThrow(new RuntimeException("Internal Server Error"));
 
             performGet(DEFAULT_URL)

--- a/popup-service/src/test/java/com/t1/popcon/popup/detail/controller/PopupDetailControllerTest.java
+++ b/popup-service/src/test/java/com/t1/popcon/popup/detail/controller/PopupDetailControllerTest.java
@@ -1,5 +1,6 @@
 package com.t1.popcon.popup.detail.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -77,7 +78,7 @@ class PopupDetailControllerTest extends AbstractRestDocsTest {
             ApiResponse<PopupDetailResponse> expectedResponse =
                     ApiResponse.ok("팝업스토어 조회를 성공했습니다.", responseDto);
 
-            given(popupDetailService.getPopupDetail(anyLong())).willReturn(responseDto);
+            given(popupDetailService.getPopupDetail(anyLong(), any())).willReturn(responseDto);
 
             // when & then
             mockMvc.perform(
@@ -108,7 +109,7 @@ class PopupDetailControllerTest extends AbstractRestDocsTest {
             Long popupId = 1L;
             ApiResponse<Void> expectedResponse = ApiResponse.fail(ErrorCode.ERROR_SYSTEM);
 
-            given(popupDetailService.getPopupDetail(anyLong()))
+            given(popupDetailService.getPopupDetail(anyLong(), any()))
                     .willThrow(new RuntimeException("Internal Server Error"));
 
             // when & then

--- a/popup-service/src/test/java/com/t1/popcon/popup/listings/controller/PopupListingsControllerTest.java
+++ b/popup-service/src/test/java/com/t1/popcon/popup/listings/controller/PopupListingsControllerTest.java
@@ -83,7 +83,7 @@ class PopupListingsControllerTest extends AbstractRestDocsTest {
             ApiResponse<PopupSectionResponse<PopupCardDto>> expectedResponse =
                 ApiResponse.ok("더치 경매 섹션 조회를 성공했습니다.", responseDto);
 
-            given(popupListingsService.getPopups(any(), any(), any(), anyInt()))
+            given(popupListingsService.getPopups(any(), any(), any(), any(), anyInt()))
                 .willReturn(responseDto);
 
             given(popupListingsService.getMessage(any(), any()))
@@ -119,7 +119,7 @@ class PopupListingsControllerTest extends AbstractRestDocsTest {
             ApiResponse<PopupSectionResponse<PopupCardDto>> expectedResponse =
                 ApiResponse.ok("진행 중 드로우 섹션 조회를 성공했습니다.", responseDto);
 
-            given(popupListingsService.getPopups(any(), any(), any(), anyInt()))
+            given(popupListingsService.getPopups(any(), any(), any(), any(), anyInt()))
                 .willReturn(responseDto);
 
             given(popupListingsService.getMessage(any(), any()))
@@ -155,7 +155,7 @@ class PopupListingsControllerTest extends AbstractRestDocsTest {
             ApiResponse<PopupSectionResponse<PopupCardDto>> expectedResponse =
                 ApiResponse.ok("오픈 예정 드로우 섹션 조회를 성공했습니다.", responseDto);
 
-            given(popupListingsService.getPopups(any(), any(), any(), anyInt()))
+            given(popupListingsService.getPopups(any(), any(), any(), any(), anyInt()))
                 .willReturn(responseDto);
 
             given(popupListingsService.getMessage(any(), any()))
@@ -183,7 +183,7 @@ class PopupListingsControllerTest extends AbstractRestDocsTest {
             ApiResponse<Void> expectedResponse =
                 ApiResponse.fail(ErrorCode.INVALID_INPUT);
 
-            given(popupListingsService.getPopups(any(), any(), any(), anyInt()))
+            given(popupListingsService.getPopups(any(), any(), any(), any(), anyInt()))
                 .willThrow(new CustomException(ErrorCode.INVALID_INPUT));
 
             mockMvc.perform(
@@ -212,7 +212,7 @@ class PopupListingsControllerTest extends AbstractRestDocsTest {
             ApiResponse<?> expectedResponse =
                 invalidInput("limit", "limit는 1 이상이어야 합니다.");
 
-            given(popupListingsService.getPopups(any(), any(), any(), anyInt()))
+            given(popupListingsService.getPopups(any(), any(), any(), any(), anyInt()))
                 .willThrow(new CustomException(
                     ErrorCode.INVALID_INPUT,
                     Map.of("limit", "limit는 1 이상이어야 합니다.")
@@ -293,7 +293,7 @@ class PopupListingsControllerTest extends AbstractRestDocsTest {
         void 실패_서버_오류() throws Exception {
             ApiResponse<Void> expectedResponse = systemError();
 
-            given(popupListingsService.getPopups(any(), any(), any(), anyInt()))
+            given(popupListingsService.getPopups(any(), any(), any(), any(), anyInt()))
                 .willThrow(new RuntimeException("Internal Server Error"));
 
             performGet(AUCTION_URL)

--- a/user-service/src/main/java/com/t1/popcon/user/client/PopupServiceClient.java
+++ b/user-service/src/main/java/com/t1/popcon/user/client/PopupServiceClient.java
@@ -1,0 +1,24 @@
+package com.t1.popcon.user.client;
+
+import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.user.client.config.FeignClientConfig;
+import com.t1.popcon.user.dto.history.PopupLikeHistoryResponse;
+import com.t1.popcon.user.dto.history.SliceResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "popup-service",
+    url = "${services.popup-service.url:http://localhost:8082}",
+    configuration = FeignClientConfig.class
+)
+public interface PopupServiceClient {
+
+    @GetMapping("/internal/popups/likes")
+    ApiResponse<SliceResponse<PopupLikeHistoryResponse>> getLikedPopups(
+        @RequestParam("userId") Long userId,
+        @RequestParam("page") int page,
+        @RequestParam("size") int size
+    );
+}

--- a/user-service/src/main/java/com/t1/popcon/user/controller/UserHistoryController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/controller/UserHistoryController.java
@@ -4,6 +4,7 @@ import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.user.dto.history.AuctionHistoryResponse;
 import com.t1.popcon.user.dto.history.DrawHistoryResponse;
+import com.t1.popcon.user.dto.history.PopupLikeHistoryResponse;
 import com.t1.popcon.user.dto.history.SliceResponse;
 import com.t1.popcon.user.dto.history.TicketHistoryResponse;
 import com.t1.popcon.user.service.UserHistoryService;
@@ -52,5 +53,15 @@ public class UserHistoryController {
     ) {
         TicketHistoryResponse response = userHistoryService.getTicketByReservationNo(authUser.id(), reservationNo);
         return ApiResponse.ok("티켓 상세 조회를 성공했습니다.", response);
+    }
+
+    @GetMapping("/likes")
+    public ApiResponse<SliceResponse<PopupLikeHistoryResponse>> getLikedPopups(
+        @AuthenticationPrincipal AuthUser authUser,
+        @RequestParam(value = "page", defaultValue = "0") int page,
+        @RequestParam(value = "size", defaultValue = "12") int size
+    ) {
+        SliceResponse<PopupLikeHistoryResponse> response = userHistoryService.getLikedPopups(authUser.id(), page, size);
+        return ApiResponse.ok("찜한 팝업스토어 목록 조회를 성공했습니다.", response);
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/PopupLikeHistoryResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/PopupLikeHistoryResponse.java
@@ -1,0 +1,36 @@
+package com.t1.popcon.user.dto.history;
+
+import java.time.OffsetDateTime;
+
+public record PopupLikeHistoryResponse(
+    Long popupId,
+    String title,
+    String supportingText,
+    String subText,
+    String caption,
+    String thumbnailUrl,
+    Boolean liked,
+    Stats stats,
+    Overlay overlay,
+    Phase phase
+) {
+    public record Stats(
+        long likeCount,
+        long viewCount
+    ) {
+    }
+
+    public record Overlay(
+        String type,
+        Integer rank
+    ) {
+    }
+
+    public record Phase(
+        String type,
+        String status,
+        OffsetDateTime openAt,
+        OffsetDateTime closeAt
+    ) {
+    }
+}

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -5,9 +5,11 @@ import com.t1.popcon.common.exception.ErrorCode;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.user.client.AuctionServiceClient;
 import com.t1.popcon.user.client.DrawServiceClient;
+import com.t1.popcon.user.client.PopupServiceClient;
 import com.t1.popcon.user.client.TicketServiceClient;
 import com.t1.popcon.user.dto.history.AuctionHistoryResponse;
 import com.t1.popcon.user.dto.history.DrawHistoryResponse;
+import com.t1.popcon.user.dto.history.PopupLikeHistoryResponse;
 import com.t1.popcon.user.dto.history.SliceResponse;
 import com.t1.popcon.user.dto.history.TicketHistoryResponse;
 import java.util.ArrayList;
@@ -27,6 +29,7 @@ public class UserHistoryService {
     private final DrawServiceClient drawServiceClient;
     private final AuctionServiceClient auctionServiceClient;
     private final TicketServiceClient ticketServiceClient;
+    private final PopupServiceClient popupServiceClient;
 
     public List<DrawHistoryResponse> getDrawHistory(Long userId) {
         try {
@@ -100,6 +103,20 @@ public class UserHistoryService {
             throw e;
         } catch (Exception e) {
             log.error(">>>> [Ticket-Service 연동 실패] userId={}, reservationNo={}, Error: {}", userId, reservationNo, e.getMessage());
+            throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
+        }
+    }
+
+    public SliceResponse<PopupLikeHistoryResponse> getLikedPopups(Long userId, int page, int size) {
+        try {
+            ApiResponse<SliceResponse<PopupLikeHistoryResponse>> response =
+                popupServiceClient.getLikedPopups(userId, page, size);
+            if (response == null || response.getData() == null) {
+                throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
+            }
+            return response.getData();
+        } catch (Exception e) {
+            log.error(">>>> [Popup-Service 연동 실패] User ID: {}, Error: {}", userId, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #159 

## 📝 작업 내용

> 마이페이지 찜 목록 기능을 위해 사용자별 찜 조회, 찜 추가/해제 API를 구현하고, 기존 카드 응답의 liked 값을 실제 사용자 찜 여부 기준으로 동작하도록 정리했습니다.
- user-service에 마이페이지 찜 목록 API GET /history/likes 추가
- popup-service에 내부 찜 목록 조회 API GET /internal/popups/likes 추가
- popup-service에 찜 추가 API POST /popups/{popupId}/likes 추가
- popup-service에 찜 해제 API DELETE /popups/{popupId}/likes 추가
- popup_likes 기준 사용자별 찜 목록을 페이지네이션으로 조회하도록 구현
- 찜 추가/해제 시 popups.like_count 증감 반영
- 상세, 일반 목록, 추천, 랭킹, 주목, 마감임박, 배너 응답의 liked 하드코딩 제거
- 로그인 사용자가 있으면 실제 찜 여부를 반영하고, 비로그인 상태에서는 liked=false가 내려가도록 처리
- 좋아요 중복 요청 시 unique 제약 예외로 실패하지 않도록 멱등하게 보강
## ✅ 테스트 결과 (선택)

> 로컬 환경에서 Postman으로 아래 항목 확인했습니다.
- POST /popups/{popupId}/likes 성공 응답 확인
- GET /history/likes에서 찜한 팝업 목록 조회 성공 확인
- DELETE /popups/{popupId}/likes 성공 응답 확인
- 찜 해제 후 GET /history/likes 재조회 시 목록에서 제거되는 것 확인
- 상세/목록 API에서 liked 값이 실제 찜 상태에 따라 true/false로 변경되는 것 확인
## 📷 스크린샷 (선택)

> 
<img width="622" height="872" alt="찜한 목록 조회 성공 응답" src="https://github.com/user-attachments/assets/159fdb97-e4ae-4e99-8edb-bfba9a8500d0" />
<img width="673" height="910" alt="좋아요" src="https://github.com/user-attachments/assets/98f172dc-7dfa-4898-b405-0858396d7c28" />
<img width="618" height="818" alt="찜 추가 성공응답" src="https://github.com/user-attachments/assets/efeea2c4-4eec-43c7-a2ce-65191c591f97" />
<img width="592" height="798" alt="찜 해제" src="https://github.com/user-attachments/assets/df1363c3-95df-475b-ac45-40ff85f39d6c" />


## 💬 리뷰 요구사항(선택)