### PR TITLE
refactor: 로그인 사용자 검증 추가 및 보안퀴즈 제출자 id 검증

### DIFF
--- a/queue-service/src/main/java/com/t1/popcon/queue/controller/VqaController.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/controller/VqaController.java
@@ -1,5 +1,6 @@
 package com.t1.popcon.queue.controller;
 
+import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.exception.CustomException;
 import com.t1.popcon.common.exception.ErrorCode;
 import com.t1.popcon.common.response.ApiResponse;
@@ -10,6 +11,7 @@ import com.t1.popcon.queue.dto.vqa.VqaNextQuestionResponse;
 import com.t1.popcon.queue.service.VqaService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,30 +27,34 @@ public class VqaController {
     /** 보안 퀴즈 시작 및 면제 판단 */
     @PostMapping("/start")
     public ApiResponse<VqaStartResponse> start(
-            @RequestHeader(value = QUEUE_TOKEN_HEADER, required = false) String queueToken) {
+            @RequestHeader(value = QUEUE_TOKEN_HEADER, required = false) String queueToken,
+            @AuthenticationPrincipal AuthUser authUser) {
         validateQueueToken(queueToken);
-        VqaStartResponse response = vqaService.start(queueToken);
+        VqaStartResponse response = vqaService.start(queueToken, authUser.id());
         return ApiResponse.ok(response);
     }
 
     /** 다음 문제 정보 조회 */
     @GetMapping("/next")
     public ApiResponse<VqaNextQuestionResponse> getNextQuestion(
-            @RequestParam String sessionId) {
-        VqaNextQuestionResponse response = vqaService.getNextQuestion(sessionId);
+            @RequestParam String sessionId,
+            @AuthenticationPrincipal AuthUser authUser) {
+        VqaNextQuestionResponse response = vqaService.getNextQuestion(sessionId, authUser.id());
         return ApiResponse.ok(response);
     }
 
     /** 답변 제출 및 결과 확인 */
     @PostMapping("/submit")
     public ApiResponse<VqaSubmitResult> submit(
-            @Valid @RequestBody VqaUserSubmitRequest request) {
+            @Valid @RequestBody VqaUserSubmitRequest request,
+            @AuthenticationPrincipal AuthUser authUser) {
         VqaSubmitResult result = vqaService.submit(
             request.vqaSessionId(),
             request.videoId(),
             request.questionId(),
             request.userAnswer(),
-            request.totalTime()
+            request.totalTime(),
+            authUser.id()
         );
         return ApiResponse.ok(result);
     }

--- a/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
@@ -50,11 +50,17 @@ public class VqaService {
      * 보안 퀴즈 시작 (원샷 방식)
      * - 분산 락을 통해 동일 사용자의 중복 세션 생성 방지
      */
-    public VqaStartResponse start(String queueToken) {
+    public VqaStartResponse start(String queueToken, Long currentUserId) {
         QueueTokenResolver.TokenInfo tokenInfo = tokenResolver.resolve(queueToken);
         long userId = tokenInfo.userId();
         String phaseType = tokenInfo.phaseType();
         long phaseId = tokenInfo.phaseId();
+
+        // 0. 사용자 일치 검증
+        if (userId != currentUserId) {
+            log.warn("[VQA] 대기열 토큰 사용자 불일치 - tokenUserId={}, currentUserId={}", userId, currentUserId);
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
 
         RLock lock = redissonClient.getLock(VQA_LOCK_START_PREFIX + userId + ":" + phaseId);
         try {
@@ -91,7 +97,7 @@ public class VqaService {
                 String sessionData = redisTemplate.opsForValue().get(VQA_SESSION_KEY_PREFIX + existingVqaSessionId);
                 if (sessionData != null) {
                     log.info("[VQA] 기존 세션 재사용 - userId={}, vqaSessionId={}", userId, existingVqaSessionId);
-                    VqaNextQuestionResponse nextQuestion = getNextQuestion(existingVqaSessionId);
+                    VqaNextQuestionResponse nextQuestion = getNextQuestion(existingVqaSessionId, currentUserId);
                     return VqaStartResponse.session(existingVqaSessionId, nextQuestion);
                 }
             }
@@ -131,16 +137,25 @@ public class VqaService {
     }
 
     /** 다음 문제 정보 조회 */
-    public VqaNextQuestionResponse getNextQuestion(String vqaSessionId) {
+    public VqaNextQuestionResponse getNextQuestion(String vqaSessionId, Long currentUserId) {
         String sessionData = getSessionDataOrThrow(vqaSessionId);
-        Long pythonSessionId = parsePythonSessionId(sessionData);
-        int score = parseScore(sessionData);
+        String[] parts = sessionData.split(":");
+        long userId = parseNumeric(parts[2], "userId");
+
+        // 사용자 일치 검증
+        if (userId != currentUserId) {
+            log.warn("[VQA] 세션 사용자 불일치 - sessionUserId={}, currentUserId={}", userId, currentUserId);
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        Long pythonSessionId = parseNumeric(parts[3], "pythonSessionId");
+        int score = (int) parseNumeric(parts[5], "score");
 
         return vqaClient.getNextQuestion(pythonSessionId, score);
     }
 
     /** 답변 제출 (분산 락을 통한 원자성 보장) */
-    public VqaSubmitResult submit(String vqaSessionId, Long videoId, Long questionId, String answer, Double time) {
+    public VqaSubmitResult submit(String vqaSessionId, Long videoId, Long questionId, String answer, Double time, Long currentUserId) {
         RLock lock = redissonClient.getLock(VQA_LOCK_SUBMIT_PREFIX + vqaSessionId);
         
         try {
@@ -159,6 +174,13 @@ public class VqaService {
             String phaseType = parts[0];
             long phaseId = parseNumeric(parts[1], "phaseId");
             long userId = parseNumeric(parts[2], "userId");
+
+            // 사용자 일치 검증
+            if (userId != currentUserId) {
+                log.warn("[VQA] 제출 세션 사용자 불일치 - sessionUserId={}, currentUserId={}", userId, currentUserId);
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
+
             long pythonSessionId = parseNumeric(parts[3], "pythonSessionId");
             int score = (int) parseNumeric(parts[5], "score");
 

--- a/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
@@ -140,6 +140,11 @@ public class VqaService {
     public VqaNextQuestionResponse getNextQuestion(String vqaSessionId, Long currentUserId) {
         String sessionData = getSessionDataOrThrow(vqaSessionId);
         String[] parts = sessionData.split(":");
+
+        if (parts.length < 6) {
+            throw new CustomException(ErrorCode.VQA_SESSION_EXPIRED, "세션 데이터 형식이 올바르지 않습니다.");
+        }
+
         long userId = parseNumeric(parts[2], "userId");
 
         // 사용자 일치 검증
@@ -148,7 +153,7 @@ public class VqaService {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
-        Long pythonSessionId = parseNumeric(parts[3], "pythonSessionId");
+        long pythonSessionId = parseNumeric(parts[3], "pythonSessionId");
         int score = (int) parseNumeric(parts[5], "score");
 
         return vqaClient.getNextQuestion(pythonSessionId, score);


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #193 

## 📝 작업 내용

> 보안퀴즈 api 엔드포인트 진입시 로그인 사용자 검증과 서비스 내부에서 사용자 일치 검증 추가했습니다
- `VqaController.java` `@AuthenticationPrincipal` 추가
- `VqaService.java` 내부에 사용자 검증 로직 추가

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> 