### PR TITLE
fix: DrawDetailResponse serverTime 밀리초 제외, 초까지만 반환

### DIFF
--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawDetailResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawDetailResponse.java
@@ -1,5 +1,6 @@
 package com.t1.popcon.draw.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record DrawDetailResponse(
@@ -7,6 +8,7 @@ public record DrawDetailResponse(
         LocalDateTime drawOpenAt,
         LocalDateTime drawCloseAt,
         boolean participatable,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") // 밀리초 제외, 초까지만 반환
         LocalDateTime serverTime
 ) {
     public static DrawDetailResponse of(


### PR DESCRIPTION
## 📝 작업 내용

프론트 요청에 따라 DrawDetailResponse serverTime 밀리초 제외, 초까지만 반환