### PR TITLE
fix: DrawDetailResponse serverTime 밀리초 제외

### DIFF
--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawDetailResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawDetailResponse.java
@@ -1,6 +1,5 @@
 package com.t1.popcon.draw.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record DrawDetailResponse(
@@ -8,7 +7,6 @@ public record DrawDetailResponse(
         LocalDateTime drawOpenAt,
         LocalDateTime drawCloseAt,
         boolean participatable,
-        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") // 밀리초 제외, 초까지만 반환
         LocalDateTime serverTime
 ) {
     public static DrawDetailResponse of(

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +25,7 @@ public class DrawService {
         Draw draw = drawRepository.findById(drawId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DRAW_NOT_FOUND));
 
-        LocalDateTime serverTime = LocalDateTime.now(clock);
+        LocalDateTime serverTime = LocalDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS); // 밀리초 제거
 
         boolean participatable =
                 !serverTime.isBefore(draw.getDrawOpenAt()) &&

--- a/popup-service/src/main/resources/application-staging.yml
+++ b/popup-service/src/main/resources/application-staging.yml
@@ -41,11 +41,8 @@ server:
 
 logging:
   level:
-    root: debug
+    root: info
     org.hibernate: warn
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
-    com.t1.popcon.popup.listings.service.PopupListingsService: debug
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📝 작업 내용

> 프론트 요청에 따라 DrawDetailResponse serverTime 밀리초 제외, 초까지만 반환