### PR TITLE
feat: 프로필 조회 API 구현

### DIFF
--- a/user-service/src/main/java/com/t1/popcon/user/controller/UserController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/controller/UserController.java
@@ -21,14 +21,13 @@ public class UserController {
     /**
      * 내 프로필 조회
      * GET /users/me
-     *
-     * @param authUser JWT에서 추출된 인증 사용자
-     * @return 사용자 프로필 정보
      */
     @GetMapping("/me")
     public ApiResponse<UserProfileResponse> getMyProfile(@AuthenticationPrincipal AuthUser authUser) {
         UserProfileResponse response = userService.getUserProfile(authUser.id());
         return ApiResponse.ok("프로필 조회를 완료했습니다.", response);
+    }
+
     @GetMapping("/me/id")
     public ApiResponse<UserIdResponse> getMyId(
       @AuthenticationPrincipal AuthUser authUser

--- a/user-service/src/main/java/com/t1/popcon/user/controller/UserController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.t1.popcon.user.controller;
+
+import com.t1.popcon.common.auth.domain.AuthUser;
+import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.user.dto.UserProfileResponse;
+import com.t1.popcon.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 사용자 프로필 관련 API 컨트롤러
+ * - My 팝콘 페이지 / 프로필 관리 페이지에서 사용
+ */
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 내 프로필 조회
+     * GET /users/me
+     *
+     * @param authUser JWT에서 추출된 인증 사용자
+     * @return 사용자 프로필 정보
+     */
+    @GetMapping("/me")
+    public ApiResponse<UserProfileResponse> getMyProfile(@AuthenticationPrincipal AuthUser authUser) {
+        UserProfileResponse response = userService.getUserProfile(authUser.id());
+        return ApiResponse.ok("프로필 조회를 완료했습니다.", response);
+    }
+}

--- a/user-service/src/main/java/com/t1/popcon/user/domain/User.java
+++ b/user-service/src/main/java/com/t1/popcon/user/domain/User.java
@@ -70,6 +70,10 @@ public class User extends BaseSoftDeleteEntity {
     @Column(name = "email", length = 255)
     private String email;
 
+    /** 사용자가 직접 등록한 프로필 이미지 URL */
+    @Column(name = "profile_image_url", length = 512)
+    private String profileImageUrl;
+
     @Column(name = "kakao_user_id", length = 128)
     private String kakaoUserId;
 

--- a/user-service/src/main/java/com/t1/popcon/user/dto/UserProfileResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/UserProfileResponse.java
@@ -1,0 +1,35 @@
+package com.t1.popcon.user.dto;
+
+import com.t1.popcon.user.domain.User;
+
+import java.time.LocalDate;
+
+/**
+ * GET /users/me 프로필 조회 응답 DTO
+ */
+public record UserProfileResponse(
+        Long id,
+        String name,
+        String nickname,
+        String email,
+        String phone,
+        LocalDate birthDate,
+        String gender,
+        String profileImage,
+        LocalDate joinDate
+) {
+    /** User 엔티티와 복호화된 민감정보로 응답 객체 생성 */
+    public static UserProfileResponse of(User user, String name, String phone, String birthDate, String gender) {
+        return new UserProfileResponse(
+                user.getId(),
+                name,
+                user.getNickname(),
+                user.getEmail(),
+                phone,
+                birthDate != null ? LocalDate.parse(birthDate) : null,
+                gender,
+                user.getProfileImageUrl(),
+                user.getCreatedAt() != null ? user.getCreatedAt().toLocalDate() : null
+        );
+    }
+}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/UserProfileResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/UserProfileResponse.java
@@ -26,7 +26,7 @@ public record UserProfileResponse(
                 user.getNickname(),
                 user.getEmail(),
                 phone,
-                birthDate != null ? LocalDate.parse(birthDate) : null,
+                (birthDate != null && !birthDate.isBlank()) ? LocalDate.parse(birthDate.trim()) : null,
                 gender,
                 user.getProfileImageUrl(),
                 user.getCreatedAt() != null ? user.getCreatedAt().toLocalDate() : null

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -1,10 +1,12 @@
 package com.t1.popcon.user.service;
 
+import com.t1.popcon.common.encryption.EncryptionService;
 import com.t1.popcon.common.exception.CustomException;
 import com.t1.popcon.common.exception.ErrorCode;
 import com.t1.popcon.user.domain.User;
 import com.t1.popcon.user.dto.UserLookupResponse;
 import com.t1.popcon.user.dto.UserInternalResponse;
+import com.t1.popcon.user.dto.UserProfileResponse;
 import com.t1.popcon.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,11 +28,28 @@ public class UserService {
 
     private static final int MAX_NICKNAME_RETRIES = 5;
     private static final String NICKNAME_CONSTRAINT = "uk_users_nickname";
-    
+
     private final UserRepository userRepository;
+    private final EncryptionService encryptionService;
 
     @Value("${user.nickname.prefix:User}")
     private String nicknamePrefix;
+
+    /**
+     * 사용자 프로필 조회 (GET /users/me)
+     * 암호화된 민감정보를 복호화하여 반환
+     */
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = getUserOrThrow(userId);
+        return UserProfileResponse.of(
+                user,
+                encryptionService.decrypt(user.getEncryptedName()),
+                encryptionService.decrypt(user.getEncryptedPhoneNumber()),
+                encryptionService.decrypt(user.getEncryptedBirthDate()),
+                encryptionService.decrypt(user.getEncryptedGender())
+        );
+    }
 
     /**
      * 사용자 상세 정보 조회 (내부 서비스용)


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #191 
> Related to #190 

## 📝 작업 내용
- `GET /users/me` 엔드포인트 추가
- JWT에서 userId 추출 후 암호화된 개인정보 복호화하여 반환
- User 엔티티에 `profileImageUrl` 컬럼 추가 (프로필 수정 API를 통해서만 업데이트)

## ✅ 테스트 결과
<img width="565" height="527" alt="image" src="https://github.com/user-attachments/assets/07ac6c78-d8ca-47a5-8db8-6c53e43e2098" />
 