### PR TITLE
refactor: 경매 낙찰 이후 예약확인 페이지 썸네일 응답 추가

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/dto/PopupInternalResponse.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/dto/PopupInternalResponse.java
@@ -7,6 +7,7 @@ public record PopupInternalResponse(
 	Long popupId,
 	String title,
 	String location,
-	String thumbnailUrl
+	String hThumbnailUrl,
+	String vThumbnailUrl
 ) {
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/dto/response/ReservationDetailResponse.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/dto/response/ReservationDetailResponse.java
@@ -10,6 +10,7 @@ public record ReservationDetailResponse(
     String reservationNo,
     String popupTitle,
     String popupAddress,
+    String popupThumbnail,
     LocalDate entryDate,
     LocalTime entryTime,
     Integer startPrice,

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -94,6 +94,7 @@ public class BidService {
             .reservationNo(bid.getReservationNo())
             .popupTitle(bid.getPopupTitle())
             .popupAddress(bid.getPopupAddress())
+            .popupThumbnail(bid.getThumbnailUrl())
             .entryDate(bid.getEntryDate())
             .entryTime(bid.getEntryTime())
             .startPrice(startPrice)
@@ -193,7 +194,7 @@ public class BidService {
                     PopupInternalResponse popupInfo = popupResponse.getData();
                     popupTitle = popupInfo.title();
                     popupAddress = popupInfo.location();
-                    thumbnailUrl = popupInfo.thumbnailUrl();
+                    thumbnailUrl = popupInfo.vThumbnailUrl();
                 } else {
                     log.warn(">>>> [팝업 정보 조회 실패] 응답이 비어있음 popupId={}", option.getAuction().getPopupId());
                 }

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -113,7 +113,7 @@ public class BidServiceTest {
 		PortOnePaymentResponse paymentResponse = new PortOnePaymentResponse(paymentDetail);
 		given(portOneClient.executePayment(anyString(), anyString(), anyInt(), anyString())).willReturn(paymentResponse);
 
-		PopupInternalResponse popupInfo = new PopupInternalResponse(1L, "Pop-up Title", "Location", "thumbnail.url");
+		PopupInternalResponse popupInfo = new PopupInternalResponse(1L, "Pop-up Title", "Location", "h_thumbnail.url", "v_thumbnail.url");
 		given(auction.getPopupId()).willReturn(1L);
 		given(popupServiceClient.getPopupDetail(anyLong())).willReturn(ApiResponse.ok(popupInfo));
 		given(option.getEntryDate()).willReturn(LocalDate.now());
@@ -146,7 +146,7 @@ public class BidServiceTest {
 			eq("TKT123456789012"),
 			eq("Pop-up Title"),
 			eq("Location"),
-			eq("thumbnail.url"),
+			eq("v_thumbnail.url"),
 			any(LocalDate.class),
 			any(LocalTime.class),
 			eq(10000)


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #197 

## 📝 작업 내용

> 경매 낙찰 이후 예약 확인 페이지에서 사용 가능한 썸네일 url 추가 작업 진행했습니다
- `PopupInternalResponse.java` 썸네일 필드 추가
- `ReservationDetailResponse.java` 썸네일 필드 추가
- `BidService.java` 썸네일 주입 추가

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> 