### PR TITLE
chore(anti-macro): 전체 요청 로깅, IP 추출, gzip 지원

### DIFF
--- a/anti-macro-service/src/analysis/analyze.ts
+++ b/anti-macro-service/src/analysis/analyze.ts
@@ -77,8 +77,8 @@ export function analyzeRawData(payload: PageSignalPayload): AnalysisResult {
       });
     }
 
-    // Medium: 클릭 간격 일정성
-    if (intervals.length >= 2) {
+    // Medium: 클릭 간격 일정성 (샘플 부족 시 stddev 신뢰도 낮아 최소 4 interval = 5 clicks)
+    if (intervals.length >= 4) {
       const intervalStddev = stddev(intervals);
       if (intervalStddev < THRESHOLDS.CLICK_INTERVAL_STDDEV_MS) {
         detected.push({

--- a/anti-macro-service/src/index.ts
+++ b/anti-macro-service/src/index.ts
@@ -6,6 +6,7 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 import express from 'express';
 import cors from 'cors';
+import zlib from 'zlib';
 import signalsRouter from './routes/signals';
 import { env } from './config/env';
 import { redis, waitForRedis } from './config/redis';
@@ -15,6 +16,47 @@ import type { Server } from 'http';
 const app = express();
 
 app.use(cors());
+
+// gzip 요청 본문 해제 후 JSON 파싱
+const MAX_BODY_BYTES = 1024 * 1024; // 1MB
+app.use((req, res, next) => {
+  if (req.headers['content-encoding'] !== 'gzip') return next();
+  if (req.method === 'GET' || req.method === 'HEAD') return next();
+
+  const chunks: Buffer[] = [];
+  let received = 0;
+  req.on('data', (chunk: Buffer) => {
+    received += chunk.length;
+    if (received > MAX_BODY_BYTES * 2) {
+      req.destroy();
+      res.status(413).json({ error: 'payload too large' });
+      return;
+    }
+    chunks.push(chunk);
+  });
+  req.on('end', () => {
+    zlib.gunzip(Buffer.concat(chunks), (err, decoded) => {
+      if (err) return res.status(400).json({ error: 'invalid gzip body' });
+      if (decoded.length > MAX_BODY_BYTES) {
+        return res.status(413).json({ error: 'payload too large' });
+      }
+      try {
+        const contentType = req.headers['content-type'] || '';
+        if (contentType.includes('application/json')) {
+          req.body = JSON.parse(decoded.toString('utf8'));
+        } else {
+          req.body = decoded;
+        }
+        delete req.headers['content-encoding'];
+        next();
+      } catch {
+        res.status(400).json({ error: 'invalid JSON' });
+      }
+    });
+  });
+  req.on('error', next);
+});
+
 app.use(express.json({ limit: '1mb' }));
 
 // 라우트

--- a/anti-macro-service/src/routes/signals.ts
+++ b/anti-macro-service/src/routes/signals.ts
@@ -13,6 +13,19 @@ function maskId(id?: string): string {
   return id.slice(0, 4) + '****';
 }
 
+/** Cloudflare 뒤에서 실제 클라이언트 IP 추출 */
+function getClientIp(req: Request): string | undefined {
+  const cfIp = req.headers['cf-connecting-ip'];
+  if (typeof cfIp === 'string' && cfIp.length > 0) return cfIp;
+
+  const xff = req.headers['x-forwarded-for'];
+  if (typeof xff === 'string' && xff.length > 0) {
+    return xff.split(',')[0].trim();
+  }
+
+  return req.ip || req.socket?.remoteAddress;
+}
+
 // POST /signals - raw 데이터 수신 + 분석
 router.post('/signals', async (req: Request, res: Response) => {
   try {
@@ -43,11 +56,13 @@ router.post('/signals', async (req: Request, res: Response) => {
     const totalScore = identityKey ? await getTotalScore(identityKey) : result.score;
 
     // 3. 로그 출력 (ID 마스킹)
-    console.log(`[anti-macro] page=${payload.page} score=${result.score} total=${totalScore} vqaLevel=${result.vqaLevel}`, {
-      signals: result.detectedSignals.map((s) => `${s.name}(${s.weight})`),
-      visitorId: maskId(body.visitorId),
-      userId: maskId(body.userId),
-    });
+    console.log(
+      `[anti-macro] user=${maskId(body.userId)} visitor=${maskId(body.visitorId)} page=${payload.page} ` +
+      `pageScore=${result.score} totalScore=${totalScore} vqaLevel=${result.vqaLevel}`,
+      {
+        signals: result.detectedSignals.map((s) => `${s.name}(${s.weight})`),
+      }
+    );
 
     // 4. 의심 로그 DB 저장 (score > 0이면 저장, fire-and-forget)
     if (identityKey) {
@@ -59,7 +74,7 @@ router.post('/signals', async (req: Request, res: Response) => {
         pageScore: result.score,
         totalScore,
         result,
-        ipAddress: req.ip || req.socket?.remoteAddress,
+        ipAddress: getClientIp(req),
         userAgent: req.headers['user-agent'],
         rawSummary: {
           clicks: payload.rawData.clicks?.length ?? 0,

--- a/anti-macro-service/src/routes/signals.ts
+++ b/anti-macro-service/src/routes/signals.ts
@@ -64,7 +64,7 @@ router.post('/signals', async (req: Request, res: Response) => {
       }
     );
 
-    // 4. 의심 로그 DB 저장 (score > 0이면 저장, fire-and-forget)
+    // 4. 시그널 로그 DB 저장 (fire-and-forget)
     if (identityKey) {
       saveIfSuspicious({
         visitorId: body.visitorId,

--- a/anti-macro-service/src/services/suspicious-logger.ts
+++ b/anti-macro-service/src/services/suspicious-logger.ts
@@ -15,15 +15,13 @@ type LogParams = {
 };
 
 /**
- * 의심 로그 DB 저장 (fire-and-forget)
- * score > 0이면 저장 (시그널이 하나라도 감지된 경우)
+ * 시그널 로그 DB 저장 (fire-and-forget)
+ * 모든 요청 저장
  */
 export function saveIfSuspicious(params: LogParams): void {
-  if (params.pageScore <= 0) return; // 정상이면 저장 안 함
-
   // fire-and-forget: await 안 함
   insertLog(params).catch((err) => {
-    console.error('[db] 의심 로그 저장 실패:', err.message);
+    console.error('[db] 시그널 로그 저장 실패:', err.message);
   });
 }
 
@@ -51,5 +49,5 @@ async function insertLog(params: LogParams): Promise<void> {
     params.userAgent || null,
   ]);
 
-  console.log(`[db] 의심 로그 저장: page=${params.page} score=${params.pageScore} total=${params.totalScore}`);
+  console.log(`[db] 시그널 로그 저장: page=${params.page} score=${params.pageScore} total=${params.totalScore}`);
 }


### PR DESCRIPTION
## Summary
- 모든 시그널 요청을 DB에 저장 (기존: score > 0 조건)
- Cloudflare 뒤 실제 클라이언트 IP 추출 (`CF-Connecting-IP` 우선)
- 시그널 분석 결과를 콘솔 로그로 출력
- `click_interval_uniform` 최소 샘플 2 → 4 interval (5 clicks)
- 프론트의 gzip 압축 요청 본문 해제 미들웨어 추가

## Deploy 순서
1. **백엔드 먼저 배포** — gzip 미들웨어는 비압축 요청에 영향 없음 (호환)
2. 프론트엔드 배포 (별도 PR) — `Content-Encoding: gzip`으로 전송

백엔드를 먼저 배포하지 않으면 프론트 압축 요청이 파싱 실패해 로그/분석이 스킵됨.

## Test plan
- [ ] 배포 후 기존(비압축) 시그널 요청이 정상 처리되는지 (로그 찍힘, DB 저장)
- [ ] 프론트 배포 후 gzip 요청 본문이 해제되어 정상 처리되는지
- [ ] `macro_detection_log.ip_address`에 실제 클라이언트 IP 기록되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)