### PR TITLE
feat: 카테고리 섹션 구현

### DIFF
--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawService.java
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +24,7 @@ public class DrawService {
         Draw draw = drawRepository.findById(drawId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DRAW_NOT_FOUND));
 
-        LocalDateTime serverTime = LocalDateTime.now(clock).truncatedTo(ChronoUnit.SECONDS); // 밀리초 제거
+        LocalDateTime serverTime = LocalDateTime.now(clock);
 
         boolean participatable =
                 !serverTime.isBefore(draw.getDrawOpenAt()) &&

--- a/popup-service/src/main/java/com/t1/popcon/popup/categories/controller/CategoryController.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/categories/controller/CategoryController.java
@@ -1,0 +1,29 @@
+package com.t1.popcon.popup.categories.controller;
+
+import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.popup.categories.dto.CategoryIconDto;
+import com.t1.popcon.popup.categories.service.CategoryService;
+import com.t1.popcon.popup.dto.section.PopupSectionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/popups/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    // 카테고리 섹션 조회 - 아이콘 이미지, 이름, 연결 팝업 ID 반환
+    @GetMapping
+    public ResponseEntity<ApiResponse<PopupSectionResponse<CategoryIconDto>>> getCategories(
+        @RequestParam(defaultValue = "6") int limit
+    ) {
+        PopupSectionResponse<CategoryIconDto> data = categoryService.getCategories(limit);
+        return ResponseEntity.ok(ApiResponse.ok("카테고리 섹션 조회를 성공했습니다.", data));
+    }
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/categories/dto/CategoryIconDto.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/categories/dto/CategoryIconDto.java
@@ -1,0 +1,8 @@
+package com.t1.popcon.popup.categories.dto;
+
+// 카테고리 아이콘 DTO - 아이콘 이미지, 이름, 연결된 팝업 ID만 포함
+public record CategoryIconDto(
+    String iconUrl,
+    String iconName,
+    Long popupId
+) {}

--- a/popup-service/src/main/java/com/t1/popcon/popup/categories/entity/Category.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/categories/entity/Category.java
@@ -1,0 +1,36 @@
+package com.t1.popcon.popup.categories.entity;
+
+import com.t1.popcon.common.entity.BaseAuditEntity;
+import com.t1.popcon.popup.detail.entity.Popup;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "categories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseAuditEntity {
+
+    // 아이콘 이미지 URL
+    @Column(nullable = false, length = 512)
+    private String iconUrl;
+
+    // 아이콘 이름 (카테고리 라벨)
+    @Column(nullable = false, length = 50)
+    private String iconName;
+
+    // 연결된 팝업
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "popup_id", nullable = false)
+    private Popup popup;
+
+    // 노출 순서
+    @Column(nullable = false)
+    private int priority;
+
+    // 활성 여부
+    @Column(nullable = false)
+    private boolean isActive = true;
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/categories/repository/CategoryRepository.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/categories/repository/CategoryRepository.java
@@ -1,0 +1,15 @@
+package com.t1.popcon.popup.categories.repository;
+
+import com.t1.popcon.popup.categories.entity.Category;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    // 활성 카테고리를 priority 오름차순으로 조회
+    @Query("select c from Category c join fetch c.popup p where c.isActive = true order by c.priority asc")
+    List<Category> findActiveCategoriesWithPopup(Pageable pageable);
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/categories/service/CategoryService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/categories/service/CategoryService.java
@@ -1,0 +1,45 @@
+package com.t1.popcon.popup.categories.service;
+
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.popup.categories.dto.CategoryIconDto;
+import com.t1.popcon.popup.categories.repository.CategoryRepository;
+import com.t1.popcon.popup.dto.section.PopupSectionResponse;
+import com.t1.popcon.popup.dto.section.SectionKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    public PopupSectionResponse<CategoryIconDto> getCategories(int limit) {
+        // limit 유효성 검사 - 범위 초과 시 필드별 상세 메시지 포함
+        if (limit < 1 || limit > 6) {
+            Map<String, String> errors = new LinkedHashMap<>();
+            errors.put("limit", "limit는 1 이상 6 이하여야 합니다.");
+            throw new CustomException(ErrorCode.INVALID_INPUT, errors);
+        }
+
+        List<CategoryIconDto> items = categoryRepository
+                .findActiveCategoriesWithPopup(PageRequest.of(0, limit))
+                .stream()
+                .map(c -> new CategoryIconDto(
+                        c.getIconUrl(),
+                        c.getIconName(),
+                        c.getPopup().getId()
+                ))
+                .toList();
+
+        return PopupSectionResponse.of(SectionKey.CATEGORIES, items);
+    }
+}

--- a/popup-service/src/main/java/com/t1/popcon/popup/dto/section/SectionKey.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/dto/section/SectionKey.java
@@ -3,6 +3,7 @@ package com.t1.popcon.popup.dto.section;
 public enum SectionKey {
     // Home
     BANNERS,
+    CATEGORIES,
     RECOMMENDED,
     RANKINGS_WEEKLY,
     AUCTIONS,


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #182 

## 📝 작업 내용

**카테고리 섹션 추가**
- Category 엔티티 및 테이블 추가 (icon_url, icon_name, popup_id, priority, is_active)
- `GET /popups/categories` 엔드포인트 추가
- SectionKey에 CATEGORIES 추가
- 응답: CategoryIconDto (iconUrl, iconName, popupId)

## ✅ 테스트 결과

> <img width="330" height="431" alt="image" src="https://github.com/user-attachments/assets/0683023c-542c-4009-8ee3-91e313b0f504" />