### PR TITLE
fix: queue-service 임시 permitAll 인증 설정 복구

### DIFF
--- a/common/src/main/java/com/t1/popcon/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/t1/popcon/common/exception/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // CustomException 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<?>> handleCustom(CustomException e, HttpServletRequest request) {
         ErrorCode ec = e.getErrorCode();
@@ -44,6 +45,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(ec));
     }
 
+    // DTO 검증 실패 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValid(
             MethodArgumentNotValidException e,
@@ -70,6 +72,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(ec, fieldErrors));
     }
 
+    // 파라미터 타입 불일치 처리
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<?>> handleTypeMismatch(
             MethodArgumentTypeMismatchException e,
@@ -83,6 +86,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(ec));
     }
 
+    // 파라미터 검증 실패 처리
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiResponse<?>> handleConstraintViolation(
             ConstraintViolationException e,
@@ -95,6 +99,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(ec));
     }
 
+    // 허용되지 않는 HTTP 메서드 처리
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodNotSupported(
             HttpRequestMethodNotSupportedException e,
@@ -118,6 +123,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(ec));
     }
 
+    // 비동기 요청 타임아웃 처리
     @ExceptionHandler(AsyncRequestTimeoutException.class)
     public void handleAsyncRequestTimeout(
             AsyncRequestTimeoutException e,
@@ -136,6 +142,7 @@ public class GlobalExceptionHandler {
         }
     }
 
+    // 기타 서버 오류 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e, HttpServletRequest request) {
         ErrorCode ec = ErrorCode.ERROR_SYSTEM;

--- a/queue-service/src/main/java/com/t1/popcon/queue/config/QueueSecurityConfig.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/config/QueueSecurityConfig.java
@@ -33,15 +33,13 @@ public class QueueSecurityConfig extends CommonSecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         super.configureCommonSettings(http);
 
-        // TODO: 운영 배포 전 아래 인증 설정으로 복구
-        // http.authorizeHttpRequests(auth -> auth
-        //         .requestMatchers("/health", "/actuator/**").permitAll()
-        //         .requestMatchers(HttpMethod.GET, "/queues/status").permitAll()
-        //         .requestMatchers(HttpMethod.DELETE, "/queues").permitAll()
-        //         .requestMatchers(HttpMethod.POST, "/queues/**").authenticated()
-        //         .anyRequest().authenticated()
-        // );
-        http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers("/health", "/actuator/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/queues/status").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/queues").authenticated()
+                .requestMatchers(HttpMethod.POST, "/queues/**").authenticated()
+                .anyRequest().authenticated()
+        );
 
         return http.build();
     }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> x

## 📝 작업 내용
QueueSecurityConfig anyRequest().permitAll() 운영 인증 설정 복구
- anyRequest().permitAll() 임시 설정 제거
- 전 엔드포인트 JWT 인증 필수로 변경 (/health, /actuator 제외)