### PR TITLE
feat: 마케팅 수신 동의 여부 저장 구현

### DIFF
--- a/user-service/src/main/java/com/t1/popcon/user/domain/User.java
+++ b/user-service/src/main/java/com/t1/popcon/user/domain/User.java
@@ -91,6 +91,10 @@ public class User extends BaseSoftDeleteEntity {
     @Column(name = "naver_connected_at")
     private LocalDateTime naverConnectedAt;
 
+    /** 마케팅 수신 동의 여부 (회원가입 시 선택) */
+    @Column(name = "is_marketing_agreed", nullable = false)
+    private boolean isMarketingAgreed;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = 10)
     private Role role;
@@ -112,7 +116,8 @@ public class User extends BaseSoftDeleteEntity {
             String encryptedGender,
             String encryptedNationality,
             String nickname,
-            String email
+            String email,
+            boolean isMarketingAgreed
     ) {
         return User.builder()
                 .ciHash(ciHash)
@@ -124,6 +129,7 @@ public class User extends BaseSoftDeleteEntity {
                 .encryptedNationality(encryptedNationality)
                 .nickname(nickname)
                 .email(email)
+                .isMarketingAgreed(isMarketingAgreed)
                 .role(Role.USER)
                 .status(UserStatus.ACTIVE);
     }
@@ -138,6 +144,7 @@ public class User extends BaseSoftDeleteEntity {
             String encryptedNationality,
             String nickname,
             String email,
+            boolean isMarketingAgreed,
             String kakaoUserId
     ) {
         User user = baseBuilder(
@@ -149,7 +156,8 @@ public class User extends BaseSoftDeleteEntity {
                 encryptedGender,
                 encryptedNationality,
                 nickname,
-                email
+                email,
+                isMarketingAgreed
         ).build();
 
         user.connectKakao(kakaoUserId, LocalDateTime.now());
@@ -166,6 +174,7 @@ public class User extends BaseSoftDeleteEntity {
             String encryptedNationality,
             String nickname,
             String email,
+            boolean isMarketingAgreed,
             String naverUserId
     ) {
         User user = baseBuilder(
@@ -177,7 +186,8 @@ public class User extends BaseSoftDeleteEntity {
                 encryptedGender,
                 encryptedNationality,
                 nickname,
-                email
+                email,
+                isMarketingAgreed
         ).build();
 
         user.connectNaver(naverUserId, LocalDateTime.now());

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -107,6 +107,7 @@ public class UserService {
                         request.encryptedNationality(),
                         currentNickname,
                         request.email(),
+                        Boolean.TRUE.equals(request.isMarketingAgreed()),
                         request.providerUserId()
                 );
                 case "NAVER" -> User.createUserWithNaver(
@@ -119,6 +120,7 @@ public class UserService {
                         request.encryptedNationality(),
                         currentNickname,
                         request.email(),
+                        Boolean.TRUE.equals(request.isMarketingAgreed()),
                         request.providerUserId()
                 );
                 default -> throw new CustomException(ErrorCode.INVALID_PROVIDER);


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #205 

## 📝 작업 내용

- `User` 엔티티에 `is_marketing_agreed` 컬럼 추가
- `createUserWithKakao/Naver` 및 `baseBuilder`에 `isMarketingAgreed` 파라미터 추가
- `UserService.createUser`에서 `UserCreateRequest.isMarketingAgreed()` 전달
  - `isMarketingAgreed`가 `Boolean` (nullable) 타입이라 `Boolean.TRUE.equals()`로 null이 들어와도 false로 안전하게 처리
 