### PR TITLE
feat: 본인인증 기반 휴대폰 번호 변경 구현

### DIFF
--- a/auth-service/src/main/java/com/t1/popcon/auth/client/user/UserServiceClient.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/client/user/UserServiceClient.java
@@ -1,11 +1,16 @@
 package com.t1.popcon.auth.client.user;
 
 import com.t1.popcon.auth.client.user.config.FeignClientConfig;
+import com.t1.popcon.auth.client.user.dto.PhoneUpdateRequest;
+import com.t1.popcon.auth.client.user.dto.UserInternalResponse;
 import com.t1.popcon.auth.client.user.dto.UserLookupResponse;
 import com.t1.popcon.common.response.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -43,5 +48,22 @@ public interface UserServiceClient {
             @RequestParam("ciHash") String ciHash,
             @RequestParam("provider") String provider,
             @RequestParam("providerUserId") String providerUserId
+    );
+
+    /**
+     * userId로 사용자 상세 정보 조회 (ciHash 포함)
+     */
+    @GetMapping("/internal/users/{userId}")
+    ApiResponse<UserInternalResponse> getUserInternal(
+            @PathVariable("userId") Long userId
+    );
+
+    /**
+     * 휴대폰 번호 변경
+     */
+    @PatchMapping("/internal/users/{userId}/phone")
+    ApiResponse<Void> updatePhone(
+            @PathVariable("userId") Long userId,
+            @RequestBody PhoneUpdateRequest request
     );
 }

--- a/auth-service/src/main/java/com/t1/popcon/auth/client/user/dto/PhoneUpdateRequest.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/client/user/dto/PhoneUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.t1.popcon.auth.client.user.dto;
+
+/**
+ * user-service의 PATCH /internal/users/{userId}/phone 요청 DTO
+ */
+public record PhoneUpdateRequest(
+        String encryptedPhone,
+        String phoneHash
+) {
+}

--- a/auth-service/src/main/java/com/t1/popcon/auth/client/user/dto/UserInternalResponse.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/client/user/dto/UserInternalResponse.java
@@ -1,0 +1,12 @@
+package com.t1.popcon.auth.client.user.dto;
+
+/**
+ * user-service의 GET /internal/users/{userId} 응답 DTO
+ */
+public record UserInternalResponse(
+        Long userId,
+        String encryptedName,
+        String encryptedPhoneNumber,
+        String ciHash
+) {
+}

--- a/auth-service/src/main/java/com/t1/popcon/auth/common/RedisRegisterTokenStore.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/common/RedisRegisterTokenStore.java
@@ -110,6 +110,7 @@ public class RedisRegisterTokenStore implements RegisterTokenStore {
             String encryptedGender,
             String encryptedBirthDate,
             String encryptedPhoneNumber,
+            String phoneHash,
             String encryptedNationality,
             long ttlSecondsToExtend
     ) {
@@ -122,6 +123,7 @@ public class RedisRegisterTokenStore implements RegisterTokenStore {
                 encryptedGender,
                 encryptedBirthDate,
                 encryptedPhoneNumber,
+                phoneHash,
                 encryptedNationality
         );
 

--- a/auth-service/src/main/java/com/t1/popcon/auth/common/RegisterPayload.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/common/RegisterPayload.java
@@ -21,6 +21,7 @@ public record RegisterPayload(
         String encryptedGender,           // 성별 (양방향 암호화)
         String encryptedBirthDate,        // 생년월일 (양방향 암호화)
         String encryptedPhoneNumber,      // 전화번호 (양방향 암호화)
+        String phoneHash,                 // 전화번호 해시 (단방향, 중복 검증용)
         String encryptedNationality       // 내외국인 여부 (양방향)
 ) {
 
@@ -37,7 +38,7 @@ public record RegisterPayload(
     ) {
         return new RegisterPayload(
                 provider, providerUserId, email, nickname, name, profileImageUrl,
-                null, null, null, null, null, null
+                null, null, null, null, null, null, null
         );
     }
 
@@ -50,11 +51,12 @@ public record RegisterPayload(
             String encryptedGender,
             String encryptedBirthDate,
             String encryptedPhoneNumber,
+            String phoneHash,
             String encryptedNationality
     ) {
         return new RegisterPayload(
                 provider, providerUserId, email, nickname, name, profileImageUrl,
-                ciHash, encryptedName, encryptedGender, encryptedBirthDate, encryptedPhoneNumber, encryptedNationality
+                ciHash, encryptedName, encryptedGender, encryptedBirthDate, encryptedPhoneNumber, phoneHash, encryptedNationality
         );
     }
 }

--- a/auth-service/src/main/java/com/t1/popcon/auth/common/RegisterTokenStore.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/common/RegisterTokenStore.java
@@ -32,6 +32,7 @@ public interface RegisterTokenStore {
             String encryptedGender,
             String encryptedBirthDate,
             String encryptedPhoneNumber,
+            String phoneHash,
             String encryptedNationality,
             long ttlSecondsToExtend
     );

--- a/auth-service/src/main/java/com/t1/popcon/auth/config/AuthSecurityConfig.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/config/AuthSecurityConfig.java
@@ -27,13 +27,13 @@ public class AuthSecurityConfig extends CommonSecurityConfig {
 		super.configureCommonSettings(http);
 
 		http.authorizeHttpRequests(auth -> auth
+			.requestMatchers("/auth/identity/phone-change").authenticated()
 			.requestMatchers(
 				"/auth/**",          // 로그인, 회원가입, 토큰 재발급 등
 				"/v3/api-docs/**",   // Swagger 관련
 				"/auth/swagger-ui/**",
 				"/health",           // 헬스체크
-					"/actuator/**"
-
+				"/actuator/**"
 			).permitAll()
 			.anyRequest().authenticated()
 		);

--- a/auth-service/src/main/java/com/t1/popcon/auth/identity/controller/PhoneChangeController.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/identity/controller/PhoneChangeController.java
@@ -1,0 +1,38 @@
+package com.t1.popcon.auth.identity.controller;
+
+import com.t1.popcon.auth.identity.dto.PhoneChangeRequest;
+import com.t1.popcon.auth.identity.dto.PhoneChangeResponse;
+import com.t1.popcon.auth.identity.service.PhoneChangeService;
+import com.t1.popcon.common.auth.domain.AuthUser;
+import com.t1.popcon.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/auth/identity")
+@RequiredArgsConstructor
+public class PhoneChangeController {
+
+    private final PhoneChangeService phoneChangeService;
+
+    /**
+     * 휴대폰 번호 변경
+     * - 개인정보 수정 페이지에서 본인인증 완료 후 호출
+     * - JWT 필수 (로그인한 사용자만 허용)
+     */
+    @PostMapping("/phone-change")
+    public ApiResponse<PhoneChangeResponse> changePhone(
+            @Valid @RequestBody PhoneChangeRequest request,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        PhoneChangeResponse response = phoneChangeService.changePhone(authUser.id(), request);
+        return ApiResponse.ok("휴대폰 번호가 성공적으로 변경되었습니다.", response);
+    }
+}

--- a/auth-service/src/main/java/com/t1/popcon/auth/identity/dto/PhoneChangeRequest.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/identity/dto/PhoneChangeRequest.java
@@ -1,0 +1,13 @@
+package com.t1.popcon.auth.identity.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 휴대폰 번호 변경 요청 DTO
+ * POST /auth/identity/phone-change
+ */
+public record PhoneChangeRequest(
+        @NotBlank(message = "본인인증 식별자가 필요합니다.")
+        String identityVerificationId
+) {
+}

--- a/auth-service/src/main/java/com/t1/popcon/auth/identity/dto/PhoneChangeResponse.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/identity/dto/PhoneChangeResponse.java
@@ -1,0 +1,9 @@
+package com.t1.popcon.auth.identity.dto;
+
+/**
+ * 휴대폰 번호 변경 성공 응답 DTO
+ */
+public record PhoneChangeResponse(
+        String phone
+) {
+}

--- a/auth-service/src/main/java/com/t1/popcon/auth/identity/service/IdentityCompleteService.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/identity/service/IdentityCompleteService.java
@@ -158,6 +158,8 @@ public class IdentityCompleteService {
 		String encryptedGender = encryptNullable(customer.gender());
 		String encryptedBirthDate = encryptionService.encrypt(customer.birthDate());
 		String encryptedPhoneNumber = encryptionService.encrypt(customer.phoneNumber());
+		// 전화번호 해시 — 회원가입 시 phone_hash 저장을 위해 plain 번호에서 단방향 해시 생성
+		String phoneHash = encryptionService.generateHash(customer.phoneNumber());
 		String encryptedForeigner = encryptNullable(
 				customer.isForeigner() == null ? null : String.valueOf(customer.isForeigner())
 		);
@@ -169,6 +171,7 @@ public class IdentityCompleteService {
 				encryptedGender,
 				encryptedBirthDate,
 				encryptedPhoneNumber,
+				phoneHash,
 				encryptedForeigner,
 				REGISTER_TOKEN_EXTEND_SECONDS
 		);

--- a/auth-service/src/main/java/com/t1/popcon/auth/identity/service/PhoneChangeService.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/identity/service/PhoneChangeService.java
@@ -1,0 +1,116 @@
+package com.t1.popcon.auth.identity.service;
+
+import com.t1.popcon.auth.client.user.UserServiceClient;
+import com.t1.popcon.auth.client.user.dto.PhoneUpdateRequest;
+import com.t1.popcon.auth.client.user.dto.UserInternalResponse;
+import com.t1.popcon.auth.identity.dto.PhoneChangeRequest;
+import com.t1.popcon.auth.identity.dto.PhoneChangeResponse;
+import com.t1.popcon.common.encryption.EncryptionService;
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.common.infrastructure.dto.PortOneIdentityVerificationResponse;
+import com.t1.popcon.common.infrastructure.portone.PortOneClient;
+import com.t1.popcon.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhoneChangeService {
+
+    private final PortOneClient portOneClient;
+    private final UserServiceClient userServiceClient;
+    private final EncryptionService encryptionService;
+
+    /**
+     * 휴대폰 번호 변경
+     * 1. PortOne 본인인증 결과 조회 및 검증
+     * 2. 신규 CI 해시와 현재 사용자의 CI 해시 비교
+     * 3. 일치 시 암호화된 번호로 업데이트
+     */
+    public PhoneChangeResponse changePhone(Long userId, PhoneChangeRequest request) {
+        log.info("휴대폰 번호 변경 시작 - identityVerificationIdHash: {}, userId: {}",
+                shortHash(request.identityVerificationId()), userId % 1000);
+
+        // PortOne 본인인증 결과 조회
+        PortOneIdentityVerificationResponse verification =
+                portOneClient.fetchIdentityVerification(request.identityVerificationId());
+
+        if (!verification.isVerified() || verification.verifiedCustomer() == null) {
+            log.warn("본인인증 검증 실패 - status: {}", verification.status());
+            throw new CustomException(ErrorCode.IDENTITY_VERIFICATION_FAILED);
+        }
+
+        PortOneIdentityVerificationResponse.VerifiedCustomer customer = verification.verifiedCustomer();
+        validateVerifiedCustomer(customer);
+
+        // 신규 CI 해시 생성
+        String ciHashNew = encryptionService.generateHash(customer.ci());
+
+        // 현재 사용자의 CI 해시 조회
+        ApiResponse<UserInternalResponse> userResponse = userServiceClient.getUserInternal(userId);
+        if (userResponse.getData() == null) {
+            log.warn("사용자 정보 조회 실패 - userId: {}", userId % 1000);
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        String ciHashCurrent = userResponse.getData().ciHash();
+
+        // CI 해시 비교 (다른 명의 휴대폰 사용 방지)
+        if (!ciHashNew.equals(ciHashCurrent)) {
+            throw new CustomException(ErrorCode.IDENTITY_VERIFICATION_FAILED, "본인 명의의 휴대폰 번호로만 변경할 수 있습니다.");
+        }
+
+        // 새 휴대폰 번호 암호화 및 해시 생성 후 저장
+        // phoneHash로 타 계정 중복 여부는 user-service에서 검증
+        String encryptedPhone = encryptionService.encrypt(customer.phoneNumber());
+        String phoneHash = encryptionService.generateHash(customer.phoneNumber());
+        userServiceClient.updatePhone(userId, new PhoneUpdateRequest(encryptedPhone, phoneHash));
+
+        log.info("휴대폰 번호 변경 완료 - userId: {}", userId % 1000);
+        return new PhoneChangeResponse(formatPhone(customer.phoneNumber()));
+    }
+
+    /**
+     * CI(해시 비교용)와 phoneNumber(저장용) 검증
+     */
+    private void validateVerifiedCustomer(PortOneIdentityVerificationResponse.VerifiedCustomer customer) {
+        if (customer.ci() == null || customer.ci().isBlank()) {
+            throw new CustomException(ErrorCode.IDENTITY_VERIFICATION_FAILED);
+        }
+        if (customer.phoneNumber() == null || customer.phoneNumber().isBlank()) {
+            throw new CustomException(ErrorCode.IDENTITY_VERIFICATION_FAILED);
+        }
+    }
+
+    /**
+     * 전화번호를 010-XXXX-XXXX 형식으로 변환
+     * PortOne 응답은 하이픈 없는 숫자열로 반환될 수 있음
+     */
+    private String formatPhone(String phone) {
+        if (phone == null || phone.isBlank()) {
+            return phone;
+        }
+        String trimmed = phone.trim();
+        if (trimmed.contains("-")) {
+            return trimmed;
+        }
+        // 11자리 순수 숫자인 경우만 하이픈 포맷 적용
+        if (trimmed.length() == 11 && trimmed.matches("\\d+")) {
+            return trimmed.substring(0, 3) + "-" + trimmed.substring(3, 7) + "-" + trimmed.substring(7);
+        }
+        return trimmed;
+    }
+
+    /**
+     * 로그용 단방향 해시 앞 8자리만 반환 (민감정보 마스킹)
+     */
+    private String shortHash(String value) {
+        if (value == null || value.isBlank()) {
+            return "null";
+        }
+        String hashed = encryptionService.generateHash(value);
+        return hashed.length() <= 8 ? hashed : hashed.substring(0, 8);
+    }
+}

--- a/auth-service/src/main/java/com/t1/popcon/auth/signup/client/dto/UserCreateRequest.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/signup/client/dto/UserCreateRequest.java
@@ -15,7 +15,8 @@ public record UserCreateRequest(
     String encryptedBirthDate,
     String encryptedGender,
     String encryptedNationality,
-    
+    String phoneHash,
+
     Boolean isMarketingAgreed
 ) {
     public static UserCreateRequest of(RegisterPayload payload, SignUpRequest.Agreements agreements) {
@@ -30,6 +31,7 @@ public record UserCreateRequest(
             payload.encryptedBirthDate(),
             payload.encryptedGender(),
             payload.encryptedNationality(),
+            payload.phoneHash(),
             agreements.isMarketingAgreed()
         );
     }

--- a/auth-service/src/main/resources/static/swagger-ui/auth/openapi3.yaml
+++ b/auth-service/src/main/resources/static/swagger-ui/auth/openapi3.yaml
@@ -76,7 +76,7 @@ paths:
                   value: "{\r\n  \"code\" : \"SUCCESS\",\r\n  \"message\" : \"약관 동\
                     의 및 회원가입이 완료되었습니다.\",\r\n  \"data\" : {\r\n    \"userId\" : 1,\r\
                     \n    \"name\" : \"홍길동\",\r\n    \"accessToken\" : \"access_token\"\
-                    ,\r\n    \"createdAt\" : \"2026-03-27T13:53:32.9351242\"\r\n \
+                    ,\r\n    \"createdAt\" : \"2026-04-13T10:18:07.1442657\"\r\n \
                     \ }\r\n}"
         '409':
           description: '409'
@@ -97,14 +97,14 @@ paths:
               examples:
                 auth-signup-fail-invalid-input:
                   value: "{\r\n  \"code\" : \"C001\",\r\n  \"message\" : \"입력값이 올바\
-                    르지 않습니다.\",\r\n  \"data\" : {\r\n    \"agreements.isIdentifierPolicyAgreed\"\
-                    \ : \"필수 동의 항목입니다.\",\r\n    \"agreements.isPrivacyPolicyAgreed\"\
+                    르지 않습니다.\",\r\n  \"data\" : {\r\n    \"agreements.isServicePolicyAgreed\"\
                     \ : \"필수 동의 항목입니다.\",\r\n    \"agreements.isMarketingAgreed\"\
-                    \ : \"선택 약관 항목이 누락되었습니다.\",\r\n    \"agreements.isServicePolicyAgreed\"\
+                    \ : \"선택 약관 항목이 누락되었습니다.\",\r\n    \"agreements.isIdentifierPolicyAgreed\"\
+                    \ : \"필수 동의 항목입니다.\",\r\n    \"agreements.isPrivacyPolicyAgreed\"\
                     \ : \"필수 동의 항목입니다.\"\r\n  }\r\n}"
                 auth-signup-fail-social-info-missing:
                   value: "{\r\n  \"code\" : \"U002\",\r\n  \"message\" : \"가입 세션의\
-                    \ 소셜 정보가 누락되었습니다.\"\r\n}"
+                    \ 소셜 정보가 유실되었습니다.\"\r\n}"
         '401':
           description: '401'
           content:
@@ -116,8 +116,8 @@ paths:
                   value: "{\r\n  \"code\" : \"A002\",\r\n  \"message\" : \"유효하지 않은\
                     \ 토큰입니다.\"\r\n}"
                 auth-signup-fail-token-expired:
-                  value: "{\r\n  \"code\" : \"A001\",\r\n  \"message\" : \"회원가입 세션\
-                    이 만료되었습니다. 다시 가입 절차를 진행해주세요.\"\r\n}"
+                  value: "{\r\n  \"code\" : \"A001\",\r\n  \"message\" : \"회원가입 인증\
+                    이 만료되었습니다. 다시 가입 절차를 진행해 주세요.\"\r\n}"
         '500':
           description: '500'
           content:
@@ -155,16 +155,16 @@ paths:
               $ref: '#/components/schemas/Complete'
             examples:
               identity-complete-existing-user-success:
-                value: "{\r\n  \"identityVerificationId\" : \"imp_1234567890\"\r\n\
-                  }"
+                value: "{\r\n  \"identityVerificationId\" : \"identity-verification-0191a111-2222-7e3c-a7d4-test12345678\"\
+                  \r\n}"
               identity-complete-fail-invalid-input:
                 value: "{\r\n  \"identityVerificationId\" : \"\"\r\n}"
               identity-complete-fail-missing-cookie:
-                value: "{\r\n  \"identityVerificationId\" : \"imp_1234567890\"\r\n\
-                  }"
+                value: "{\r\n  \"identityVerificationId\" : \"identity-verification-0191a111-2222-7e3c-a7d4-test12345678\"\
+                  \r\n}"
               identity-complete-new-user-success:
-                value: "{\r\n  \"identityVerificationId\" : \"imp_1234567890\"\r\n\
-                  }"
+                value: "{\r\n  \"identityVerificationId\" : \"identity-verification-0191a111-2222-7e3c-a7d4-test12345678\"\
+                  \r\n}"
       responses:
         '200':
           description: '200'
@@ -201,8 +201,100 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
               examples:
                 identity-complete-fail-missing-cookie:
-                  value: "{\r\n  \"code\" : \"A001\",\r\n  \"message\" : \"회원가입 세션\
-                    이 만료되었습니다. 다시 가입 절차를 진행해주세요.\"\r\n}"
+                  value: "{\r\n  \"code\" : \"A001\",\r\n  \"message\" : \"회원가입 인증\
+                    이 만료되었습니다. 다시 가입 절차를 진행해 주세요.\"\r\n}"
+  /auth/identity/phone-change:
+    post:
+      tags:
+      - Auth
+      summary: 휴대폰 번호 변경
+      description: |
+        본인인증(PortOne) 완료 후 CI 검증을 통해 휴대폰 번호를 변경합니다.
+
+        [헤더 파라미터]
+        - Authorization: (필수) Bearer {accessToken}
+
+        [에러 케이스]
+        - 400 (C001): 본인인증 식별자 누락
+        - 502 (I001): PortOne 본인인증 정보 조회 실패
+        - 401 (I002): 본인 명의의 휴대폰 번호가 아닌 경우
+        - 409 (U004): 이미 사용 중인 휴대폰 번호
+        - 401 (A002): 유효하지 않은 accessToken
+        - 401 (A003): accessToken 만료
+      operationId: phone-change-
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/PhoneChangeRequest'
+            examples:
+              phone-change-fail-ci-mismatch:
+                value: "{\r\n  \"identityVerificationId\" : \"identity-verification-0191a111-2222-7e3c-a7d4-test12345678\"\
+                  \r\n}"
+              phone-change-fail-invalid-input:
+                value: "{\r\n  \"identityVerificationId\" : \"\"\r\n}"
+              phone-change-fail-phone-in-use:
+                value: "{\r\n  \"identityVerificationId\" : \"identity-verification-0191a111-2222-7e3c-a7d4-test12345678\"\
+                  \r\n}"
+              phone-change-fail-portone-fetch:
+                value: "{\r\n  \"identityVerificationId\" : \"identity-verification-0191a111-2222-7e3c-a7d4-test12345678\"\
+                  \r\n}"
+              phone-change-success:
+                value: "{\r\n  \"identityVerificationId\" : \"identity-verification-0191a111-2222-7e3c-a7d4-test12345678\"\
+                  \r\n}"
+      responses:
+        '401':
+          description: '401'
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              examples:
+                phone-change-fail-ci-mismatch:
+                  value: "{\r\n  \"code\" : \"I002\",\r\n  \"message\" : \"본인 명의의\
+                    \ 휴대폰 번호로만 변경할 수 있습니다.\"\r\n}"
+        '400':
+          description: '400'
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              examples:
+                phone-change-fail-invalid-input:
+                  value: "{\r\n  \"code\" : \"C001\",\r\n  \"message\" : \"입력값이 올바\
+                    르지 않습니다.\",\r\n  \"data\" : {\r\n    \"identityVerificationId\"\
+                    \ : \"본인인증 식별자가 필요합니다.\"\r\n  }\r\n}"
+        '409':
+          description: '409'
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              examples:
+                phone-change-fail-phone-in-use:
+                  value: "{\r\n  \"code\" : \"U004\",\r\n  \"message\" : \"이미 사용중인\
+                    \ 휴대폰 번호입니다.\"\r\n}"
+        '502':
+          description: '502'
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              examples:
+                phone-change-fail-portone-fetch:
+                  value: "{\r\n  \"code\" : \"I001\",\r\n  \"message\" : \"본인인증 정보\
+                    \ 조회에 실패했습니다.\"\r\n}"
+        '200':
+          description: '200'
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+              examples:
+                phone-change-success:
+                  value: "{\r\n  \"code\" : \"SUCCESS\",\r\n  \"message\" : \"휴대폰\
+                    \ 번호가 성공적으로 변경되었습니다.\",\r\n  \"data\" : {\r\n    \"phone\" : \"\
+                    010-9999-9999\"\r\n  }\r\n}"
   /auth/token/refresh:
     post:
       tags:
@@ -230,7 +322,7 @@ paths:
                     \ 토큰입니다.\"\r\n}"
                 token-refresh-fail-token-expired:
                   value: "{\r\n  \"code\" : \"A003\",\r\n  \"message\" : \"인증이 만료되\
-                    었습니다. 다시 로그인해주세요.\"\r\n}"
+                    었습니다. 다시 로그인해 주세요.\"\r\n}"
         '400':
           description: '400'
           content:
@@ -300,21 +392,9 @@ components:
         data:
           type: object
           properties:
-            nextStep:
+            phone:
               type: string
-              description: nextStep
-              nullable: true
-            isNewUser:
-              type: boolean
-              description: isNewUser
-              nullable: true
-            accessToken:
-              type: string
-              description: accessToken
-              nullable: true
-            userId:
-              type: number
-              description: userId
+              description: phone
               nullable: true
           description: data
         message:
@@ -347,6 +427,14 @@ components:
           description: agreements
     Complete:
       title: Complete
+      type: object
+      properties:
+        identityVerificationId:
+          type: string
+          description: identityVerificationId
+          nullable: true
+    PhoneChangeRequest:
+      title: PhoneChangeRequest
       type: object
       properties:
         identityVerificationId:

--- a/auth-service/src/test/java/com/t1/popcon/auth/identity/controller/IdentityCompleteControllerTest.java
+++ b/auth-service/src/test/java/com/t1/popcon/auth/identity/controller/IdentityCompleteControllerTest.java
@@ -36,7 +36,7 @@ class IdentityCompleteControllerTest extends AbstractRestDocsTest {
 
 	private static final String DEFAULT_URL = "/auth/identity/complete";
 	private static final String VALID_REGISTER_TOKEN = "valid_register_token_mock";
-	private static final String VALID_VERIFICATION_ID = "imp_1234567890";
+	private static final String VALID_VERIFICATION_ID = "identity-verification-0191a111-2222-7e3c-a7d4-test12345678";
 	private static final String VALID_DEVICE_ID = "354e-4a2a-9b1b";
 
 	@Autowired

--- a/auth-service/src/test/java/com/t1/popcon/auth/identity/controller/PhoneChangeControllerTest.java
+++ b/auth-service/src/test/java/com/t1/popcon/auth/identity/controller/PhoneChangeControllerTest.java
@@ -1,0 +1,213 @@
+package com.t1.popcon.auth.identity.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.t1.popcon.auth.identity.dto.PhoneChangeRequest;
+import com.t1.popcon.auth.identity.dto.PhoneChangeResponse;
+import com.t1.popcon.auth.identity.service.PhoneChangeService;
+import com.t1.popcon.common.auth.domain.AuthUser;
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.support.AbstractRestDocsTest;
+import com.t1.popcon.support.RestDocsFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+class PhoneChangeControllerTest extends AbstractRestDocsTest {
+
+    private static final String DEFAULT_URL = "/auth/identity/phone-change";
+    private static final String VALID_VERIFICATION_ID = "identity-verification-0191a111-2222-7e3c-a7d4-test12345678";
+    private static final Long MOCK_USER_ID = 1L;
+
+    @Autowired
+    private RestDocsFactory restDocsFactory;
+
+    @MockitoBean
+    private PhoneChangeService phoneChangeService;
+
+    @Nested
+    class 휴대폰_번호_변경_API {
+
+        private static final String SUMMARY = "휴대폰 번호 변경";
+        private static final String DESCRIPTION = """
+                본인인증(PortOne) 완료 후 CI 검증을 통해 휴대폰 번호를 변경합니다.
+
+                [헤더 파라미터]
+                - Authorization: (필수) Bearer {accessToken}
+
+                [에러 케이스]
+                - 400 (C001): 본인인증 식별자 누락
+                - 502 (I001): PortOne 본인인증 정보 조회 실패
+                - 401 (I002): 본인 명의의 휴대폰 번호가 아닌 경우
+                - 409 (U004): 이미 사용 중인 휴대폰 번호
+                - 401 (A002): 유효하지 않은 accessToken
+                - 401 (A003): accessToken 만료
+                """;
+
+        @Test
+        void 성공() throws Exception {
+            // given
+            PhoneChangeRequest requestDto = new PhoneChangeRequest(VALID_VERIFICATION_ID);
+            PhoneChangeResponse responseDto = new PhoneChangeResponse("010-9999-9999");
+            ApiResponse<PhoneChangeResponse> expectedResponse =
+                    ApiResponse.ok("휴대폰 번호가 성공적으로 변경되었습니다.", responseDto);
+
+            given(phoneChangeService.changePhone(anyLong(), any()))
+                    .willReturn(responseDto);
+
+            // when & then
+            performPost(DEFAULT_URL, requestDto)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.message").value("휴대폰 번호가 성공적으로 변경되었습니다."))
+                    .andExpect(jsonPath("$.data.phone").value("010-9999-9999"))
+                    .andDo(
+                            restDocsFactory.success(
+                                    "phone-change-success",
+                                    SUMMARY,
+                                    DESCRIPTION,
+                                    "Auth",
+                                    requestDto,
+                                    expectedResponse
+                            )
+                    );
+        }
+
+        @Test
+        void 실패_잘못된_입력값() throws Exception {
+            // given
+            PhoneChangeRequest requestDto = new PhoneChangeRequest("");
+            ApiResponse<?> expectedResponse =
+                    ApiResponse.fail(ErrorCode.INVALID_INPUT,
+                            Map.of("identityVerificationId", "본인인증 식별자가 필요합니다."));
+
+            // when & then
+            performPost(DEFAULT_URL, requestDto)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C001"))
+                    .andDo(
+                            restDocsFactory.failure(
+                                    "phone-change-fail-invalid-input",
+                                    SUMMARY,
+                                    DESCRIPTION,
+                                    "Auth",
+                                    requestDto,
+                                    expectedResponse
+                            )
+                    );
+        }
+
+        @Test
+        void 실패_포트원_조회_실패() throws Exception {
+            // given
+            PhoneChangeRequest requestDto = new PhoneChangeRequest(VALID_VERIFICATION_ID);
+            ApiResponse<Void> expectedResponse =
+                    ApiResponse.fail(ErrorCode.IDENTITY_VERIFICATION_FETCH_FAILED);
+
+            given(phoneChangeService.changePhone(anyLong(), any()))
+                    .willThrow(new CustomException(ErrorCode.IDENTITY_VERIFICATION_FETCH_FAILED));
+
+            // when & then
+            performPost(DEFAULT_URL, requestDto)
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("$.code").value("I001"))
+                    .andDo(
+                            restDocsFactory.failure(
+                                    "phone-change-fail-portone-fetch",
+                                    SUMMARY,
+                                    DESCRIPTION,
+                                    "Auth",
+                                    requestDto,
+                                    expectedResponse
+                            )
+                    );
+        }
+
+        @Test
+        void 실패_CI_불일치() throws Exception {
+            // given
+            PhoneChangeRequest requestDto = new PhoneChangeRequest(VALID_VERIFICATION_ID);
+            ApiResponse<Void> expectedResponse =
+                    ApiResponse.fail("I002", "본인 명의의 휴대폰 번호로만 변경할 수 있습니다.");
+
+            given(phoneChangeService.changePhone(anyLong(), any()))
+                    .willThrow(new CustomException(ErrorCode.IDENTITY_VERIFICATION_FAILED,
+                            "본인 명의의 휴대폰 번호로만 변경할 수 있습니다."));
+
+            // when & then
+            performPost(DEFAULT_URL, requestDto)
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("I002"))
+                    .andExpect(jsonPath("$.message").value("본인 명의의 휴대폰 번호로만 변경할 수 있습니다."))
+                    .andDo(
+                            restDocsFactory.failure(
+                                    "phone-change-fail-ci-mismatch",
+                                    SUMMARY,
+                                    DESCRIPTION,
+                                    "Auth",
+                                    requestDto,
+                                    expectedResponse
+                            )
+                    );
+        }
+
+        @Test
+        void 실패_이미_사용중인_번호() throws Exception {
+            // given
+            PhoneChangeRequest requestDto = new PhoneChangeRequest(VALID_VERIFICATION_ID);
+            ApiResponse<Void> expectedResponse = ApiResponse.fail(ErrorCode.PHONE_ALREADY_IN_USE);
+
+            given(phoneChangeService.changePhone(anyLong(), any()))
+                    .willThrow(new CustomException(ErrorCode.PHONE_ALREADY_IN_USE));
+
+            // when & then
+            performPost(DEFAULT_URL, requestDto)
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("U004"))
+                    .andDo(
+                            restDocsFactory.failure(
+                                    "phone-change-fail-phone-in-use",
+                                    SUMMARY,
+                                    DESCRIPTION,
+                                    "Auth",
+                                    requestDto,
+                                    expectedResponse
+                            )
+                    );
+        }
+    }
+
+    /**
+     * 인증된 사용자로 POST 요청 수행
+     * authentication() 으로 SecurityContext에 AuthUser를 직접 주입
+     */
+    private ResultActions performPost(String url, Object body) throws Exception {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                new AuthUser(MOCK_USER_ID, List.of()), null, List.of()
+        );
+
+        MockHttpServletRequestBuilder requestBuilder =
+                (MockHttpServletRequestBuilder) restDocsFactory.createRequest(
+                        url, body, HttpMethod.POST, objectMapper
+                );
+
+        return mockMvc.perform(requestBuilder.with(authentication(auth)));
+    }
+}

--- a/auth-service/src/test/java/com/t1/popcon/auth/identity/service/PhoneChangeServiceTest.java
+++ b/auth-service/src/test/java/com/t1/popcon/auth/identity/service/PhoneChangeServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
 
 import com.t1.popcon.auth.client.user.UserServiceClient;
 import com.t1.popcon.auth.client.user.dto.PhoneUpdateRequest;
@@ -79,6 +80,11 @@ class PhoneChangeServiceTest {
 
             // then
             assertThat(response.phone()).isEqualTo("010-9999-9999");
+            // updatePhone이 올바른 encryptedPhone, phoneHash로 호출됐는지 검증
+            verify(userServiceClient).updatePhone(
+                    eq(USER_ID),
+                    eq(new PhoneUpdateRequest(ENCRYPTED_PHONE, PHONE_HASH))
+            );
         }
     }
 

--- a/auth-service/src/test/java/com/t1/popcon/auth/identity/service/PhoneChangeServiceTest.java
+++ b/auth-service/src/test/java/com/t1/popcon/auth/identity/service/PhoneChangeServiceTest.java
@@ -1,0 +1,124 @@
+package com.t1.popcon.auth.identity.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.t1.popcon.auth.client.user.UserServiceClient;
+import com.t1.popcon.auth.client.user.dto.PhoneUpdateRequest;
+import com.t1.popcon.auth.client.user.dto.UserInternalResponse;
+import com.t1.popcon.auth.identity.dto.PhoneChangeRequest;
+import com.t1.popcon.auth.identity.dto.PhoneChangeResponse;
+import com.t1.popcon.common.encryption.EncryptionService;
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.common.infrastructure.dto.PortOneIdentityVerificationResponse;
+import com.t1.popcon.common.infrastructure.portone.PortOneClient;
+import com.t1.popcon.common.response.ApiResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PhoneChangeServiceTest {
+
+    @Mock private PortOneClient portOneClient;
+    @Mock private UserServiceClient userServiceClient;
+    @Mock private EncryptionService encryptionService;
+
+    @InjectMocks
+    private PhoneChangeService phoneChangeService;
+
+    private static final Long USER_ID = 1L;
+    private static final String VERIFICATION_ID = "identity-verification-0191a111-2222-7e3c-a7d4-test12345678";
+    private static final String CI_NEW = "ci-new-raw";
+    private static final String CI_HASH_CURRENT = "hash-current";
+    private static final String CI_HASH_NEW = "hash-new";
+    private static final String PHONE_NUMBER = "01099999999";
+    private static final String PHONE_HASH = "phone-hash";
+    private static final String ENCRYPTED_PHONE = "encrypted-phone";
+
+    private PortOneIdentityVerificationResponse verificationResponse;
+
+    @BeforeEach
+    void setUp() {
+        PortOneIdentityVerificationResponse.VerifiedCustomer validCustomer =
+                new PortOneIdentityVerificationResponse.VerifiedCustomer(
+                        CI_NEW, "홍길동", "MALE", "1990-01-01", PHONE_NUMBER, false
+                );
+        verificationResponse = new PortOneIdentityVerificationResponse(VERIFICATION_ID, "VERIFIED", validCustomer);
+
+        // shortHash() 내부에서 generateHash(VERIFICATION_ID) 호출 → 로그용 masking
+        given(encryptionService.generateHash(VERIFICATION_ID)).willReturn("hashed-verification-id-for-log");
+    }
+
+    @Nested
+    class CI_일치_성공 {
+
+        @Test
+        void CI가_일치하면_전화번호를_업데이트하고_포맷된_번호를_반환한다() {
+            // given
+            given(portOneClient.fetchIdentityVerification(VERIFICATION_ID)).willReturn(verificationResponse);
+            given(encryptionService.generateHash(CI_NEW)).willReturn(CI_HASH_CURRENT); // 현재 사용자와 동일 CI
+            given(userServiceClient.getUserInternal(USER_ID))
+                    .willReturn(ApiResponse.ok(new UserInternalResponse(USER_ID, "encrypted-name", ENCRYPTED_PHONE, CI_HASH_CURRENT)));
+            given(encryptionService.encrypt(PHONE_NUMBER)).willReturn(ENCRYPTED_PHONE);
+            given(encryptionService.generateHash(PHONE_NUMBER)).willReturn(PHONE_HASH);
+            // updatePhone 리턴값은 서비스에서 사용하지 않으므로 별도 stubbing 불필요
+
+            // when
+            PhoneChangeResponse response = phoneChangeService.changePhone(USER_ID, new PhoneChangeRequest(VERIFICATION_ID));
+
+            // then
+            assertThat(response.phone()).isEqualTo("010-9999-9999");
+        }
+    }
+
+    @Nested
+    class CI_불일치_I002 {
+
+        @Test
+        void 본인_명의가_아닌_번호로_변경_시도하면_I002를_반환한다() {
+            // given: 신규 CI 해시가 현재 사용자의 CI 해시와 다름
+            given(portOneClient.fetchIdentityVerification(VERIFICATION_ID)).willReturn(verificationResponse);
+            given(encryptionService.generateHash(CI_NEW)).willReturn(CI_HASH_NEW);
+            given(userServiceClient.getUserInternal(USER_ID))
+                    .willReturn(ApiResponse.ok(new UserInternalResponse(USER_ID, "encrypted-name", ENCRYPTED_PHONE, CI_HASH_CURRENT)));
+
+            // when & then
+            assertThatThrownBy(() -> phoneChangeService.changePhone(USER_ID, new PhoneChangeRequest(VERIFICATION_ID)))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.IDENTITY_VERIFICATION_FAILED));
+        }
+    }
+
+    @Nested
+    class 휴대폰_중복_U004 {
+
+        @Test
+        void 동일_번호가_다른_계정에_등록된_경우_U004를_반환한다() {
+            // given: CI는 일치하지만 user-service에서 phoneHash 중복 감지
+            given(portOneClient.fetchIdentityVerification(VERIFICATION_ID)).willReturn(verificationResponse);
+            given(encryptionService.generateHash(CI_NEW)).willReturn(CI_HASH_CURRENT); // CI 일치
+            given(userServiceClient.getUserInternal(USER_ID))
+                    .willReturn(ApiResponse.ok(new UserInternalResponse(USER_ID, "encrypted-name", ENCRYPTED_PHONE, CI_HASH_CURRENT)));
+            given(encryptionService.encrypt(PHONE_NUMBER)).willReturn(ENCRYPTED_PHONE);
+            given(encryptionService.generateHash(PHONE_NUMBER)).willReturn(PHONE_HASH);
+            willThrow(new CustomException(ErrorCode.PHONE_ALREADY_IN_USE))
+                    .given(userServiceClient).updatePhone(eq(USER_ID), any(PhoneUpdateRequest.class));
+
+            // when & then
+            assertThatThrownBy(() -> phoneChangeService.changePhone(USER_ID, new PhoneChangeRequest(VERIFICATION_ID)))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(e -> assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.PHONE_ALREADY_IN_USE));
+        }
+    }
+}

--- a/auth-service/src/test/java/com/t1/popcon/support/AbstractRestDocsTest.java
+++ b/auth-service/src/test/java/com/t1/popcon/support/AbstractRestDocsTest.java
@@ -1,6 +1,7 @@
 package com.t1.popcon.support;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.t1.popcon.auth.token.domain.RefreshTokenRepository;
@@ -46,6 +47,7 @@ public abstract class AbstractRestDocsTest {
 	@BeforeEach
 	void setUp(RestDocumentationContextProvider restDocumentation) {
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.apply(springSecurity())
 			.apply(documentationConfiguration(restDocumentation))
 			.alwaysDo(MockMvcResultHandlers.print())
 			.addFilters(new CharacterEncodingFilter("UTF-8", true))

--- a/common/src/main/java/com/t1/popcon/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/t1/popcon/common/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND("U001", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     SOCIAL_INFO_MISSING("U002", HttpStatus.BAD_REQUEST, "가입 세션의 소셜 정보가 유실되었습니다."),
+    PHONE_ALREADY_IN_USE("U004", HttpStatus.CONFLICT, "이미 사용중인 휴대폰 번호입니다."),
 
     // Payment
     PAYMENT_FETCH_FAILED("P001", HttpStatus.BAD_GATEWAY, "결제 수단 정보 조회에 실패했습니다."),

--- a/common/src/main/java/com/t1/popcon/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/t1/popcon/common/exception/GlobalExceptionHandler.java
@@ -36,13 +36,16 @@ public class GlobalExceptionHandler {
                 )
         );
 
+        // overrideMessage가 있으면 우선 사용, 없으면 ErrorCode 기본 메시지 사용
+        String message = e.getMessage() != null ? e.getMessage() : ec.getMessage();
+
         if (e.getData() != null) {
             return ResponseEntity.status(ec.getStatus())
-                    .body(ApiResponse.fail(ec, e.getData()));
+                    .body(ApiResponse.fail(ec.getCode(), message, e.getData()));
         }
 
         return ResponseEntity.status(ec.getStatus())
-                .body(ApiResponse.fail(ec));
+                .body(ApiResponse.fail(ec.getCode(), message));
     }
 
     // DTO 검증 실패 처리

--- a/user-service/src/main/java/com/t1/popcon/user/controller/InternalUserController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/controller/InternalUserController.java
@@ -6,6 +6,7 @@ import com.t1.popcon.user.dto.UserLookupResponse;
 import com.t1.popcon.user.service.UserService;
 import com.t1.popcon.user.dto.UserCreateRequest;
 import com.t1.popcon.user.dto.UserCreateResponse;
+import com.t1.popcon.user.dto.PhoneUpdateRequest;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -68,5 +69,17 @@ public class InternalUserController {
     ) {
         userService.linkSocialByCi(ciHash, provider, providerUserId);
         return ApiResponse.ok("소셜 계정이 연결되었습니다.");
+    }
+
+    /**
+     * 휴대폰 번호 변경 (auth-service에서 본인인증 CI 검증 완료 후 호출)
+     */
+    @PatchMapping("/internal/users/{userId}/phone")
+    public ApiResponse<Void> updatePhone(
+            @PathVariable Long userId,
+            @Valid @RequestBody PhoneUpdateRequest request
+    ) {
+        userService.updatePhone(userId, request.encryptedPhone(), request.phoneHash());
+        return ApiResponse.ok("휴대폰 번호가 변경되었습니다.");
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/domain/User.java
+++ b/user-service/src/main/java/com/t1/popcon/user/domain/User.java
@@ -107,6 +107,7 @@ public class User extends BaseSoftDeleteEntity {
             String ciHash,
             String encryptedName,
             String encryptedPhoneNumber,
+            String phoneHash,
             String encryptedBirthDate,
             String encryptedGender,
             String encryptedNationality,
@@ -117,6 +118,7 @@ public class User extends BaseSoftDeleteEntity {
                 .ciHash(ciHash)
                 .encryptedName(encryptedName)
                 .encryptedPhoneNumber(encryptedPhoneNumber)
+                .phoneHash(phoneHash)
                 .encryptedBirthDate(encryptedBirthDate)
                 .encryptedGender(encryptedGender)
                 .encryptedNationality(encryptedNationality)
@@ -130,6 +132,7 @@ public class User extends BaseSoftDeleteEntity {
             String ciHash,
             String encryptedName,
             String encryptedPhoneNumber,
+            String phoneHash,
             String encryptedBirthDate,
             String encryptedGender,
             String encryptedNationality,
@@ -141,6 +144,7 @@ public class User extends BaseSoftDeleteEntity {
                 ciHash,
                 encryptedName,
                 encryptedPhoneNumber,
+                phoneHash,
                 encryptedBirthDate,
                 encryptedGender,
                 encryptedNationality,
@@ -156,6 +160,7 @@ public class User extends BaseSoftDeleteEntity {
             String ciHash,
             String encryptedName,
             String encryptedPhoneNumber,
+            String phoneHash,
             String encryptedBirthDate,
             String encryptedGender,
             String encryptedNationality,
@@ -167,6 +172,7 @@ public class User extends BaseSoftDeleteEntity {
                 ciHash,
                 encryptedName,
                 encryptedPhoneNumber,
+                phoneHash,
                 encryptedBirthDate,
                 encryptedGender,
                 encryptedNationality,

--- a/user-service/src/main/java/com/t1/popcon/user/domain/User.java
+++ b/user-service/src/main/java/com/t1/popcon/user/domain/User.java
@@ -35,7 +35,8 @@ import java.util.List;
         @UniqueConstraint(name = "uk_users_ci_hash", columnNames = "ci_hash"),
         @UniqueConstraint(name = "uk_users_nickname", columnNames = "nickname"),
         @UniqueConstraint(name = "uk_users_kakao_user_id", columnNames = "kakao_user_id"),
-        @UniqueConstraint(name = "uk_users_naver_user_id", columnNames = "naver_user_id")
+        @UniqueConstraint(name = "uk_users_naver_user_id", columnNames = "naver_user_id"),
+        @UniqueConstraint(name = "uk_users_phone_hash", columnNames = "phone_hash")
     },
     indexes = {
         @Index(name = "idx_users_status", columnList = "status"),
@@ -54,6 +55,10 @@ public class User extends BaseSoftDeleteEntity {
 
     @Column(name = "encrypted_phone_number", length = 255, nullable = false)
     private String encryptedPhoneNumber;
+
+    /** SHA-256 해시값 — 전화번호 중복 여부 확인 및 조회용 (복호화 없이 비교 가능) */
+    @Column(name = "phone_hash", length = 64)
+    private String phoneHash;
 
     @Column(name = "encrypted_birth_date", length = 255, nullable = false)
     private String encryptedBirthDate;
@@ -181,6 +186,11 @@ public class User extends BaseSoftDeleteEntity {
     public void connectNaver(String naverUserId, LocalDateTime connectedAt) {
         this.naverUserId = naverUserId;
         this.naverConnectedAt = connectedAt;
+    }
+
+    public void updatePhoneNumber(String encryptedPhoneNumber, String phoneHash) {
+        this.encryptedPhoneNumber = encryptedPhoneNumber;
+        this.phoneHash = phoneHash;
     }
 
     public void block() {

--- a/user-service/src/main/java/com/t1/popcon/user/dto/PhoneUpdateRequest.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/PhoneUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.t1.popcon.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 휴대폰 번호 변경 내부 요청 DTO
+ */
+public record PhoneUpdateRequest(
+        @NotBlank(message = "암호화된 휴대폰 번호가 필요합니다.")
+        String encryptedPhone
+) {
+}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/PhoneUpdateRequest.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/PhoneUpdateRequest.java
@@ -1,12 +1,18 @@
 package com.t1.popcon.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 /**
  * 휴대폰 번호 변경 내부 요청 DTO
  */
 public record PhoneUpdateRequest(
         @NotBlank(message = "암호화된 휴대폰 번호가 필요합니다.")
-        String encryptedPhone
+        @Size(max = 255, message = "암호화된 휴대폰 번호가 너무 깁니다.")
+        String encryptedPhone,
+
+        @NotBlank(message = "전화번호 해시가 필요합니다.")
+        @Size(max = 64)
+        String phoneHash
 ) {
 }

--- a/user-service/src/main/java/com/t1/popcon/user/dto/UserCreateRequest.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/UserCreateRequest.java
@@ -15,6 +15,7 @@ public record UserCreateRequest(
     @NotBlank String encryptedBirthDate,
     String encryptedGender,
     String encryptedNationality,
+    String phoneHash,
     
     @NotNull Boolean isMarketingAgreed
 ) {}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/UserCreateRequest.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/UserCreateRequest.java
@@ -15,7 +15,7 @@ public record UserCreateRequest(
     @NotBlank String encryptedBirthDate,
     String encryptedGender,
     String encryptedNationality,
-    String phoneHash,
+    @NotBlank String phoneHash,
     
     @NotNull Boolean isMarketingAgreed
 ) {}

--- a/user-service/src/main/java/com/t1/popcon/user/dto/UserInternalResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/UserInternalResponse.java
@@ -3,6 +3,7 @@ package com.t1.popcon.user.dto;
 public record UserInternalResponse(
     Long userId,
     String encryptedName,
-    String encryptedPhoneNumber
+    String encryptedPhoneNumber,
+    String ciHash
 ) {
 }

--- a/user-service/src/main/java/com/t1/popcon/user/dto/UserProfileResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/UserProfileResponse.java
@@ -25,11 +25,22 @@ public record UserProfileResponse(
                 name,
                 user.getNickname(),
                 user.getEmail(),
-                phone,
+                formatPhone(phone),
                 (birthDate != null && !birthDate.isBlank()) ? LocalDate.parse(birthDate.trim()) : null,
                 gender,
                 user.getProfileImageUrl(),
                 user.getCreatedAt() != null ? user.getCreatedAt().toLocalDate() : null
         );
+    }
+
+    /** 전화번호를 010-XXXX-XXXX 형식으로 변환 */
+    private static String formatPhone(String phone) {
+        if (phone == null || phone.isBlank() || phone.contains("-")) {
+            return phone;
+        }
+        if (phone.length() == 11) {
+            return phone.substring(0, 3) + "-" + phone.substring(3, 7) + "-" + phone.substring(7);
+        }
+        return phone;
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/repository/UserRepository.java
+++ b/user-service/src/main/java/com/t1/popcon/user/repository/UserRepository.java
@@ -14,5 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoUserId(String kakaoUserId);
     Optional<User> findByNaverUserId(String naverUserId);
 
+    Optional<User> findByPhoneHash(String phoneHash);
+
     boolean existsByNickname(String nickname);
     }

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -28,6 +28,7 @@ public class UserService {
 
     private static final int MAX_NICKNAME_RETRIES = 5;
     private static final String NICKNAME_CONSTRAINT = "uk_users_nickname";
+    private static final String PHONE_HASH_CONSTRAINT = "uk_users_phone_hash";
 
     private final UserRepository userRepository;
     private final EncryptionService encryptionService;
@@ -81,6 +82,7 @@ public class UserService {
                         request.ciHash(),
                         request.encryptedName(),
                         request.encryptedPhoneNumber(),
+                        request.phoneHash(),
                         request.encryptedBirthDate(),
                         request.encryptedGender(),
                         request.encryptedNationality(),
@@ -92,6 +94,7 @@ public class UserService {
                         request.ciHash(),
                         request.encryptedName(),
                         request.encryptedPhoneNumber(),
+                        request.phoneHash(),
                         request.encryptedBirthDate(),
                         request.encryptedGender(),
                         request.encryptedNationality(),
@@ -209,15 +212,18 @@ public class UserService {
 
     /**
      * 휴대폰 번호 변경 (본인인증 CI 검증 완료 후 auth-service에서 호출)
-     * phoneHash로 타 계정 중복 여부를 먼저 확인 후 업데이트
+     * phoneHash로 타 계정 중복 여부 사전 확인 + DB 제약 위반 시에도 U004 반환
      */
     @Transactional
     public void updatePhone(Long userId, String encryptedPhone, String phoneHash) {
         if (encryptedPhone == null || encryptedPhone.isBlank()) {
             throw new CustomException(ErrorCode.INVALID_INPUT);
         }
+        if (phoneHash == null || phoneHash.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
 
-        // 동일 번호가 다른 계정에 이미 등록되어 있는지 확인
+        // 동일 번호가 다른 계정에 이미 등록되어 있는지 사전 확인 (레이스 컨디션 보완은 아래 catch에서 처리)
         userRepository.findByPhoneHash(phoneHash)
                 .filter(existing -> !existing.getId().equals(userId))
                 .ifPresent(existing -> {
@@ -226,6 +232,24 @@ public class UserService {
 
         User user = getUserOrThrow(userId);
         user.updatePhoneNumber(encryptedPhone, phoneHash);
+
+        try {
+            // flush를 강제하여 레이스 컨디션 시 DB 제약 위반을 트랜잭션 내에서 잡음
+            userRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException e) {
+            if (isPhoneHashConflict(e)) {
+                throw new CustomException(ErrorCode.PHONE_ALREADY_IN_USE);
+            }
+            throw e;
+        }
+    }
+
+    private boolean isPhoneHashConflict(DataIntegrityViolationException e) {
+        Throwable cause = e.getRootCause();
+        if (cause instanceof ConstraintViolationException hibernateEx) {
+            return PHONE_HASH_CONSTRAINT.equals(hibernateEx.getConstraintName());
+        }
+        return e.getMessage() != null && e.getMessage().contains(PHONE_HASH_CONSTRAINT);
     }
 
     @Transactional

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -60,7 +60,8 @@ public class UserService {
         return new UserInternalResponse(
                 user.getId(),
                 user.getEncryptedName(),
-                user.getEncryptedPhoneNumber()
+                user.getEncryptedPhoneNumber(),
+                user.getCiHash()
         );
     }
 
@@ -204,6 +205,27 @@ public class UserService {
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         user.connectNaver(naverUserId, LocalDateTime.now());
+    }
+
+    /**
+     * 휴대폰 번호 변경 (본인인증 CI 검증 완료 후 auth-service에서 호출)
+     * phoneHash로 타 계정 중복 여부를 먼저 확인 후 업데이트
+     */
+    @Transactional
+    public void updatePhone(Long userId, String encryptedPhone, String phoneHash) {
+        if (encryptedPhone == null || encryptedPhone.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        // 동일 번호가 다른 계정에 이미 등록되어 있는지 확인
+        userRepository.findByPhoneHash(phoneHash)
+                .filter(existing -> !existing.getId().equals(userId))
+                .ifPresent(existing -> {
+                    throw new CustomException(ErrorCode.PHONE_ALREADY_IN_USE);
+                });
+
+        User user = getUserOrThrow(userId);
+        user.updatePhoneNumber(encryptedPhone, phoneHash);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #206 

## 📝 작업 내용

- **`POST /auth/identity/phone-change`** API 구현 (JWT 필수)
- PortOne 본인인증 CI 해시 비교 → 본인 명의 검증 → 전화번호 암호화 저장 및 포맷 반환
- **`User` 엔티티에 `phone_hash` 컬럼 추가**, 회원가입/번호 변경 시 모두 저장
- 동일 번호 타 계정 등록 시 U004 반환 (pre-check + DB 제약 위반 레이스 컨디션 처리)
- `PATCH /internal/users/{userId}/phone` 내부 API 구현 (auth-service → user-service)
- `UserInternalResponse`에 `ciHash` 추가 (draw-service 하위호환 유지)
- 프로필 조회 전화번호 포맷(010-XXXX-XXXX) 적용
- `CustomException` overrideMessage 지원 → 에러 코드 동일, 상황별 메시지 분리


## ✅ 테스트 결과

> **PhoneChangeControllerTest** — 5개 케이스 통과, Swagger 문서화 완료

| 케이스 | 예상 응답 | 결과 |
|---|---|---|
| 성공 | 200 SUCCESS | ✅ |
| 입력값 오류 (identityVerificationId 누락) | 400 C001 | ✅ |
| PortOne 조회 실패 | 502 I001 | ✅ |
| CI 불일치 (다른 명의 휴대폰) | 401 I002 | ✅ |
| 이미 사용 중인 번호 | 409 U004 | ✅ |

> **PhoneChangeServiceTest** — 3개 케이스 통과

| 케이스 | 결과 |
|---|---|
| CI 일치 → 전화번호 변경 성공 | ✅ |
| CI 불일치 → I002 | ✅ |
| 동일 번호 타 계정 등록 → U004 전파 | ✅ |
## 💬 리뷰 요구사항

> CI 불일치 / 이미 사용 중인 번호 에러 케이스 분기 로직 확인 부탁드립니다.
> 이미 사용 중인 번호일 경우 처리 방식은 기획팀 결정에 따라 추가 수정 가능합니다.