### PR TITLE
feat: CategoryIconDto에 phase 정보 추가

### DIFF
--- a/popup-service/src/main/java/com/t1/popcon/popup/categories/dto/CategoryIconDto.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/categories/dto/CategoryIconDto.java
@@ -1,8 +1,11 @@
 package com.t1.popcon.popup.categories.dto;
 
-// 카테고리 아이콘 DTO - 아이콘 이미지, 이름, 연결된 팝업 ID만 포함
+import com.t1.popcon.popup.dto.card.PopupCardDto;
+
+// 카테고리 아이콘 DTO
 public record CategoryIconDto(
     String iconUrl,
     String iconName,
-    Long popupId
+    Long popupId,
+    PopupCardDto.PhaseDto phase
 ) {}

--- a/popup-service/src/main/java/com/t1/popcon/popup/categories/service/CategoryService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/categories/service/CategoryService.java
@@ -4,6 +4,9 @@ import com.t1.popcon.common.exception.CustomException;
 import com.t1.popcon.common.exception.ErrorCode;
 import com.t1.popcon.popup.categories.dto.CategoryIconDto;
 import com.t1.popcon.popup.categories.repository.CategoryRepository;
+import com.t1.popcon.popup.detail.entity.Popup;
+import com.t1.popcon.popup.dto.card.PopupCardDto;
+import com.t1.popcon.popup.dto.card.PopupMapper;
 import com.t1.popcon.popup.dto.section.PopupSectionResponse;
 import com.t1.popcon.popup.dto.section.SectionKey;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +14,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +23,8 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
+
+    private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
 
     private final CategoryRepository categoryRepository;
 
@@ -30,16 +37,30 @@ public class CategoryService {
             throw new CustomException(ErrorCode.INVALID_INPUT, errors);
         }
 
+        LocalDateTime now = LocalDateTime.now(KST_ZONE);
+
         List<CategoryIconDto> items = categoryRepository
                 .findActiveCategoriesWithPopup(PageRequest.of(0, limit))
                 .stream()
-                .map(c -> new CategoryIconDto(
-                        c.getIconUrl(),
-                        c.getIconName(),
-                        c.getPopup().getId()
-                ))
+                .map(c -> toIconDto(c.getIconUrl(), c.getIconName(), c.getPopup(), now))
                 .toList();
 
         return PopupSectionResponse.of(SectionKey.CATEGORIES, items);
+    }
+
+    private CategoryIconDto toIconDto(String iconUrl, String iconName, Popup popup, LocalDateTime now) {
+        PopupMapper.PhaseInfo phaseInfo = PopupMapper.resolvePhase(popup, now);
+
+        return new CategoryIconDto(
+                iconUrl,
+                iconName,
+                popup.getId(),
+                new PopupCardDto.PhaseDto(
+                        phaseInfo.type(),
+                        phaseInfo.status(),
+                        phaseInfo.openAt().atZone(KST_ZONE).toOffsetDateTime(),
+                        phaseInfo.closeAt().atZone(KST_ZONE).toOffsetDateTime()
+                )
+        );
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Related to #182, #186 

## 📝 작업 내용

프론트엔드 요청으로 카테고리 섹션 응답에 phase 정보 추가
- `CategoryIconDto`에 `phase` 필드 추가 (type, status, openAt, closeAt)
- `CategoryService`에서 `PopupMapper.resolvePhase()` 를 통해 phase 계산

## ✅ 테스트 결과
> `GET /popups/categories`
<img width="697" height="594" alt="image" src="https://github.com/user-attachments/assets/4936351d-c85d-4b54-8ad0-653ee015cf5d" />
