### PR TITLE
fix: auth-service Feign PATCH 메서드 호출 실패 수정

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-okhttp'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
+
   datasource:
     url: jdbc:h2:mem:popcon
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #227 

## 📝 작업 내용

**문제**
- 휴대폰 번호 변경 시 `PATCH /internal/users/{userId}/phone` Feign 호출에서 `Invalid HTTP method: PATCH` 예외 발생
- Java 기본 HTTP 클라이언트(`HttpURLConnection`)가 PATCH 메서드를 지원하지 않아 발생

**변경 사항**
- `feign-okhttp` 의존성 추가
- `spring.cloud.openfeign.okhttp.enabled: true` 설정 추가