### PR TITLE
fix: 보안퀴즈 테스트를 위해 block-ttl을 1800 -> 60초로 임시 수정

### DIFF
--- a/queue-service/src/main/resources/application.yml
+++ b/queue-service/src/main/resources/application.yml
@@ -28,7 +28,7 @@ queue:
   cleanup-interval-ms: 60000
   heartbeat-cleanup-interval-ms: 10000
   heartbeat-ttl-seconds: 15
-  block-ttl-seconds: 1800
+  block-ttl-seconds: 60
   active-ttl:
     draw-seconds: 900
     auction-seconds: 3600

--- a/queue-worker/src/main/resources/application.yml
+++ b/queue-worker/src/main/resources/application.yml
@@ -17,7 +17,7 @@ queue:
   cleanup-interval-ms: 60000
   heartbeat-cleanup-interval-ms: 10000
   heartbeat-ttl-seconds: 15
-  block-ttl-seconds: 1800
+  block-ttl-seconds: 60
   active-ttl:
     draw-seconds: 900
     auction-seconds: 3600

--- a/queue-worker/src/test/resources/application-test.yml
+++ b/queue-worker/src/test/resources/application-test.yml
@@ -15,7 +15,7 @@ queue:
   cleanup-interval-ms: 60000
   heartbeat-cleanup-interval-ms: 10000
   heartbeat-ttl-seconds: 15
-  block-ttl-seconds: 1800
+  block-ttl-seconds: 60
   active-ttl:
     draw-seconds: 900
     auction-seconds: 3600


### PR DESCRIPTION
## #️⃣ 관련 이슈

> x

## 📝 작업 내용

> 보안퀴즈 테스트를 위해 block-ttl을 1800 -> 60초로 임시 수정