### PR TITLE
debug: 드로우 OPEN 상태 조회 디버깅 로그 추가

### DIFF
--- a/popup-service/src/main/java/com/t1/popcon/popup/listings/service/PopupListingsService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/listings/service/PopupListingsService.java
@@ -12,6 +12,7 @@ import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
 import com.t1.popcon.popup.listings.repository.PopupListingsRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PopupListingsService {
@@ -55,8 +57,9 @@ public class PopupListingsService {
         boolean upcomingEnabled = statuses.contains(PhaseStatus.UPCOMING);
         boolean closedEnabled   = statuses.contains(PhaseStatus.CLOSED);
 
-        // 디버깅 로그
-        System.out.println("[DEBUG] phaseType=" + phaseType + ", statuses=" + statuses + ", openEnabled=" + openEnabled + ", now=" + now);
+        // 드로우 조회 디버깅 로그
+        log.debug("[DRAW_LISTINGS] phaseType={}, statuses={}, openEnabled={}, upcomingEnabled={}, closedEnabled={}, now={}, limit={}",
+                phaseType, statuses, openEnabled, upcomingEnabled, closedEnabled, now, limit);
 
         // phaseType에 따라 경매 또는 드로우 쿼리 분기
         List<Popup> popups;
@@ -70,6 +73,12 @@ public class PopupListingsService {
                 now, openEnabled, upcomingEnabled, closedEnabled,
                 PageRequest.of(0, limit)
             );
+        }
+
+        log.debug("[DRAW_LISTINGS] 조회 결과: {} 건", popups.size());
+        if (!popups.isEmpty()) {
+            popups.forEach(p -> log.debug("[DRAW_LISTINGS] id={}, drawOpenAt={}, drawCloseAt={}, deleted={}",
+                    p.getId(), p.getDrawOpenAt(), p.getDrawCloseAt(), p.isDeleted()));
         }
 
         List<PopupCardDto> items = popups.stream()


### PR DESCRIPTION
## #️⃣ 관련 이슈

> x

## 📝 작업 내용

> phaseStatus 파라미터 전달 및 DB 조회 조건을 로깅하여 프로덕션 환경에서 드로우 진행중 팝업이 조회되지 않는 이유 파악

SLF4J를 사용하여 드로우 목록 조회 시 파라미터, 조건, 결과를 상세히 로깅
- 요청 파라미터 (phaseType, statuses, boolean 플래그)
- 현재 시간 (now)
- DB 조회 결과 건수
- 조회된 각 popup의 id, drawOpenAt, drawCloseAt, deleted 상태

## ✅ 테스트 결과

> 로컬에서는 정상 동작 확인

## 📷 스크린샷

>