### PR TITLE
fix: 퀴즈 block 해제 후 재시도 시 QUIZ_ATTEMPTS_EXCEEDED 오류 수정

### DIFF
--- a/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
@@ -43,7 +43,6 @@ public class VqaService {
     private static final String VQA_LOCK_START_PREFIX = "lock:vqa:start:";
     
     private static final long VQA_SESSION_TTL_SECONDS = 600; // 10분
-    private static final long VQA_GLOBAL_LOCKOUT_TTL_SECONDS = 1800; // 30분
     private static final int MAX_ATTEMPTS = 3;
 
     /**
@@ -210,7 +209,8 @@ public class VqaService {
             int nextAttempts = (nextAttemptsLong != null) ? nextAttemptsLong.intValue() : 0;
             
             if (nextAttempts == 1) {
-                redisTemplate.expire(globalKey, Duration.ofSeconds(VQA_GLOBAL_LOCKOUT_TTL_SECONDS));
+                // globalAttempts TTL을 blockTtlSeconds와 동기화 (block 해제 시 재시도 가능하도록)
+                redisTemplate.expire(globalKey, Duration.ofSeconds(queueProperties.getBlockTtlSeconds()));
             }
 
             if (nextAttempts >= MAX_ATTEMPTS) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
> Closes #210 
> Related to #208 

## 📝 작업 내용

VqaService.java
- `VQA_GLOBAL_LOCKOUT_TTL_SECONDS`(1800s 하드코딩) 제거
- globalAttempts 키 TTL을 `queueProperties.getBlockTtlSeconds()`로 변경
- block TTL과 globalAttempts TTL 불일치로 인해 block 해제 후에도 시도 횟수 초과 에러가 발생하던 문제 해결