### PR TITLE
fix: 마이페이지 티켓 목록/상세 조회 개선

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/controller/InternalBidController.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/controller/InternalBidController.java
@@ -1,11 +1,13 @@
 package com.t1.popcon.auction.bid.controller;
 
 import com.t1.popcon.auction.bid.dto.response.BidHistoryResponse;
+import com.t1.popcon.auction.bid.dto.response.ReservationDetailResponse;
 import com.t1.popcon.auction.bid.service.BidService;
 import com.t1.popcon.common.response.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +22,15 @@ public class InternalBidController {
     @GetMapping("/bids")
     public ApiResponse<List<BidHistoryResponse>> getBidHistory(@RequestParam("userId") Long userId) {
         List<BidHistoryResponse> responses = bidService.getBidHistory(userId);
-        return ApiResponse.ok("경매 응찰 이력 조회를 성공했습니다.", responses);
+        return ApiResponse.ok("경매 참여 이력 조회 성공", responses);
+    }
+
+    @GetMapping("/bids/{bidId}")
+    public ApiResponse<ReservationDetailResponse> getBidDetail(
+        @PathVariable("bidId") Long bidId,
+        @RequestParam("userId") Long userId
+    ) {
+        ReservationDetailResponse response = bidService.getBidDetail(userId, bidId);
+        return ApiResponse.ok("경매 상세 조회 성공", response);
     }
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
@@ -40,6 +40,8 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
 	Optional<Bid> findByIdAndUserId(Long id, Long userId);
 
+	Optional<Bid> findByIdAndUserIdAndStatus(Long id, Long userId, BidStatus status);
+
 	@Query("SELECT b FROM Bid b " +
 		"WHERE b.userId = :userId AND b.status = :status AND b.deleted = false " +
 		"ORDER BY b.createdAt DESC")

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
@@ -36,6 +36,8 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
 	Optional<Bid> findByReservationNo(String reservationNo);
 
+	Optional<Bid> findByReservationNoAndUserId(String reservationNo, Long userId);
+
 	Optional<Bid> findByIdAndUserId(Long id, Long userId);
 
 	@Query("SELECT b FROM Bid b " +

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
@@ -36,6 +36,8 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
 	Optional<Bid> findByReservationNo(String reservationNo);
 
+	Optional<Bid> findByIdAndUserId(Long id, Long userId);
+
 	@Query("SELECT b FROM Bid b " +
 		"WHERE b.userId = :userId AND b.status = :status AND b.deleted = false " +
 		"ORDER BY b.createdAt DESC")

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -83,25 +83,14 @@ public class BidService {
         }
 
         Integer startPrice = bid.getStartPrice() != null ? bid.getStartPrice() : 0;
-        Integer bidPrice = bid.getBidPrice();
+        Integer bidPrice = bid.getBidPrice() != null ? bid.getBidPrice() : 0;
 
         Integer discountAmount = Math.max(0, startPrice - bidPrice);
         if (bid.getStartPrice() == null) {
             log.warn(">>>> [데이터 정합성 경고] reservationNo={} 의 startPrice가 null입니다.", reservationNo);
         }
 
-        return ReservationDetailResponse.builder()
-            .reservationNo(bid.getReservationNo())
-            .popupTitle(bid.getPopupTitle())
-            .popupAddress(bid.getPopupAddress())
-            .popupThumbnail(bid.getThumbnailUrl())
-            .entryDate(bid.getEntryDate())
-            .entryTime(bid.getEntryTime())
-            .startPrice(startPrice)
-            .discountAmount(discountAmount)
-            .finalPrice(bidPrice)
-            .paidAt(bid.getPaidAt())
-            .build();
+        return buildReservationDetailResponse(bid, startPrice, discountAmount, bidPrice);
     }
 
     public ReservationDetailResponse getBidDetail(Long userId, Long bidId) {
@@ -115,8 +104,21 @@ public class BidService {
 
         Integer startPrice = bid.getStartPrice() != null ? bid.getStartPrice() : 0;
         Integer bidPrice = bid.getBidPrice() != null ? bid.getBidPrice() : 0;
+        if (bid.getBidPrice() == null) {
+            log.warn(">>>> [?곗씠???뺥빀??寃쎄퀬] bidId={}, startPrice={} ??bidPrice媛 null?낅땲??",
+                bid.getId(), bid.getStartPrice());
+        }
         Integer discountAmount = Math.max(0, startPrice - bidPrice);
 
+        return buildReservationDetailResponse(bid, startPrice, discountAmount, bidPrice);
+    }
+
+    private ReservationDetailResponse buildReservationDetailResponse(
+        Bid bid,
+        Integer startPrice,
+        Integer discountAmount,
+        Integer bidPrice
+    ) {
         return ReservationDetailResponse.builder()
             .reservationNo(bid.getReservationNo())
             .popupTitle(bid.getPopupTitle())

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -108,8 +108,13 @@ public class BidService {
         Bid bid = bidRepository.findByIdAndUserId(bidId, userId)
             .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
+        if (bid.getStartPrice() == null) {
+            log.warn(">>>> [데이터 정합성 경고] bidId={}, userId={}, reservationNo={} 의 startPrice가 null입니다.",
+                bidId, userId, bid.getReservationNo());
+        }
+
         Integer startPrice = bid.getStartPrice() != null ? bid.getStartPrice() : 0;
-        Integer bidPrice = bid.getBidPrice();
+        Integer bidPrice = bid.getBidPrice() != null ? bid.getBidPrice() : 0;
         Integer discountAmount = Math.max(0, startPrice - bidPrice);
 
         return ReservationDetailResponse.builder()

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -92,7 +92,7 @@ public class BidService {
     }
 
     public ReservationDetailResponse getBidDetail(Long userId, Long bidId) {
-        Bid bid = bidRepository.findByIdAndUserId(bidId, userId)
+        Bid bid = bidRepository.findByIdAndUserIdAndStatus(bidId, userId, BidStatus.SUCCESS)
             .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
         PriceDetails priceDetails = computePriceDetails(bid, bid.getReservationNo());
@@ -238,9 +238,15 @@ public class BidService {
                     popupServiceClient.getPopupDetail(option.getAuction().getPopupId());
                 if (popupResponse != null && popupResponse.getData() != null) {
                     PopupInternalResponse popupInfo = popupResponse.getData();
-                    popupTitle = popupInfo.title();
-                    popupAddress = popupInfo.location();
-                    thumbnailUrl = popupInfo.vThumbnailUrl();
+                    if (popupInfo.title() != null) {
+                        popupTitle = popupInfo.title();
+                    }
+                    if (popupInfo.location() != null) {
+                        popupAddress = popupInfo.location();
+                    }
+                    if (popupInfo.vThumbnailUrl() != null) {
+                        thumbnailUrl = popupInfo.vThumbnailUrl();
+                    }
                 } else {
                     log.warn("Popup detail response is empty. popupId={}", option.getAuction().getPopupId());
                 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -42,6 +42,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BidService {
 
+    private static final String PAYMENT_PRODUCT_NAME = "팝업 입장권 결제";
+    private static final String DEFAULT_POPUP_TITLE = "팝업 정보 확인 중";
+    private static final String DEFAULT_POPUP_ADDRESS = "주소 확인 중";
+
     private final BidRedisRepository bidRedisRepository;
     private final BidRepository bidRepository;
     private final AuctionOptionRepository auctionOptionRepository;
@@ -75,46 +79,47 @@ public class BidService {
     }
 
     public ReservationDetailResponse getReservationDetail(Long userId, String reservationNo) {
-        Bid bid = bidRepository.findByReservationNo(reservationNo)
+        Bid bid = bidRepository.findByReservationNoAndUserId(reservationNo, userId)
             .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
-        if (!bid.getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
-
-        Integer startPrice = bid.getStartPrice() != null ? bid.getStartPrice() : 0;
-        Integer bidPrice = bid.getBidPrice() != null ? bid.getBidPrice() : 0;
-        if (bid.getBidPrice() == null) {
-            log.warn("Bid price is null for reservationNo={}, bidId={}, startPrice={}",
-                reservationNo, bid.getId(), bid.getStartPrice());
-        }
-
-        Integer discountAmount = Math.max(0, startPrice - bidPrice);
-        if (bid.getStartPrice() == null) {
-            log.warn("Start price is null for reservationNo={}", reservationNo);
-        }
-
-        return buildReservationDetailResponse(bid, startPrice, discountAmount, bidPrice);
+        PriceDetails priceDetails = computePriceDetails(bid, reservationNo);
+        return buildReservationDetailResponse(
+            bid,
+            priceDetails.startPrice(),
+            priceDetails.discountAmount(),
+            priceDetails.bidPrice()
+        );
     }
 
     public ReservationDetailResponse getBidDetail(Long userId, Long bidId) {
         Bid bid = bidRepository.findByIdAndUserId(bidId, userId)
             .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
-        if (bid.getStartPrice() == null) {
-            log.warn("Start price is null for bidId={}, userId={}, reservationNo={}",
-                bidId, userId, bid.getReservationNo());
+        PriceDetails priceDetails = computePriceDetails(bid, bid.getReservationNo());
+        return buildReservationDetailResponse(
+            bid,
+            priceDetails.startPrice(),
+            priceDetails.discountAmount(),
+            priceDetails.bidPrice()
+        );
+    }
+
+    private PriceDetails computePriceDetails(Bid bid, String reservationNo) {
+        Integer startPrice = bid.getStartPrice();
+        Integer bidPrice = bid.getBidPrice();
+
+        if (startPrice == null) {
+            log.warn("Start price is null for reservationNo={}, bidId={}", reservationNo, bid.getId());
+            startPrice = 0;
+        }
+        if (bidPrice == null) {
+            log.warn("Bid price is null for reservationNo={}, bidId={}, startPrice={}",
+                reservationNo, bid.getId(), bid.getStartPrice());
+            bidPrice = 0;
         }
 
-        Integer startPrice = bid.getStartPrice() != null ? bid.getStartPrice() : 0;
-        Integer bidPrice = bid.getBidPrice() != null ? bid.getBidPrice() : 0;
-        if (bid.getBidPrice() == null) {
-            log.warn("Bid price is null for bidId={}, startPrice={}",
-                bid.getId(), bid.getStartPrice());
-        }
         Integer discountAmount = Math.max(0, startPrice - bidPrice);
-
-        return buildReservationDetailResponse(bid, startPrice, discountAmount, bidPrice);
+        return new PriceDetails(startPrice, bidPrice, discountAmount);
     }
 
     private ReservationDetailResponse buildReservationDetailResponse(
@@ -135,6 +140,13 @@ public class BidService {
             .finalPrice(bidPrice)
             .paidAt(bid.getPaidAt())
             .build();
+    }
+
+    private record PriceDetails(
+        Integer startPrice,
+        Integer bidPrice,
+        Integer discountAmount
+    ) {
     }
 
     private BidHistoryResponse convertToHistoryResponse(Bid bid) {
@@ -201,28 +213,29 @@ public class BidService {
                 billingKey,
                 bid.getMerchantUid(),
                 bid.getBidPrice(),
-                "입장권 응찰"
+                PAYMENT_PRODUCT_NAME
             );
 
             if (!paymentResponse.isPaid()) {
                 log.error("Payment execution failed because paidAt is missing. merchantUid={}", bid.getMerchantUid());
-                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제가 완료되지 않았습니다.");
+                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment was not completed.");
             }
 
             String pgTxId = paymentResponse.getPgTxId();
             if (pgTxId == null || pgTxId.isBlank()) {
                 log.error("Payment response is missing pgTxId. merchantUid={}", bid.getMerchantUid());
-                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제 트랜잭션 ID가 누락되었습니다.");
+                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment transaction id is missing.");
             }
 
             LocalDateTime paidAt = parsePaidAt(paymentResponse.payment().paidAt());
 
-            String popupTitle = "정보 확인 중";
-            String popupAddress = "주소 확인 중";
+            String popupTitle = DEFAULT_POPUP_TITLE;
+            String popupAddress = DEFAULT_POPUP_ADDRESS;
             String thumbnailUrl = null;
 
             try {
-                ApiResponse<PopupInternalResponse> popupResponse = popupServiceClient.getPopupDetail(option.getAuction().getPopupId());
+                ApiResponse<PopupInternalResponse> popupResponse =
+                    popupServiceClient.getPopupDetail(option.getAuction().getPopupId());
                 if (popupResponse != null && popupResponse.getData() != null) {
                     PopupInternalResponse popupInfo = popupResponse.getData();
                     popupTitle = popupInfo.title();
@@ -259,7 +272,8 @@ public class BidService {
                     break;
                 } catch (DataIntegrityViolationException e) {
                     retryCount++;
-                    log.warn("Reservation number collision detected. retryCount={}, merchantUid={}", retryCount, bid.getMerchantUid());
+                    log.warn("Reservation number collision detected. retryCount={}, merchantUid={}",
+                        retryCount, bid.getMerchantUid());
                     if (retryCount >= maxRetries) {
                         throw e;
                     }
@@ -273,7 +287,7 @@ public class BidService {
             }
 
             issueAuctionWinTicket(bid, option, reservationNo);
-            return new BidResponse(bid.getId(), BidStatus.SUCCESS, "응찰이 완료되었습니다.", reservationNo);
+            return new BidResponse(bid.getId(), BidStatus.SUCCESS, "Bid completed successfully.", reservationNo);
 
         } catch (Exception e) {
             log.error("Bid processing failed. userId={}, optionId={}, error={}", userId, option.getId(), e.getMessage());
@@ -302,7 +316,8 @@ public class BidService {
                 } else if (cancelResponse.isRequested()) {
                     log.warn("Compensation pending. Payment cancel request accepted. merchantUid={}", merchantUid);
                 } else {
-                    log.error("Compensation failed. Payment cancel failed. merchantUid={}, reason={}", merchantUid, cancelResponse.reason());
+                    log.error("Compensation failed. Payment cancel failed. merchantUid={}, reason={}",
+                        merchantUid, cancelResponse.reason());
                 }
             } catch (Exception cancelEx) {
                 log.error("Critical error while calling payment cancel API. merchantUid={}", merchantUid, cancelEx);
@@ -313,7 +328,10 @@ public class BidService {
             }
 
             if (!cancelConfirmed) {
-                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제 취소가 확정되지 않아 복구를 보류합니다.");
+                throw new CustomException(
+                    ErrorCode.PAYMENT_EXECUTION_FAILED,
+                    "Payment cancellation is not confirmed, so recovery is deferred."
+                );
             }
 
             if (e instanceof CustomException customException) {
@@ -337,13 +355,13 @@ public class BidService {
 
     private LocalDateTime parsePaidAt(String paidAtStr) {
         if (paidAtStr == null || paidAtStr.isBlank()) {
-            throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제 완료 시각이 누락되었습니다.");
+            throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment completion timestamp is missing.");
         }
         try {
             return OffsetDateTime.parse(paidAtStr).toLocalDateTime();
         } catch (Exception e) {
             log.warn("Failed to parse paidAt value: {}", paidAtStr, e);
-            throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제 완료 시각 파싱에 실패했습니다.");
+            throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Failed to parse payment completion timestamp.");
         }
     }
 
@@ -358,7 +376,6 @@ public class BidService {
         } catch (Exception e) {
             log.error("Ticket service integration failed. bidId={}, optionId={}, error={}",
                 bid.getId(), option.getId(), e.getMessage());
-            // TODO: Introduce async compensation/retry flow if ticket issuance must be recovered separately.
             if (e instanceof CustomException customException) {
                 throw customException;
             }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -84,10 +84,14 @@ public class BidService {
 
         Integer startPrice = bid.getStartPrice() != null ? bid.getStartPrice() : 0;
         Integer bidPrice = bid.getBidPrice() != null ? bid.getBidPrice() : 0;
+        if (bid.getBidPrice() == null) {
+            log.warn("Bid price is null for reservationNo={}, bidId={}, startPrice={}",
+                reservationNo, bid.getId(), bid.getStartPrice());
+        }
 
         Integer discountAmount = Math.max(0, startPrice - bidPrice);
         if (bid.getStartPrice() == null) {
-            log.warn(">>>> [데이터 정합성 경고] reservationNo={} 의 startPrice가 null입니다.", reservationNo);
+            log.warn("Start price is null for reservationNo={}", reservationNo);
         }
 
         return buildReservationDetailResponse(bid, startPrice, discountAmount, bidPrice);
@@ -98,14 +102,14 @@ public class BidService {
             .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
         if (bid.getStartPrice() == null) {
-            log.warn(">>>> [데이터 정합성 경고] bidId={}, userId={}, reservationNo={} 의 startPrice가 null입니다.",
+            log.warn("Start price is null for bidId={}, userId={}, reservationNo={}",
                 bidId, userId, bid.getReservationNo());
         }
 
         Integer startPrice = bid.getStartPrice() != null ? bid.getStartPrice() : 0;
         Integer bidPrice = bid.getBidPrice() != null ? bid.getBidPrice() : 0;
         if (bid.getBidPrice() == null) {
-            log.warn(">>>> [?곗씠???뺥빀??寃쎄퀬] bidId={}, startPrice={} ??bidPrice媛 null?낅땲??",
+            log.warn("Bid price is null for bidId={}, startPrice={}",
                 bid.getId(), bid.getStartPrice());
         }
         Integer discountAmount = Math.max(0, startPrice - bidPrice);
@@ -197,17 +201,17 @@ public class BidService {
                 billingKey,
                 bid.getMerchantUid(),
                 bid.getBidPrice(),
-                "입장권 낙찰"
+                "입장권 응찰"
             );
 
             if (!paymentResponse.isPaid()) {
-                log.error(">>>> [결제 실패] 결제 완료 시각이 없습니다. merchantUid={}", bid.getMerchantUid());
+                log.error("Payment execution failed because paidAt is missing. merchantUid={}", bid.getMerchantUid());
                 throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제가 완료되지 않았습니다.");
             }
 
             String pgTxId = paymentResponse.getPgTxId();
             if (pgTxId == null || pgTxId.isBlank()) {
-                log.error(">>>> [결제 응답 오류] pgTxId 누락 merchantUid={}", bid.getMerchantUid());
+                log.error("Payment response is missing pgTxId. merchantUid={}", bid.getMerchantUid());
                 throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제 트랜잭션 ID가 누락되었습니다.");
             }
 
@@ -225,10 +229,10 @@ public class BidService {
                     popupAddress = popupInfo.location();
                     thumbnailUrl = popupInfo.vThumbnailUrl();
                 } else {
-                    log.warn(">>>> [팝업 정보 조회 실패] 응답이 비어있음 popupId={}", option.getAuction().getPopupId());
+                    log.warn("Popup detail response is empty. popupId={}", option.getAuction().getPopupId());
                 }
             } catch (Exception e) {
-                log.error(">>>> [팝업 정보 조회 오류] 외부 서비스 호출 중 예외 발생 popupId={}, error={}",
+                log.error("Popup detail lookup failed. popupId={}, error={}",
                     option.getAuction().getPopupId(), e.getMessage());
             }
 
@@ -255,7 +259,7 @@ public class BidService {
                     break;
                 } catch (DataIntegrityViolationException e) {
                     retryCount++;
-                    log.warn(">>>> [예약번호 충돌] 재시도 중.. retryCount={}, merchantUid={}", retryCount, bid.getMerchantUid());
+                    log.warn("Reservation number collision detected. retryCount={}, merchantUid={}", retryCount, bid.getMerchantUid());
                     if (retryCount >= maxRetries) {
                         throw e;
                     }
@@ -269,10 +273,10 @@ public class BidService {
             }
 
             issueAuctionWinTicket(bid, option, reservationNo);
-            return new BidResponse(bid.getId(), BidStatus.SUCCESS, "낙찰이 완료되었습니다.", reservationNo);
+            return new BidResponse(bid.getId(), BidStatus.SUCCESS, "응찰이 완료되었습니다.", reservationNo);
 
         } catch (Exception e) {
-            log.error(">>>> 낙찰 처리 중 오류 userId={}, optionId={}, error={}", userId, option.getId(), e.getMessage());
+            log.error("Bid processing failed. userId={}, optionId={}, error={}", userId, option.getId(), e.getMessage());
 
             if (!paymentAttempted) {
                 bidRedisRepository.incrementAvailableStock(option.getId(), 1L);
@@ -294,14 +298,14 @@ public class BidService {
                 if (cancelResponse.isSucceeded()) {
                     bidRedisRepository.addPendingRestock(option.getId(), 1L);
                     cancelConfirmed = true;
-                    log.info(">>>> [보상 완료] 결제 취소 완료 merchantUid={}", merchantUid);
+                    log.info("Compensation completed. Payment cancel succeeded. merchantUid={}", merchantUid);
                 } else if (cancelResponse.isRequested()) {
-                    log.warn(">>>> [보상 보류] 결제 취소 요청만 접수 merchantUid={}", merchantUid);
+                    log.warn("Compensation pending. Payment cancel request accepted. merchantUid={}", merchantUid);
                 } else {
-                    log.error("!!!! [보상 실패] 결제 취소 실패 merchantUid={}, reason={}", merchantUid, cancelResponse.reason());
+                    log.error("Compensation failed. Payment cancel failed. merchantUid={}, reason={}", merchantUid, cancelResponse.reason());
                 }
             } catch (Exception cancelEx) {
-                log.error("!!!! [긴급] 결제 취소 API 호출 실패 merchantUid={}", merchantUid, cancelEx);
+                log.error("Critical error while calling payment cancel API. merchantUid={}", merchantUid, cancelEx);
             }
 
             if (cancelConfirmed && bid != null) {
@@ -309,7 +313,7 @@ public class BidService {
             }
 
             if (!cancelConfirmed) {
-                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제 취소가 확정되지 않아 재고 복구를 보류합니다.");
+                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제 취소가 확정되지 않아 복구를 보류합니다.");
             }
 
             if (e instanceof CustomException customException) {
@@ -338,7 +342,7 @@ public class BidService {
         try {
             return OffsetDateTime.parse(paidAtStr).toLocalDateTime();
         } catch (Exception e) {
-            log.warn(">>>> [paidAt 파싱 실패] {}", paidAtStr, e);
+            log.warn("Failed to parse paidAt value: {}", paidAtStr, e);
             throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "결제 완료 시각 파싱에 실패했습니다.");
         }
     }
@@ -352,7 +356,7 @@ public class BidService {
                 throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
             }
         } catch (Exception e) {
-            log.error(">>>> [Ticket-Service 연동 실패] bidId={}, optionId={}, error={}",
+            log.error("Ticket service integration failed. bidId={}, optionId={}, error={}",
                 bid.getId(), option.getId(), e.getMessage());
             // TODO: Introduce async compensation/retry flow if ticket issuance must be recovered separately.
             if (e instanceof CustomException customException) {

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -104,6 +104,28 @@ public class BidService {
             .build();
     }
 
+    public ReservationDetailResponse getBidDetail(Long userId, Long bidId) {
+        Bid bid = bidRepository.findByIdAndUserId(bidId, userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
+
+        Integer startPrice = bid.getStartPrice() != null ? bid.getStartPrice() : 0;
+        Integer bidPrice = bid.getBidPrice();
+        Integer discountAmount = Math.max(0, startPrice - bidPrice);
+
+        return ReservationDetailResponse.builder()
+            .reservationNo(bid.getReservationNo())
+            .popupTitle(bid.getPopupTitle())
+            .popupAddress(bid.getPopupAddress())
+            .popupThumbnail(bid.getThumbnailUrl())
+            .entryDate(bid.getEntryDate())
+            .entryTime(bid.getEntryTime())
+            .startPrice(startPrice)
+            .discountAmount(discountAmount)
+            .finalPrice(bidPrice)
+            .paidAt(bid.getPaidAt())
+            .build();
+    }
+
     private BidHistoryResponse convertToHistoryResponse(Bid bid) {
         return BidHistoryResponse.builder()
             .id(bid.getId())

--- a/common/src/main/java/com/t1/popcon/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/t1/popcon/common/exception/ErrorCode.java
@@ -16,9 +16,9 @@ public enum ErrorCode {
     INVALID_INPUT("C001", HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
 
     // Auth
-    REGISTER_TOKEN_EXPIRED("A001", HttpStatus.UNAUTHORIZED, "회원가입 인증이 만료되었습니다. 다시 가입 절차를 진행해 주세요."),
+    REGISTER_TOKEN_EXPIRED("A001", HttpStatus.UNAUTHORIZED, "회원가입 세션이 만료되었습니다. 다시 가입 절차를 진행해주세요."),
     INVALID_TOKEN("A002", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    TOKEN_EXPIRED("A003", HttpStatus.UNAUTHORIZED, "인증이 만료되었습니다. 다시 로그인해 주세요."),
+    TOKEN_EXPIRED("A003", HttpStatus.UNAUTHORIZED, "인증이 만료되었습니다. 다시 로그인해주세요."),
     ACCESS_DENIED("A004", HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     // OAuth
@@ -37,7 +37,7 @@ public enum ErrorCode {
 
     // User
     USER_NOT_FOUND("U001", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-    SOCIAL_INFO_MISSING("U002", HttpStatus.BAD_REQUEST, "가입 세션의 소셜 정보가 유실되었습니다."),
+    SOCIAL_INFO_MISSING("U002", HttpStatus.BAD_REQUEST, "가입 세션의 소셜 정보가 누락되었습니다."),
 
     // Payment
     PAYMENT_FETCH_FAILED("P001", HttpStatus.BAD_GATEWAY, "결제 수단 정보 조회에 실패했습니다."),
@@ -58,7 +58,7 @@ public enum ErrorCode {
     AUCTION_NOT_FOUND("AU001", HttpStatus.NOT_FOUND, "존재하지 않는 경매입니다."),
     AUCTION_NOT_OPEN("AU002", HttpStatus.BAD_REQUEST, "현재 진행 중인 경매가 아닙니다."),
     AUCTION_ALREADY_CLOSED("AU003", HttpStatus.BAD_REQUEST, "이미 종료된 경매입니다."),
-    AUCTION_ALREADY_SOLD_OUT("AU004", HttpStatus.CONFLICT, "이미 완판이 완료된 경매입니다."),
+    AUCTION_ALREADY_SOLD_OUT("AU004", HttpStatus.CONFLICT, "이미 낙찰이 완료된 경매입니다."),
     AUCTION_STREAM_SUBSCRIBE_FAILED("AU005", HttpStatus.INTERNAL_SERVER_ERROR, "경매 실시간 구독 연결에 실패했습니다."),
     AUCTION_OPTION_NOT_FOUND("AU006", HttpStatus.NOT_FOUND, "존재하지 않는 경매 옵션입니다."),
     AUCTION_OPTION_SOLD_OUT("AU007", HttpStatus.CONFLICT, "해당 회차는 매진되었습니다."),

--- a/draw-service/src/main/java/com/t1/popcon/draw/controller/InternalDrawEntryController.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/controller/InternalDrawEntryController.java
@@ -1,6 +1,7 @@
 package com.t1.popcon.draw.controller;
 
 import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.draw.dto.response.DrawEntryDetailResponse;
 import com.t1.popcon.draw.dto.response.DrawEntryResponse;
 import com.t1.popcon.draw.dto.response.DrawExecuteResponse;
 import com.t1.popcon.draw.service.DrawEntryService;
@@ -29,12 +30,21 @@ public class InternalDrawEntryController {
         Pageable pageable
     ) {
         Slice<DrawEntryResponse> responses = drawEntryService.getEntriesByUserId(userId, pageable);
-        return ApiResponse.ok("응모 내역 조회를 성공했습니다.", responses);
+        return ApiResponse.ok("응모 내역 조회 성공", responses);
+    }
+
+    @GetMapping("/entries/{entryId}")
+    public ApiResponse<DrawEntryDetailResponse> getEntryDetail(
+        @PathVariable("entryId") Long entryId,
+        @RequestParam("userId") Long userId
+    ) {
+        DrawEntryDetailResponse response = drawEntryService.getEntryDetail(userId, entryId);
+        return ApiResponse.ok("응모 상세 조회 성공", response);
     }
 
     @PostMapping("/options/{optionId}/execute")
     public ApiResponse<DrawExecuteResponse> executeDraw(@PathVariable("optionId") Long optionId) {
         DrawExecuteResponse response = drawResultService.executeDraw(optionId);
-        return ApiResponse.ok("드로우 추첨 실행에 성공했습니다.", response);
+        return ApiResponse.ok("추첨 실행 성공", response);
     }
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawEntryDetailResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawEntryDetailResponse.java
@@ -1,0 +1,23 @@
+package com.t1.popcon.draw.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.Builder;
+
+@Builder
+public record DrawEntryDetailResponse(
+    Long drawEntryId,
+    Long drawId,
+    String popupTitle,
+    String popupAddress,
+    String popupThumbnail,
+    LocalDate entryDate,
+    LocalTime entryTime,
+    String userName,
+    String userPhoneNumber,
+    LocalDateTime paidAt,
+    String status,
+    LocalDateTime ticketIssuedAt
+) {
+}

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -104,14 +104,7 @@ public class DrawEntryService {
         DrawEntry entry = drawEntryRepository.findByIdAndUserId(drawEntryId, userId)
             .orElseThrow(() -> new CustomException(ErrorCode.DRAW_ENTRY_NOT_FOUND));
 
-        PopupInternalResponse popupInfo = null;
-        try {
-            ApiResponse<PopupInternalResponse> popupResponse =
-                popupServiceClient.getPopupDetail(entry.getDrawOption().getDraw().getPopupId());
-            popupInfo = popupResponse != null ? popupResponse.getData() : null;
-        } catch (Exception e) {
-            log.warn("Draw entry detail popup fetch failed - drawEntryId={}", drawEntryId, e);
-        }
+        PopupInternalResponse popupInfo = fetchPopupInfo(entry.getDrawOption().getDraw().getPopupId(), drawEntryId);
 
         return DrawEntryDetailResponse.builder()
             .drawEntryId(entry.getId())
@@ -130,15 +123,7 @@ public class DrawEntryService {
     }
 
     private DrawEntryResultResponse buildApplyResult(DrawOption drawOption, UserInternalResponse userInfo) {
-        PopupInternalResponse popupInfo = null;
-
-        try {
-            ApiResponse<PopupInternalResponse> popupResponse =
-                popupServiceClient.getPopupDetail(drawOption.getDraw().getPopupId());
-            popupInfo = popupResponse != null ? popupResponse.getData() : null;
-        } catch (Exception e) {
-            log.warn("Draw apply result popup fetch failed - popupId={}", drawOption.getDraw().getPopupId(), e);
-        }
+        PopupInternalResponse popupInfo = fetchPopupInfo(drawOption.getDraw().getPopupId(), null);
 
         return DrawEntryResultResponse.builder()
             .vThumbnailUrl(popupInfo != null ? popupInfo.vThumbnailUrl() : null)
@@ -193,6 +178,20 @@ public class DrawEntryService {
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR, e);
         } catch (RuntimeException e) {
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR, e);
+        }
+    }
+
+    private PopupInternalResponse fetchPopupInfo(Long popupId, Long drawEntryId) {
+        try {
+            ApiResponse<PopupInternalResponse> popupResponse = popupServiceClient.getPopupDetail(popupId);
+            return popupResponse != null ? popupResponse.getData() : null;
+        } catch (Exception e) {
+            if (drawEntryId != null) {
+                log.warn("Draw entry detail popup fetch failed - drawEntryId={}, popupId={}", drawEntryId, popupId, e);
+            } else {
+                log.warn("Draw apply result popup fetch failed - popupId={}", popupId, e);
+            }
+            return null;
         }
     }
 

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -40,7 +40,7 @@ public class DrawEntryService {
 
     private static final String UNKNOWN_POPUP_TITLE = "알 수 없는 팝업";
     private static final long DEFAULT_PRICE = 0L;
-    private static final String DISPLAY_IN_PROGRESS = "진행중";
+    private static final String DISPLAY_IN_PROGRESS = "진행 중";
     private static final String DISPLAY_DRAW_PENDING = "추첨 대기";
     private static final String DISPLAY_ANNOUNCEMENT_PENDING = "결과 발표 대기";
     private static final String DISPLAY_TICKET_ISSUED = "티켓 발급 완료";

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -13,6 +13,7 @@ import com.t1.popcon.draw.domain.DrawEntry;
 import com.t1.popcon.draw.domain.DrawEntryStatus;
 import com.t1.popcon.draw.domain.DrawOption;
 import com.t1.popcon.draw.dto.request.DrawEntryRequest;
+import com.t1.popcon.draw.dto.response.DrawEntryDetailResponse;
 import com.t1.popcon.draw.dto.response.DrawEntryResponse;
 import com.t1.popcon.draw.dto.response.DrawEntryResultResponse;
 import com.t1.popcon.draw.repository.DrawEntryRepository;
@@ -96,6 +97,36 @@ public class DrawEntryService {
             entry,
             popupMap.get(entry.getDrawOption().getDraw().getPopupId())
         ));
+    }
+
+    @Transactional(readOnly = true)
+    public DrawEntryDetailResponse getEntryDetail(Long userId, Long drawEntryId) {
+        DrawEntry entry = drawEntryRepository.findByIdAndUserId(drawEntryId, userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.DRAW_ENTRY_NOT_FOUND));
+
+        PopupInternalResponse popupInfo = null;
+        try {
+            ApiResponse<PopupInternalResponse> popupResponse =
+                popupServiceClient.getPopupDetail(entry.getDrawOption().getDraw().getPopupId());
+            popupInfo = popupResponse != null ? popupResponse.getData() : null;
+        } catch (Exception e) {
+            log.warn("Draw entry detail popup fetch failed - drawEntryId={}", drawEntryId, e);
+        }
+
+        return DrawEntryDetailResponse.builder()
+            .drawEntryId(entry.getId())
+            .drawId(entry.getDrawOption().getDraw().getId())
+            .popupTitle(popupInfo != null ? popupInfo.title() : UNKNOWN_POPUP_TITLE)
+            .popupAddress(popupInfo != null ? popupInfo.location() : null)
+            .popupThumbnail(popupInfo != null ? popupInfo.vThumbnailUrl() : null)
+            .entryDate(entry.getDrawOption().getEntryDate())
+            .entryTime(entry.getDrawOption().getEntryTime())
+            .userName(encryptionService.decrypt(entry.getEncryptedName()))
+            .userPhoneNumber(encryptionService.decrypt(entry.getEncryptedPhoneNumber()))
+            .paidAt(entry.getPaidAt())
+            .status(entry.getStatus().name())
+            .ticketIssuedAt(entry.getTicketIssuedAt())
+            .build();
     }
 
     private DrawEntryResultResponse buildApplyResult(DrawOption drawOption, UserInternalResponse userInfo) {

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class DrawEntryService {
 
+    private static final String SUCCESS_CODE = "SUCCESS";
     private static final String UNKNOWN_POPUP_TITLE = "알 수 없는 팝업";
     private static final long DEFAULT_PRICE = 0L;
     private static final String DISPLAY_IN_PROGRESS = "진행 중";
@@ -184,20 +186,34 @@ public class DrawEntryService {
     private PopupInternalResponse fetchPopupInfo(Long popupId, Long drawEntryId) {
         try {
             ApiResponse<PopupInternalResponse> popupResponse = popupServiceClient.getPopupDetail(popupId);
-            return popupResponse != null ? popupResponse.getData() : null;
+            if (popupResponse == null) {
+                return null;
+            }
+            if (!SUCCESS_CODE.equalsIgnoreCase(popupResponse.getCode())) {
+                log.error("Popup service returned non-success response. popupId={}, drawEntryId={}, code={}",
+                    popupId, drawEntryId, popupResponse.getCode());
+                throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
+            }
+            if (popupResponse.getData() == null) {
+                return null;
+            }
+            return popupResponse.getData();
+        } catch (CustomException e) {
+            throw e;
         } catch (Exception e) {
             if (drawEntryId != null) {
-                log.warn("Draw entry detail popup fetch failed - drawEntryId={}, popupId={}", drawEntryId, popupId, e);
+                log.error("Draw entry popup fetch failed - drawEntryId={}, popupId={}", drawEntryId, popupId, e);
             } else {
-                log.warn("Draw apply result popup fetch failed - popupId={}", popupId, e);
+                log.error("Draw apply popup fetch failed - popupId={}", popupId, e);
             }
-            return null;
+            throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR, e);
         }
     }
 
     private List<Long> extractPopupIds(Slice<DrawEntry> entries) {
         return entries.getContent().stream()
             .map(entry -> entry.getDrawOption().getDraw().getPopupId())
+            .filter(Objects::nonNull)
             .distinct()
             .toList();
     }

--- a/ticket-service/src/main/java/com/t1/popcon/ticket/controller/InternalTicketController.java
+++ b/ticket-service/src/main/java/com/t1/popcon/ticket/controller/InternalTicketController.java
@@ -27,7 +27,7 @@ public class InternalTicketController {
     @PostMapping
     public ApiResponse<TicketIssueResponse> issue(@Valid @RequestBody TicketIssueRequest request) {
         TicketIssueResponse response = ticketIssueService.issue(request);
-        return ApiResponse.ok("티켓 발급에 성공했습니다.", response);
+        return ApiResponse.ok("티켓 발급 성공", response);
     }
 
     @GetMapping
@@ -40,7 +40,7 @@ public class InternalTicketController {
             userId,
             PageRequest.of(page, size)
         );
-        return ApiResponse.ok("티켓 목록 조회에 성공했습니다.", response);
+        return ApiResponse.ok("티켓 목록 조회 성공", response);
     }
 
     @GetMapping("/reservations/{reservationNo}")
@@ -49,6 +49,15 @@ public class InternalTicketController {
         @RequestParam("userId") Long userId
     ) {
         TicketDetailResponse response = ticketIssueService.getTicketByReservationNo(reservationNo, userId);
-        return ApiResponse.ok("티켓 상세 조회에 성공했습니다.", response);
+        return ApiResponse.ok("티켓 상세 조회 성공", response);
+    }
+
+    @GetMapping("/{ticketId}")
+    public ApiResponse<TicketDetailResponse> getTicketById(
+        @PathVariable("ticketId") Long ticketId,
+        @RequestParam("userId") Long userId
+    ) {
+        TicketDetailResponse response = ticketIssueService.getTicketById(ticketId, userId);
+        return ApiResponse.ok("티켓 상세 조회 성공", response);
     }
 }

--- a/ticket-service/src/main/java/com/t1/popcon/ticket/repository/TicketRepository.java
+++ b/ticket-service/src/main/java/com/t1/popcon/ticket/repository/TicketRepository.java
@@ -17,6 +17,8 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     Optional<Ticket> findByReservationNoAndUserId(String reservationNo, Long userId);
 
+    Optional<Ticket> findByIdAndUserId(Long id, Long userId);
+
     Slice<Ticket> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     @Query("""

--- a/ticket-service/src/main/java/com/t1/popcon/ticket/service/TicketIssueService.java
+++ b/ticket-service/src/main/java/com/t1/popcon/ticket/service/TicketIssueService.java
@@ -68,9 +68,7 @@ public class TicketIssueService {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
 
-        if (userId == null || userId <= 0) {
-            throw new CustomException(ErrorCode.INVALID_INPUT);
-        }
+        validatePositiveId(userId);
 
         Ticket ticket = ticketRepository.findByReservationNoAndUserId(reservationNo, userId)
             .orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
@@ -79,16 +77,18 @@ public class TicketIssueService {
 
     @Transactional(readOnly = true)
     public TicketDetailResponse getTicketById(Long ticketId, Long userId) {
-        if (ticketId == null || ticketId <= 0) {
-            throw new CustomException(ErrorCode.INVALID_INPUT);
-        }
+        validatePositiveId(ticketId);
 
-        if (userId == null || userId <= 0) {
-            throw new CustomException(ErrorCode.INVALID_INPUT);
-        }
+        validatePositiveId(userId);
 
         Ticket ticket = ticketRepository.findByIdAndUserId(ticketId, userId)
             .orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
         return TicketDetailResponse.from(ticket);
+    }
+
+    private void validatePositiveId(Long id) {
+        if (id == null || id <= 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
     }
 }

--- a/ticket-service/src/main/java/com/t1/popcon/ticket/service/TicketIssueService.java
+++ b/ticket-service/src/main/java/com/t1/popcon/ticket/service/TicketIssueService.java
@@ -76,4 +76,19 @@ public class TicketIssueService {
             .orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
         return TicketDetailResponse.from(ticket);
     }
+
+    @Transactional(readOnly = true)
+    public TicketDetailResponse getTicketById(Long ticketId, Long userId) {
+        if (ticketId == null || ticketId <= 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        if (userId == null || userId <= 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        Ticket ticket = ticketRepository.findByIdAndUserId(ticketId, userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
+        return TicketDetailResponse.from(ticket);
+    }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/billing/service/BillingKeyService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/billing/service/BillingKeyService.java
@@ -118,4 +118,14 @@ public class BillingKeyService {
 			.map(UserBillingKey::getCustomerUid)
 			.orElseThrow(() -> new CustomException(ErrorCode.BILLING_KEY_NOT_FOUND));
 	}
+
+	@Transactional(readOnly = true)
+	public BillingKeyInfoResponse getDefaultBillingKeyInfo(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		return billingKeyRepository.findByUserAndIsDefaultTrueAndIsActiveTrue(user)
+			.map(BillingKeyInfoResponse::from)
+			.orElse(null);
+	}
 }

--- a/user-service/src/main/java/com/t1/popcon/user/billing/service/BillingKeyService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/billing/service/BillingKeyService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -120,12 +121,11 @@ public class BillingKeyService {
 	}
 
 	@Transactional(readOnly = true)
-	public BillingKeyInfoResponse getDefaultBillingKeyInfo(Long userId) {
+	public Optional<BillingKeyInfoResponse> getDefaultBillingKeyInfo(Long userId) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		return billingKeyRepository.findByUserAndIsDefaultTrueAndIsActiveTrue(user)
-			.map(BillingKeyInfoResponse::from)
-			.orElse(null);
+			.map(BillingKeyInfoResponse::from);
 	}
 }

--- a/user-service/src/main/java/com/t1/popcon/user/client/AuctionServiceClient.java
+++ b/user-service/src/main/java/com/t1/popcon/user/client/AuctionServiceClient.java
@@ -2,9 +2,11 @@ package com.t1.popcon.user.client;
 
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.user.client.config.FeignClientConfig;
+import com.t1.popcon.user.dto.history.AuctionReservationDetailResponse;
 import com.t1.popcon.user.dto.history.AuctionHistoryResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
@@ -18,4 +20,10 @@ public interface AuctionServiceClient {
 
 	@GetMapping("/internal/auctions/bids")
 	ApiResponse<List<AuctionHistoryResponse>> getAuctionBids(@RequestParam("userId") Long userId);
+
+	@GetMapping("/internal/auctions/bids/{bidId}")
+	ApiResponse<AuctionReservationDetailResponse> getBidDetail(
+		@PathVariable("bidId") Long bidId,
+		@RequestParam("userId") Long userId
+	);
 }

--- a/user-service/src/main/java/com/t1/popcon/user/client/DrawServiceClient.java
+++ b/user-service/src/main/java/com/t1/popcon/user/client/DrawServiceClient.java
@@ -2,10 +2,12 @@ package com.t1.popcon.user.client;
 
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.user.client.config.FeignClientConfig;
+import com.t1.popcon.user.dto.history.DrawEntryDetailResponse;
 import com.t1.popcon.user.dto.history.DrawHistoryResponse;
 import com.t1.popcon.user.dto.history.SliceResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
@@ -20,5 +22,11 @@ public interface DrawServiceClient {
         @RequestParam("userId") Long userId,
         @RequestParam("page") int page,
         @RequestParam("size") int size
+    );
+
+    @GetMapping("/internal/draws/entries/{entryId}")
+    ApiResponse<DrawEntryDetailResponse> getDrawEntryDetail(
+        @PathVariable("entryId") Long entryId,
+        @RequestParam("userId") Long userId
     );
 }

--- a/user-service/src/main/java/com/t1/popcon/user/client/PopupServiceClient.java
+++ b/user-service/src/main/java/com/t1/popcon/user/client/PopupServiceClient.java
@@ -2,10 +2,13 @@ package com.t1.popcon.user.client;
 
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.user.client.config.FeignClientConfig;
+import com.t1.popcon.user.dto.history.PopupInternalResponse;
 import com.t1.popcon.user.dto.history.PopupLikeHistoryResponse;
 import com.t1.popcon.user.dto.history.SliceResponse;
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
@@ -14,6 +17,12 @@ import org.springframework.web.bind.annotation.RequestParam;
     configuration = FeignClientConfig.class
 )
 public interface PopupServiceClient {
+
+    @GetMapping("/internal/popups/{popupId}")
+    ApiResponse<PopupInternalResponse> getPopupDetail(@PathVariable("popupId") Long popupId);
+
+    @GetMapping("/internal/popups/bulk")
+    ApiResponse<List<PopupInternalResponse>> getPopupsByBulkIds(@RequestParam("popupIds") List<Long> popupIds);
 
     @GetMapping("/internal/popups/likes")
     ApiResponse<SliceResponse<PopupLikeHistoryResponse>> getLikedPopups(

--- a/user-service/src/main/java/com/t1/popcon/user/client/TicketServiceClient.java
+++ b/user-service/src/main/java/com/t1/popcon/user/client/TicketServiceClient.java
@@ -28,4 +28,10 @@ public interface TicketServiceClient {
         @PathVariable("reservationNo") String reservationNo,
         @RequestParam("userId") Long userId
     );
+
+    @GetMapping("/internal/tickets/{ticketId}")
+    ApiResponse<TicketHistoryResponse> getTicketById(
+        @PathVariable("ticketId") Long ticketId,
+        @RequestParam("userId") Long userId
+    );
 }

--- a/user-service/src/main/java/com/t1/popcon/user/client/TicketServiceClient.java
+++ b/user-service/src/main/java/com/t1/popcon/user/client/TicketServiceClient.java
@@ -3,6 +3,7 @@ package com.t1.popcon.user.client;
 import com.t1.popcon.common.response.ApiResponse;
 import com.t1.popcon.user.client.config.FeignClientConfig;
 import com.t1.popcon.user.dto.history.SliceResponse;
+import com.t1.popcon.user.dto.history.TicketDetailResponse;
 import com.t1.popcon.user.dto.history.TicketHistoryResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,13 +25,13 @@ public interface TicketServiceClient {
     );
 
     @GetMapping("/internal/tickets/reservations/{reservationNo}")
-    ApiResponse<TicketHistoryResponse> getTicketByReservationNo(
+    ApiResponse<TicketDetailResponse> getTicketByReservationNo(
         @PathVariable("reservationNo") String reservationNo,
         @RequestParam("userId") Long userId
     );
 
     @GetMapping("/internal/tickets/{ticketId}")
-    ApiResponse<TicketHistoryResponse> getTicketById(
+    ApiResponse<TicketDetailResponse> getTicketById(
         @PathVariable("ticketId") Long ticketId,
         @RequestParam("userId") Long userId
     );

--- a/user-service/src/main/java/com/t1/popcon/user/controller/UserHistoryController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/controller/UserHistoryController.java
@@ -6,6 +6,7 @@ import com.t1.popcon.user.dto.history.AuctionHistoryResponse;
 import com.t1.popcon.user.dto.history.DrawHistoryResponse;
 import com.t1.popcon.user.dto.history.PopupLikeHistoryResponse;
 import com.t1.popcon.user.dto.history.SliceResponse;
+import com.t1.popcon.user.dto.history.TicketDetailViewResponse;
 import com.t1.popcon.user.dto.history.TicketHistoryResponse;
 import com.t1.popcon.user.service.UserHistoryService;
 import java.util.List;
@@ -27,13 +28,13 @@ public class UserHistoryController {
     @GetMapping("/draws")
     public ApiResponse<List<DrawHistoryResponse>> getDrawHistory(@AuthenticationPrincipal AuthUser authUser) {
         List<DrawHistoryResponse> response = userHistoryService.getDrawHistory(authUser.id());
-        return ApiResponse.ok("드로우 응모 내역 조회를 성공했습니다.", response);
+        return ApiResponse.ok("응모 내역 조회 성공", response);
     }
 
     @GetMapping("/auctions")
     public ApiResponse<List<AuctionHistoryResponse>> getAuctionHistory(@AuthenticationPrincipal AuthUser authUser) {
         List<AuctionHistoryResponse> response = userHistoryService.getAuctionHistory(authUser.id());
-        return ApiResponse.ok("경매 참여 내역 조회를 성공했습니다.", response);
+        return ApiResponse.ok("경매 참여 이력 조회 성공", response);
     }
 
     @GetMapping("/tickets")
@@ -43,7 +44,16 @@ public class UserHistoryController {
         @RequestParam(value = "size", defaultValue = "20") int size
     ) {
         SliceResponse<TicketHistoryResponse> response = userHistoryService.getTicketHistory(authUser.id(), page, size);
-        return ApiResponse.ok("티켓 목록 조회를 성공했습니다.", response);
+        return ApiResponse.ok("티켓 목록 조회 성공", response);
+    }
+
+    @GetMapping("/tickets/{ticketId}")
+    public ApiResponse<TicketDetailViewResponse> getTicketById(
+        @AuthenticationPrincipal AuthUser authUser,
+        @PathVariable("ticketId") Long ticketId
+    ) {
+        TicketDetailViewResponse response = userHistoryService.getTicketById(authUser.id(), ticketId);
+        return ApiResponse.ok("티켓 상세 조회 성공", response);
     }
 
     @GetMapping("/tickets/reservations/{reservationNo}")
@@ -52,7 +62,7 @@ public class UserHistoryController {
         @PathVariable("reservationNo") String reservationNo
     ) {
         TicketHistoryResponse response = userHistoryService.getTicketByReservationNo(authUser.id(), reservationNo);
-        return ApiResponse.ok("티켓 상세 조회를 성공했습니다.", response);
+        return ApiResponse.ok("티켓 상세 조회 성공", response);
     }
 
     @GetMapping("/likes")
@@ -62,6 +72,6 @@ public class UserHistoryController {
         @RequestParam(value = "size", defaultValue = "12") int size
     ) {
         SliceResponse<PopupLikeHistoryResponse> response = userHistoryService.getLikedPopups(authUser.id(), page, size);
-        return ApiResponse.ok("찜한 팝업스토어 목록 조회를 성공했습니다.", response);
+        return ApiResponse.ok("좋아요 팝업 목록 조회 성공", response);
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/controller/UserHistoryController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/controller/UserHistoryController.java
@@ -72,6 +72,6 @@ public class UserHistoryController {
         @RequestParam(value = "size", defaultValue = "12") int size
     ) {
         SliceResponse<PopupLikeHistoryResponse> response = userHistoryService.getLikedPopups(authUser.id(), page, size);
-        return ApiResponse.ok("좋아요 팝업 목록 조회 성공", response);
+        return ApiResponse.ok("좋아요한 팝업 목록 조회 성공", response);
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/AuctionReservationDetailResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/AuctionReservationDetailResponse.java
@@ -1,0 +1,23 @@
+package com.t1.popcon.user.dto.history;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuctionReservationDetailResponse {
+
+    private String reservationNo;
+    private String popupTitle;
+    private String popupAddress;
+    private String popupThumbnail;
+    private LocalDate entryDate;
+    private LocalTime entryTime;
+    private Integer startPrice;
+    private Integer discountAmount;
+    private Integer finalPrice;
+    private LocalDateTime paidAt;
+}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/DrawEntryDetailResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/DrawEntryDetailResponse.java
@@ -1,0 +1,25 @@
+package com.t1.popcon.user.dto.history;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DrawEntryDetailResponse {
+
+    private Long drawEntryId;
+    private Long drawId;
+    private String popupTitle;
+    private String popupAddress;
+    private String popupThumbnail;
+    private LocalDate entryDate;
+    private LocalTime entryTime;
+    private String userName;
+    private String userPhoneNumber;
+    private LocalDateTime paidAt;
+    private String status;
+    private LocalDateTime ticketIssuedAt;
+}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/PopupInternalResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/PopupInternalResponse.java
@@ -1,0 +1,10 @@
+package com.t1.popcon.user.dto.history;
+
+public record PopupInternalResponse(
+    Long popupId,
+    String title,
+    String hThumbnailUrl,
+    String vThumbnailUrl,
+    String location
+) {
+}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/SliceResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/SliceResponse.java
@@ -1,11 +1,13 @@
 package com.t1.popcon.user.dto.history;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class SliceResponse<T> {
 
     private List<T> content;

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketDetailResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketDetailResponse.java
@@ -1,0 +1,24 @@
+package com.t1.popcon.user.dto.history;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TicketDetailResponse {
+
+    private Long ticketId;
+    private Long userId;
+    private Long popupId;
+    private String ticketNumber;
+    private String reservationNo;
+    private String status;
+    private String sourceType;
+    private Long sourceId;
+    private LocalDate entryDate;
+    private LocalTime entryTime;
+    private LocalDateTime issuedAt;
+}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketDetailViewResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketDetailViewResponse.java
@@ -32,6 +32,9 @@ public class TicketDetailViewResponse {
     private String userName;
     private String userPhoneNumber;
     private String userEmail;
+    private String paymentMethod;
+    private String cardName;
+    private String cardNumber;
     private LocalDateTime paidAt;
     private Integer originalPrice;
     private Integer discountAmount;

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketDetailViewResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketDetailViewResponse.java
@@ -12,21 +12,28 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TicketHistoryResponse {
+public class TicketDetailViewResponse {
 
     private Long ticketId;
-    private Long userId;
-    private Long popupId;
     private String ticketNumber;
     private String reservationNo;
     private String status;
+    private String displayStatus;
     private String sourceType;
     private Long sourceId;
-    private LocalDate entryDate;
-    private LocalTime entryTime;
-    private LocalDateTime issuedAt;
+    private Long popupId;
     private String popupTitle;
     private String popupAddress;
     private String thumbnailUrl;
-    private String displayStatus;
+    private LocalDate entryDate;
+    private LocalTime entryTime;
+    private LocalDateTime issuedAt;
+    private String qrValue;
+    private String userName;
+    private String userPhoneNumber;
+    private String userEmail;
+    private LocalDateTime paidAt;
+    private Integer originalPrice;
+    private Integer discountAmount;
+    private Integer finalPrice;
 }

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketPurchaserProfileResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketPurchaserProfileResponse.java
@@ -1,0 +1,9 @@
+package com.t1.popcon.user.dto.history;
+
+public record TicketPurchaserProfileResponse(
+    Long userId,
+    String userName,
+    String userPhoneNumber,
+    String userEmail
+) {
+}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketPurchaserProfileResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/TicketPurchaserProfileResponse.java
@@ -4,6 +4,8 @@ public record TicketPurchaserProfileResponse(
     Long userId,
     String userName,
     String userPhoneNumber,
-    String userEmail
+    String userEmail,
+    String cardName,
+    String cardNumber
 ) {
 }

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -244,6 +244,11 @@ public class UserHistoryService {
 
         if ("AUCTION".equalsIgnoreCase(sourceType)) {
             TicketDetailViewResponse currentDetail = detailBuilder.build();
+            if (ticket.getSourceId() == null) {
+                log.warn("Auction ticket is missing sourceId. ticketId={}, sourceType={}",
+                    ticket.getTicketId(), ticket.getSourceType());
+                return;
+            }
             ApiResponse<AuctionReservationDetailResponse> response =
                 auctionServiceClient.getBidDetail(ticket.getSourceId(), userId);
             AuctionReservationDetailResponse detail = requireData(response);
@@ -261,6 +266,11 @@ public class UserHistoryService {
 
         if ("DRAW".equalsIgnoreCase(sourceType)) {
             TicketDetailViewResponse currentDetail = detailBuilder.build();
+            if (ticket.getSourceId() == null) {
+                log.warn("Draw ticket is missing sourceId. ticketId={}, sourceType={}",
+                    ticket.getTicketId(), ticket.getSourceType());
+                return;
+            }
             ApiResponse<DrawEntryDetailResponse> response =
                 drawServiceClient.getDrawEntryDetail(ticket.getSourceId(), userId);
             DrawEntryDetailResponse detail = requireData(response);

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -14,6 +14,7 @@ import com.t1.popcon.user.dto.history.DrawHistoryResponse;
 import com.t1.popcon.user.dto.history.PopupInternalResponse;
 import com.t1.popcon.user.dto.history.PopupLikeHistoryResponse;
 import com.t1.popcon.user.dto.history.SliceResponse;
+import com.t1.popcon.user.dto.history.TicketDetailResponse;
 import com.t1.popcon.user.dto.history.TicketDetailViewResponse;
 import com.t1.popcon.user.dto.history.TicketHistoryResponse;
 import com.t1.popcon.user.dto.history.TicketPurchaserProfileResponse;
@@ -122,12 +123,12 @@ public class UserHistoryService {
 
     public TicketDetailViewResponse getTicketById(Long userId, Long ticketId) {
         try {
-            ApiResponse<TicketHistoryResponse> response = ticketServiceClient.getTicketById(ticketId, userId);
+            ApiResponse<TicketDetailResponse> response = ticketServiceClient.getTicketById(ticketId, userId);
             if (response == null || response.getData() == null) {
                 throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
             }
 
-            TicketHistoryResponse ticket = response.getData();
+            TicketDetailResponse ticket = response.getData();
             PopupInternalResponse popup = fetchPopup(ticket.getPopupId());
             TicketPurchaserProfileResponse purchaser = userService.getTicketPurchaserProfile(userId);
 
@@ -140,9 +141,9 @@ public class UserHistoryService {
                 .sourceType(ticket.getSourceType())
                 .sourceId(ticket.getSourceId())
                 .popupId(ticket.getPopupId())
-                .popupTitle(firstNonBlank(popup != null ? popup.title() : null, ticket.getPopupTitle()))
-                .popupAddress(firstNonBlank(popup != null ? popup.location() : null, ticket.getPopupAddress()))
-                .thumbnailUrl(firstNonBlank(popup != null ? popup.vThumbnailUrl() : null, ticket.getThumbnailUrl()))
+                .popupTitle(popup != null ? popup.title() : null)
+                .popupAddress(popup != null ? popup.location() : null)
+                .thumbnailUrl(popup != null ? popup.vThumbnailUrl() : null)
                 .entryDate(ticket.getEntryDate())
                 .entryTime(ticket.getEntryTime())
                 .issuedAt(ticket.getIssuedAt())
@@ -151,7 +152,7 @@ public class UserHistoryService {
                 .userPhoneNumber(purchaser.userPhoneNumber())
                 .userEmail(purchaser.userEmail());
 
-            applySourceSpecificDetail(detailBuilder, userId, ticket);
+            applySourceSpecificDetail(detailBuilder, userId, ticket, purchaser);
             return detailBuilder.build();
         } catch (CustomException e) {
             throw e;
@@ -163,14 +164,14 @@ public class UserHistoryService {
 
     public TicketHistoryResponse getTicketByReservationNo(Long userId, String reservationNo) {
         try {
-            ApiResponse<TicketHistoryResponse> response = ticketServiceClient.getTicketByReservationNo(reservationNo, userId);
+            ApiResponse<TicketDetailResponse> response = ticketServiceClient.getTicketByReservationNo(reservationNo, userId);
             if (response == null || response.getData() == null) {
                 throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
             }
 
-            TicketHistoryResponse ticket = response.getData();
+            TicketDetailResponse ticket = response.getData();
             PopupInternalResponse popup = fetchPopup(ticket.getPopupId());
-            return enrichTicketSummary(ticket, popup);
+            return toTicketHistoryResponse(ticket, popup);
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
@@ -213,10 +214,31 @@ public class UserHistoryService {
             .build();
     }
 
+    private TicketHistoryResponse toTicketHistoryResponse(TicketDetailResponse ticket, PopupInternalResponse popup) {
+        return TicketHistoryResponse.builder()
+            .ticketId(ticket.getTicketId())
+            .userId(ticket.getUserId())
+            .popupId(ticket.getPopupId())
+            .ticketNumber(ticket.getTicketNumber())
+            .reservationNo(ticket.getReservationNo())
+            .status(ticket.getStatus())
+            .sourceType(ticket.getSourceType())
+            .sourceId(ticket.getSourceId())
+            .entryDate(ticket.getEntryDate())
+            .entryTime(ticket.getEntryTime())
+            .issuedAt(ticket.getIssuedAt())
+            .popupTitle(popup != null ? popup.title() : null)
+            .popupAddress(popup != null ? popup.location() : null)
+            .thumbnailUrl(popup != null ? popup.vThumbnailUrl() : null)
+            .displayStatus(resolveDisplayStatus(ticket.getStatus()))
+            .build();
+    }
+
     private void applySourceSpecificDetail(
         TicketDetailViewResponse.TicketDetailViewResponseBuilder detailBuilder,
         Long userId,
-        TicketHistoryResponse ticket
+        TicketDetailResponse ticket,
+        TicketPurchaserProfileResponse purchaser
     ) {
         String sourceType = ticket.getSourceType();
         if (sourceType == null) {
@@ -224,13 +246,17 @@ public class UserHistoryService {
         }
 
         if ("AUCTION".equalsIgnoreCase(sourceType)) {
+            TicketDetailViewResponse currentDetail = detailBuilder.build();
             ApiResponse<AuctionReservationDetailResponse> response =
                 auctionServiceClient.getBidDetail(ticket.getSourceId(), userId);
             AuctionReservationDetailResponse detail = requireData(response);
             detailBuilder
-                .popupTitle(firstNonBlank(detail.getPopupTitle(), detailBuilder.build().getPopupTitle()))
-                .popupAddress(firstNonBlank(detail.getPopupAddress(), detailBuilder.build().getPopupAddress()))
-                .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), detailBuilder.build().getThumbnailUrl()))
+                .popupTitle(firstNonBlank(detail.getPopupTitle(), currentDetail.getPopupTitle()))
+                .popupAddress(firstNonBlank(detail.getPopupAddress(), currentDetail.getPopupAddress()))
+                .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), currentDetail.getThumbnailUrl()))
+                .paymentMethod(resolvePaymentMethod(purchaser))
+                .cardName(purchaser.cardName())
+                .cardNumber(purchaser.cardNumber())
                 .paidAt(detail.getPaidAt())
                 .originalPrice(detail.getStartPrice())
                 .discountAmount(detail.getDiscountAmount())
@@ -239,16 +265,17 @@ public class UserHistoryService {
         }
 
         if ("DRAW".equalsIgnoreCase(sourceType)) {
+            TicketDetailViewResponse currentDetail = detailBuilder.build();
             ApiResponse<DrawEntryDetailResponse> response =
                 drawServiceClient.getDrawEntryDetail(ticket.getSourceId(), userId);
             DrawEntryDetailResponse detail = requireData(response);
             detailBuilder
-                .popupTitle(firstNonBlank(detail.getPopupTitle(), detailBuilder.build().getPopupTitle()))
-                .popupAddress(firstNonBlank(detail.getPopupAddress(), detailBuilder.build().getPopupAddress()))
-                .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), detailBuilder.build().getThumbnailUrl()))
+                .popupTitle(firstNonBlank(detail.getPopupTitle(), currentDetail.getPopupTitle()))
+                .popupAddress(firstNonBlank(detail.getPopupAddress(), currentDetail.getPopupAddress()))
+                .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), currentDetail.getThumbnailUrl()))
                 .paidAt(detail.getPaidAt())
-                .userName(firstNonBlank(detail.getUserName(), detailBuilder.build().getUserName()))
-                .userPhoneNumber(firstNonBlank(detail.getUserPhoneNumber(), detailBuilder.build().getUserPhoneNumber()));
+                .userName(firstNonBlank(detail.getUserName(), currentDetail.getUserName()))
+                .userPhoneNumber(firstNonBlank(detail.getUserPhoneNumber(), currentDetail.getUserPhoneNumber()));
         }
     }
 
@@ -294,11 +321,21 @@ public class UserHistoryService {
         };
     }
 
-    private String resolveQrValue(TicketHistoryResponse ticket) {
+    private String resolveQrValue(TicketDetailResponse ticket) {
         if (ticket.getTicketNumber() != null && !ticket.getTicketNumber().isBlank()) {
             return ticket.getTicketNumber();
         }
         return ticket.getReservationNo();
+    }
+
+    private String resolvePaymentMethod(TicketPurchaserProfileResponse purchaser) {
+        if (purchaser == null) {
+            return null;
+        }
+        if (firstNonBlank(purchaser.cardName(), purchaser.cardNumber()) != null) {
+            return "CARD";
+        }
+        return null;
     }
 
     private String firstNonBlank(String primary, String fallback) {

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -8,12 +8,22 @@ import com.t1.popcon.user.client.DrawServiceClient;
 import com.t1.popcon.user.client.PopupServiceClient;
 import com.t1.popcon.user.client.TicketServiceClient;
 import com.t1.popcon.user.dto.history.AuctionHistoryResponse;
+import com.t1.popcon.user.dto.history.AuctionReservationDetailResponse;
+import com.t1.popcon.user.dto.history.DrawEntryDetailResponse;
 import com.t1.popcon.user.dto.history.DrawHistoryResponse;
+import com.t1.popcon.user.dto.history.PopupInternalResponse;
 import com.t1.popcon.user.dto.history.PopupLikeHistoryResponse;
 import com.t1.popcon.user.dto.history.SliceResponse;
+import com.t1.popcon.user.dto.history.TicketDetailViewResponse;
 import com.t1.popcon.user.dto.history.TicketHistoryResponse;
+import com.t1.popcon.user.dto.history.TicketPurchaserProfileResponse;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +40,7 @@ public class UserHistoryService {
     private final AuctionServiceClient auctionServiceClient;
     private final TicketServiceClient ticketServiceClient;
     private final PopupServiceClient popupServiceClient;
+    private final UserService userService;
 
     public List<DrawHistoryResponse> getDrawHistory(Long userId) {
         try {
@@ -85,9 +96,67 @@ public class UserHistoryService {
             if (response == null || response.getData() == null) {
                 throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
             }
-            return response.getData();
+
+            SliceResponse<TicketHistoryResponse> slice = response.getData();
+            List<TicketHistoryResponse> content = slice.getContent() == null ? Collections.emptyList() : slice.getContent();
+            Map<Long, PopupInternalResponse> popupMap = fetchPopupsInBatch(extractPopupIds(content));
+
+            List<TicketHistoryResponse> enrichedTickets = content.stream()
+                .map(ticket -> enrichTicketSummary(ticket, popupMap.get(ticket.getPopupId())))
+                .toList();
+
+            return new SliceResponse<>(
+                enrichedTickets,
+                slice.isFirst(),
+                slice.isLast(),
+                slice.getNumberOfElements(),
+                slice.isEmpty()
+            );
+        } catch (CustomException e) {
+            throw e;
         } catch (Exception e) {
             log.error(">>>> [Ticket-Service 연동 실패] User ID: {}, Error: {}", userId, e.getMessage());
+            throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
+        }
+    }
+
+    public TicketDetailViewResponse getTicketById(Long userId, Long ticketId) {
+        try {
+            ApiResponse<TicketHistoryResponse> response = ticketServiceClient.getTicketById(ticketId, userId);
+            if (response == null || response.getData() == null) {
+                throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
+            }
+
+            TicketHistoryResponse ticket = response.getData();
+            PopupInternalResponse popup = fetchPopup(ticket.getPopupId());
+            TicketPurchaserProfileResponse purchaser = userService.getTicketPurchaserProfile(userId);
+
+            TicketDetailViewResponse.TicketDetailViewResponseBuilder detailBuilder = TicketDetailViewResponse.builder()
+                .ticketId(ticket.getTicketId())
+                .ticketNumber(ticket.getTicketNumber())
+                .reservationNo(ticket.getReservationNo())
+                .status(ticket.getStatus())
+                .displayStatus(resolveDisplayStatus(ticket.getStatus()))
+                .sourceType(ticket.getSourceType())
+                .sourceId(ticket.getSourceId())
+                .popupId(ticket.getPopupId())
+                .popupTitle(firstNonBlank(popup != null ? popup.title() : null, ticket.getPopupTitle()))
+                .popupAddress(firstNonBlank(popup != null ? popup.location() : null, ticket.getPopupAddress()))
+                .thumbnailUrl(firstNonBlank(popup != null ? popup.vThumbnailUrl() : null, ticket.getThumbnailUrl()))
+                .entryDate(ticket.getEntryDate())
+                .entryTime(ticket.getEntryTime())
+                .issuedAt(ticket.getIssuedAt())
+                .qrValue(resolveQrValue(ticket))
+                .userName(purchaser.userName())
+                .userPhoneNumber(purchaser.userPhoneNumber())
+                .userEmail(purchaser.userEmail());
+
+            applySourceSpecificDetail(detailBuilder, userId, ticket);
+            return detailBuilder.build();
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(">>>> [Ticket Detail 조회 실패] userId={}, ticketId={}, error={}", userId, ticketId, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }
@@ -98,7 +167,10 @@ public class UserHistoryService {
             if (response == null || response.getData() == null) {
                 throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
             }
-            return response.getData();
+
+            TicketHistoryResponse ticket = response.getData();
+            PopupInternalResponse popup = fetchPopup(ticket.getPopupId());
+            return enrichTicketSummary(ticket, popup);
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
@@ -119,5 +191,127 @@ public class UserHistoryService {
             log.error(">>>> [Popup-Service 연동 실패] User ID: {}, Error: {}", userId, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
+    }
+
+    private TicketHistoryResponse enrichTicketSummary(TicketHistoryResponse ticket, PopupInternalResponse popup) {
+        return TicketHistoryResponse.builder()
+            .ticketId(ticket.getTicketId())
+            .userId(ticket.getUserId())
+            .popupId(ticket.getPopupId())
+            .ticketNumber(ticket.getTicketNumber())
+            .reservationNo(ticket.getReservationNo())
+            .status(ticket.getStatus())
+            .sourceType(ticket.getSourceType())
+            .sourceId(ticket.getSourceId())
+            .entryDate(ticket.getEntryDate())
+            .entryTime(ticket.getEntryTime())
+            .issuedAt(ticket.getIssuedAt())
+            .popupTitle(firstNonBlank(popup != null ? popup.title() : null, ticket.getPopupTitle()))
+            .popupAddress(firstNonBlank(popup != null ? popup.location() : null, ticket.getPopupAddress()))
+            .thumbnailUrl(firstNonBlank(popup != null ? popup.vThumbnailUrl() : null, ticket.getThumbnailUrl()))
+            .displayStatus(resolveDisplayStatus(ticket.getStatus()))
+            .build();
+    }
+
+    private void applySourceSpecificDetail(
+        TicketDetailViewResponse.TicketDetailViewResponseBuilder detailBuilder,
+        Long userId,
+        TicketHistoryResponse ticket
+    ) {
+        String sourceType = ticket.getSourceType();
+        if (sourceType == null) {
+            return;
+        }
+
+        if ("AUCTION".equalsIgnoreCase(sourceType)) {
+            ApiResponse<AuctionReservationDetailResponse> response =
+                auctionServiceClient.getBidDetail(ticket.getSourceId(), userId);
+            AuctionReservationDetailResponse detail = requireData(response);
+            detailBuilder
+                .popupTitle(firstNonBlank(detail.getPopupTitle(), detailBuilder.build().getPopupTitle()))
+                .popupAddress(firstNonBlank(detail.getPopupAddress(), detailBuilder.build().getPopupAddress()))
+                .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), detailBuilder.build().getThumbnailUrl()))
+                .paidAt(detail.getPaidAt())
+                .originalPrice(detail.getStartPrice())
+                .discountAmount(detail.getDiscountAmount())
+                .finalPrice(detail.getFinalPrice());
+            return;
+        }
+
+        if ("DRAW".equalsIgnoreCase(sourceType)) {
+            ApiResponse<DrawEntryDetailResponse> response =
+                drawServiceClient.getDrawEntryDetail(ticket.getSourceId(), userId);
+            DrawEntryDetailResponse detail = requireData(response);
+            detailBuilder
+                .popupTitle(firstNonBlank(detail.getPopupTitle(), detailBuilder.build().getPopupTitle()))
+                .popupAddress(firstNonBlank(detail.getPopupAddress(), detailBuilder.build().getPopupAddress()))
+                .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), detailBuilder.build().getThumbnailUrl()))
+                .paidAt(detail.getPaidAt())
+                .userName(firstNonBlank(detail.getUserName(), detailBuilder.build().getUserName()))
+                .userPhoneNumber(firstNonBlank(detail.getUserPhoneNumber(), detailBuilder.build().getUserPhoneNumber()));
+        }
+    }
+
+    private PopupInternalResponse fetchPopup(Long popupId) {
+        if (popupId == null || popupId <= 0) {
+            return null;
+        }
+
+        ApiResponse<PopupInternalResponse> response = popupServiceClient.getPopupDetail(popupId);
+        return response != null ? response.getData() : null;
+    }
+
+    private Map<Long, PopupInternalResponse> fetchPopupsInBatch(List<Long> popupIds) {
+        if (popupIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        ApiResponse<List<PopupInternalResponse>> response = popupServiceClient.getPopupsByBulkIds(popupIds);
+        List<PopupInternalResponse> popups = requireData(response);
+        return popups.stream()
+            .filter(Objects::nonNull)
+            .collect(Collectors.toMap(PopupInternalResponse::popupId, Function.identity(), (left, right) -> left));
+    }
+
+    private List<Long> extractPopupIds(List<TicketHistoryResponse> tickets) {
+        return tickets.stream()
+            .map(TicketHistoryResponse::getPopupId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+    }
+
+    private String resolveDisplayStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+
+        return switch (status.toUpperCase()) {
+            case "ISSUED" -> "사용 가능";
+            case "USED" -> "사용 완료";
+            case "CANCELLED" -> "취소됨";
+            default -> status;
+        };
+    }
+
+    private String resolveQrValue(TicketHistoryResponse ticket) {
+        if (ticket.getTicketNumber() != null && !ticket.getTicketNumber().isBlank()) {
+            return ticket.getTicketNumber();
+        }
+        return ticket.getReservationNo();
+    }
+
+    private String firstNonBlank(String primary, String fallback) {
+        if (primary != null && !primary.isBlank()) {
+            return primary;
+        }
+        return fallback;
+    }
+
+    private <T> T requireData(ApiResponse<T> response) {
+        if (response == null || response.getData() == null) {
+            throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
+        }
+        return response.getData();
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -73,7 +73,7 @@ public class UserHistoryService {
 
             return histories;
         } catch (Exception e) {
-            log.error(">>>> [Draw-Service 연동 실패] User ID: {}, Error: {}", userId, e.getMessage());
+            log.error("Draw service integration failed. userId={}, error={}", userId, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }
@@ -86,7 +86,7 @@ public class UserHistoryService {
             }
             return response.getData();
         } catch (Exception e) {
-            log.error(">>>> [Auction-Service 연동 실패] User ID: {}, Error: {}", userId, e.getMessage());
+            log.error("Auction service integration failed. userId={}, error={}", userId, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }
@@ -116,7 +116,7 @@ public class UserHistoryService {
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            log.error(">>>> [Ticket-Service 연동 실패] User ID: {}, Error: {}", userId, e.getMessage());
+            log.error("Ticket service integration failed. userId={}, error={}", userId, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }
@@ -154,7 +154,7 @@ public class UserHistoryService {
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            log.error(">>>> [Ticket Detail 조회 실패] userId={}, ticketId={}, error={}", userId, ticketId, e.getMessage());
+            log.error("Ticket detail lookup failed. userId={}, ticketId={}, error={}", userId, ticketId, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }
@@ -172,7 +172,7 @@ public class UserHistoryService {
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            log.error(">>>> [Ticket-Service 연동 실패] userId={}, reservationNo={}, Error: {}", userId, reservationNo, e.getMessage());
+            log.error("Ticket service integration failed. userId={}, reservationNo={}, error={}", userId, reservationNo, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }
@@ -186,7 +186,7 @@ public class UserHistoryService {
             }
             return response.getData();
         } catch (Exception e) {
-            log.error(">>>> [Popup-Service 연동 실패] User ID: {}, Error: {}", userId, e.getMessage());
+            log.error("Popup service integration failed. userId={}, error={}", userId, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }
@@ -310,7 +310,7 @@ public class UserHistoryService {
         try {
             return fetchPopup(popupId);
         } catch (Exception e) {
-            log.warn(">>>> [Popup fallback fetch failed] popupId={}, error={}", popupId, e.getMessage());
+            log.warn("Popup fallback fetch failed. popupId={}, error={}", popupId, e.getMessage());
             return null;
         }
     }
@@ -339,7 +339,7 @@ public class UserHistoryService {
         if (!isBlank(displayStatus)) {
             return displayStatus;
         }
-        if (status == null || status.isBlank()) {
+        if (isBlank(status)) {
             return null;
         }
 

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -129,7 +129,6 @@ public class UserHistoryService {
             }
 
             TicketDetailResponse ticket = response.getData();
-            PopupInternalResponse popup = fetchPopup(ticket.getPopupId());
             TicketPurchaserProfileResponse purchaser = userService.getTicketPurchaserProfile(userId);
 
             TicketDetailViewResponse.TicketDetailViewResponseBuilder detailBuilder = TicketDetailViewResponse.builder()
@@ -137,13 +136,10 @@ public class UserHistoryService {
                 .ticketNumber(ticket.getTicketNumber())
                 .reservationNo(ticket.getReservationNo())
                 .status(ticket.getStatus())
-                .displayStatus(resolveDisplayStatus(ticket.getStatus()))
+                .displayStatus(resolveDisplayStatus(null, ticket.getStatus()))
                 .sourceType(ticket.getSourceType())
                 .sourceId(ticket.getSourceId())
                 .popupId(ticket.getPopupId())
-                .popupTitle(popup != null ? popup.title() : null)
-                .popupAddress(popup != null ? popup.location() : null)
-                .thumbnailUrl(popup != null ? popup.vThumbnailUrl() : null)
                 .entryDate(ticket.getEntryDate())
                 .entryTime(ticket.getEntryTime())
                 .issuedAt(ticket.getIssuedAt())
@@ -153,6 +149,7 @@ public class UserHistoryService {
                 .userEmail(purchaser.userEmail());
 
             applySourceSpecificDetail(detailBuilder, userId, ticket, purchaser);
+            applyPopupFallback(detailBuilder, ticket.getPopupId());
             return detailBuilder.build();
         } catch (CustomException e) {
             throw e;
@@ -210,7 +207,7 @@ public class UserHistoryService {
             .popupTitle(firstNonBlank(popup != null ? popup.title() : null, ticket.getPopupTitle()))
             .popupAddress(firstNonBlank(popup != null ? popup.location() : null, ticket.getPopupAddress()))
             .thumbnailUrl(firstNonBlank(popup != null ? popup.vThumbnailUrl() : null, ticket.getThumbnailUrl()))
-            .displayStatus(resolveDisplayStatus(ticket.getStatus()))
+            .displayStatus(resolveDisplayStatus(ticket.getDisplayStatus(), ticket.getStatus()))
             .build();
     }
 
@@ -230,7 +227,7 @@ public class UserHistoryService {
             .popupTitle(popup != null ? popup.title() : null)
             .popupAddress(popup != null ? popup.location() : null)
             .thumbnailUrl(popup != null ? popup.vThumbnailUrl() : null)
-            .displayStatus(resolveDisplayStatus(ticket.getStatus()))
+            .displayStatus(resolveDisplayStatus(null, ticket.getStatus()))
             .build();
     }
 
@@ -279,6 +276,27 @@ public class UserHistoryService {
         }
     }
 
+    private void applyPopupFallback(TicketDetailViewResponse.TicketDetailViewResponseBuilder detailBuilder, Long popupId) {
+        TicketDetailViewResponse currentDetail = detailBuilder.build();
+        if (!needsPopupFallback(currentDetail)) {
+            return;
+        }
+
+        PopupInternalResponse popup = fetchPopupSafely(popupId);
+        if (popup == null) {
+            return;
+        }
+
+        detailBuilder
+            .popupTitle(firstNonBlank(currentDetail.getPopupTitle(), popup.title()))
+            .popupAddress(firstNonBlank(currentDetail.getPopupAddress(), popup.location()))
+            .thumbnailUrl(firstNonBlank(currentDetail.getThumbnailUrl(), popup.vThumbnailUrl()));
+    }
+
+    private boolean needsPopupFallback(TicketDetailViewResponse detail) {
+        return isBlank(detail.getPopupTitle()) || isBlank(detail.getPopupAddress()) || isBlank(detail.getThumbnailUrl());
+    }
+
     private PopupInternalResponse fetchPopup(Long popupId) {
         if (popupId == null || popupId <= 0) {
             return null;
@@ -286,6 +304,15 @@ public class UserHistoryService {
 
         ApiResponse<PopupInternalResponse> response = popupServiceClient.getPopupDetail(popupId);
         return response != null ? response.getData() : null;
+    }
+
+    private PopupInternalResponse fetchPopupSafely(Long popupId) {
+        try {
+            return fetchPopup(popupId);
+        } catch (Exception e) {
+            log.warn(">>>> [Popup fallback fetch failed] popupId={}, error={}", popupId, e.getMessage());
+            return null;
+        }
     }
 
     private Map<Long, PopupInternalResponse> fetchPopupsInBatch(List<Long> popupIds) {
@@ -308,7 +335,10 @@ public class UserHistoryService {
             .toList();
     }
 
-    private String resolveDisplayStatus(String status) {
+    private String resolveDisplayStatus(String displayStatus, String status) {
+        if (!isBlank(displayStatus)) {
+            return displayStatus;
+        }
         if (status == null || status.isBlank()) {
             return null;
         }
@@ -343,6 +373,10 @@ public class UserHistoryService {
             return primary;
         }
         return fallback;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     private <T> T requireData(ApiResponse<T> response) {

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -148,7 +148,7 @@ public class UserHistoryService {
                 .userPhoneNumber(purchaser.userPhoneNumber())
                 .userEmail(purchaser.userEmail());
 
-            applySourceSpecificDetail(detailBuilder, userId, ticket, purchaser);
+            applySourceSpecificDetail(detailBuilder, userId, ticket);
             applyPopupFallback(detailBuilder, ticket.getPopupId());
             return detailBuilder.build();
         } catch (CustomException e) {
@@ -167,12 +167,13 @@ public class UserHistoryService {
             }
 
             TicketDetailResponse ticket = response.getData();
-            PopupInternalResponse popup = fetchPopup(ticket.getPopupId());
+            PopupInternalResponse popup = fetchPopupSafely(ticket.getPopupId());
             return toTicketHistoryResponse(ticket, popup);
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Ticket service integration failed. userId={}, reservationNo={}, error={}", userId, reservationNo, e.getMessage());
+            log.error("Ticket service integration failed. userId={}, reservationNo={}, error={}",
+                userId, reservationNo, e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
         }
     }
@@ -234,8 +235,7 @@ public class UserHistoryService {
     private void applySourceSpecificDetail(
         TicketDetailViewResponse.TicketDetailViewResponseBuilder detailBuilder,
         Long userId,
-        TicketDetailResponse ticket,
-        TicketPurchaserProfileResponse purchaser
+        TicketDetailResponse ticket
     ) {
         String sourceType = ticket.getSourceType();
         if (sourceType == null) {
@@ -247,13 +247,11 @@ public class UserHistoryService {
             ApiResponse<AuctionReservationDetailResponse> response =
                 auctionServiceClient.getBidDetail(ticket.getSourceId(), userId);
             AuctionReservationDetailResponse detail = requireData(response);
+
             detailBuilder
                 .popupTitle(firstNonBlank(detail.getPopupTitle(), currentDetail.getPopupTitle()))
                 .popupAddress(firstNonBlank(detail.getPopupAddress(), currentDetail.getPopupAddress()))
                 .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), currentDetail.getThumbnailUrl()))
-                .paymentMethod(resolvePaymentMethod(purchaser))
-                .cardName(purchaser.cardName())
-                .cardNumber(purchaser.cardNumber())
                 .paidAt(detail.getPaidAt())
                 .originalPrice(detail.getStartPrice())
                 .discountAmount(detail.getDiscountAmount())
@@ -266,6 +264,7 @@ public class UserHistoryService {
             ApiResponse<DrawEntryDetailResponse> response =
                 drawServiceClient.getDrawEntryDetail(ticket.getSourceId(), userId);
             DrawEntryDetailResponse detail = requireData(response);
+
             detailBuilder
                 .popupTitle(firstNonBlank(detail.getPopupTitle(), currentDetail.getPopupTitle()))
                 .popupAddress(firstNonBlank(detail.getPopupAddress(), currentDetail.getPopupAddress()))
@@ -320,11 +319,18 @@ public class UserHistoryService {
             return Collections.emptyMap();
         }
 
-        ApiResponse<List<PopupInternalResponse>> response = popupServiceClient.getPopupsByBulkIds(popupIds);
-        List<PopupInternalResponse> popups = requireData(response);
-        return popups.stream()
-            .filter(Objects::nonNull)
-            .collect(Collectors.toMap(PopupInternalResponse::popupId, Function.identity(), (left, right) -> left));
+        try {
+            ApiResponse<List<PopupInternalResponse>> response = popupServiceClient.getPopupsByBulkIds(popupIds);
+            List<PopupInternalResponse> popups =
+                response != null && response.getData() != null ? response.getData() : Collections.emptyList();
+
+            return popups.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(PopupInternalResponse::popupId, Function.identity(), (left, right) -> left));
+        } catch (Exception e) {
+            log.warn("Popup bulk fetch failed. popupIds={}, error={}", popupIds, e.getMessage());
+            return Collections.emptyMap();
+        }
     }
 
     private List<Long> extractPopupIds(List<TicketHistoryResponse> tickets) {
@@ -356,16 +362,6 @@ public class UserHistoryService {
             return ticket.getTicketNumber();
         }
         return ticket.getReservationNo();
-    }
-
-    private String resolvePaymentMethod(TicketPurchaserProfileResponse purchaser) {
-        if (purchaser == null) {
-            return null;
-        }
-        if (firstNonBlank(purchaser.cardName(), purchaser.cardNumber()) != null) {
-            return "CARD";
-        }
-        return null;
     }
 
     private String firstNonBlank(String primary, String fallback) {

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -1,8 +1,10 @@
 package com.t1.popcon.user.service;
 
+import com.t1.popcon.common.encryption.EncryptionService;
 import com.t1.popcon.common.exception.CustomException;
 import com.t1.popcon.common.exception.ErrorCode;
 import com.t1.popcon.user.domain.User;
+import com.t1.popcon.user.dto.history.TicketPurchaserProfileResponse;
 import com.t1.popcon.user.dto.UserLookupResponse;
 import com.t1.popcon.user.dto.UserInternalResponse;
 import com.t1.popcon.user.repository.UserRepository;
@@ -28,6 +30,7 @@ public class UserService {
     private static final String NICKNAME_CONSTRAINT = "uk_users_nickname";
     
     private final UserRepository userRepository;
+    private final EncryptionService encryptionService;
 
     @Value("${user.nickname.prefix:User}")
     private String nicknamePrefix;
@@ -42,6 +45,17 @@ public class UserService {
                 user.getId(),
                 user.getEncryptedName(),
                 user.getEncryptedPhoneNumber()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public TicketPurchaserProfileResponse getTicketPurchaserProfile(Long userId) {
+        User user = getUserOrThrow(userId);
+        return new TicketPurchaserProfileResponse(
+            user.getId(),
+            encryptionService.decrypt(user.getEncryptedName()),
+            encryptionService.decrypt(user.getEncryptedPhoneNumber()),
+            user.getEmail()
         );
     }
 

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.t1.popcon.user.service;
 import com.t1.popcon.common.encryption.EncryptionService;
 import com.t1.popcon.common.exception.CustomException;
 import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.user.billing.dto.BillingKeyInfoResponse;
+import com.t1.popcon.user.billing.service.BillingKeyService;
 import com.t1.popcon.user.domain.User;
 import com.t1.popcon.user.dto.history.TicketPurchaserProfileResponse;
 import com.t1.popcon.user.dto.UserLookupResponse;
@@ -32,6 +34,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final EncryptionService encryptionService;
+    private final BillingKeyService billingKeyService;
 
     @Value("${user.nickname.prefix:User}")
     private String nicknamePrefix;
@@ -68,11 +71,14 @@ public class UserService {
     @Transactional(readOnly = true)
     public TicketPurchaserProfileResponse getTicketPurchaserProfile(Long userId) {
         User user = getUserOrThrow(userId);
+        BillingKeyInfoResponse billingKeyInfo = billingKeyService.getDefaultBillingKeyInfo(userId);
         return new TicketPurchaserProfileResponse(
             user.getId(),
             encryptionService.decrypt(user.getEncryptedName()),
             encryptionService.decrypt(user.getEncryptedPhoneNumber()),
-            user.getEmail()
+            user.getEmail(),
+            billingKeyInfo != null ? billingKeyInfo.cardName() : null,
+            billingKeyInfo != null ? billingKeyInfo.cardNumber() : null
         );
     }
 

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -17,6 +17,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.hibernate.exception.ConstraintViolationException;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import com.t1.popcon.user.dto.UserCreateRequest;
@@ -71,14 +72,14 @@ public class UserService {
     @Transactional(readOnly = true)
     public TicketPurchaserProfileResponse getTicketPurchaserProfile(Long userId) {
         User user = getUserOrThrow(userId);
-        BillingKeyInfoResponse billingKeyInfo = billingKeyService.getDefaultBillingKeyInfo(userId);
+        Optional<BillingKeyInfoResponse> billingKeyInfo = billingKeyService.getDefaultBillingKeyInfo(userId);
         return new TicketPurchaserProfileResponse(
             user.getId(),
             encryptionService.decrypt(user.getEncryptedName()),
             encryptionService.decrypt(user.getEncryptedPhoneNumber()),
             user.getEmail(),
-            billingKeyInfo != null ? billingKeyInfo.cardName() : null,
-            billingKeyInfo != null ? billingKeyInfo.cardNumber() : null
+            billingKeyInfo.map(BillingKeyInfoResponse::cardName).orElse(null),
+            billingKeyInfo.map(BillingKeyInfoResponse::cardNumber).orElse(null)
         );
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #158 

## 📝 작업 내용

> 마이페이지 티켓 목록 조회와 상세 조회 API를 화면 기준으로 사용할 수 있도록 개선했습니다.
- ticket-service
  - ticketId 기준 상세 조회 API 추가
  - 기존 티켓 원장 조회 기능 보강
- user-service
  -/history/tickets 목록 응답에 팝업명, 주소, 썸네일, 표시 상태값 조합
  -/history/tickets/{ticketId} 상세 조회 API 추가
  - 공통 티켓 정보 + 팝업 정보 + 구매자 정보 + 타입별 상세 정보 조합하도록 수정

- auction-service
  - AUCTION 타입 상세 조합을 위한 내부 상세 조회 API 추가

- draw-service
  - DRAW 타입 상세 조합을 위한 내부 상세 조회 API 추가
- 목록/상세 응답 DTO 분리
  - 목록은 카드형 응답 중심
  - 상세는 qrValue, 구매자 정보, 가격 정보 포함한 화면 전용 응답으로 구성

## ✅ 테스트 결과 (선택)

> 포스트맨 및 로컬 서버 실행 환경에서 확인했습니다.
- GET /history/tickets?page=0&size=20 목록 조회 성공
- GET /history/tickets/{ticketId} 상세 조회 성공
- AUCTION 타입 상세 응답 정상 확인
- DRAW 타입 상세 응답 정상 확인
- ticketId 기준 상세 조회 정상 동작 확인

## 📷 스크린샷 (선택)

> 
<img width="1217" height="920" alt="경매 티켓 발급 성공" src="https://github.com/user-attachments/assets/0eff48a1-f3ca-49ef-933b-0ac30e2258b6" />
<img width="1220" height="875" alt="드로우 티켓 발급 성공" src="https://github.com/user-attachments/assets/23896546-0635-4246-bbed-d24d381f72de" />
<img width="1202" height="855" alt="티켓 목록 조회 성공" src="https://github.com/user-attachments/assets/742a5fbe-801a-426a-ae0a-23df909abb32" />
<img width="1187" height="872" alt="티켓 상세 조회" src="https://github.com/user-attachments/assets/75cd7835-e744-44bd-8ab2-c034069fd573" />
<img width="1196" height="882" alt="티켓 상세 조회2" src="https://github.com/user-attachments/assets/2103c25f-c60f-4493-ad25-ff0c465f9c92" />


## 💬 리뷰 요구사항(선택)
