### PR TITLE
fix: auth-service FeignClient 409 응답 에러코드 전파 누락 수정

### DIFF
--- a/auth-service/src/main/java/com/t1/popcon/auth/client/user/config/FeignClientConfig.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/client/user/config/FeignClientConfig.java
@@ -1,14 +1,22 @@
 package com.t1.popcon.auth.client.user.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.t1.popcon.common.exception.CustomException;
 import com.t1.popcon.common.exception.ErrorCode;
 import feign.RequestInterceptor;
 import feign.Response;
 import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+@Slf4j
 @Configuration
 public class FeignClientConfig {
 
@@ -29,6 +37,7 @@ public class FeignClientConfig {
     static class UserServiceFeignErrorDecoder implements ErrorDecoder {
 
         private final ErrorDecoder defaultDecoder = new ErrorDecoder.Default();
+        private final ObjectMapper objectMapper = new ObjectMapper();
 
         @Override
         public Exception decode(String methodKey, Response response) {
@@ -43,8 +52,33 @@ public class FeignClientConfig {
             if (status == 401) {
                 return new CustomException(ErrorCode.ERROR_SYSTEM, "내부 API 인증에 실패했습니다.");
             }
+            // 409 응답의 에러 코드를 파싱하여 user-service 에러를 그대로 전파
+            if (status == 409) {
+                return parseErrorCode(response);
+            }
 
             return defaultDecoder.decode(methodKey, response);
+        }
+
+        /**
+         * 응답 본문에서 code 필드를 파싱하여 일치하는 ErrorCode로 CustomException 반환
+         * 파싱 실패 시 S001 반환
+         */
+        private CustomException parseErrorCode(Response response) {
+            try {
+                byte[] body = response.body().asInputStream().readAllBytes();
+                JsonNode node = objectMapper.readTree(new String(body, StandardCharsets.UTF_8));
+                String code = node.path("code").asText();
+
+                return Arrays.stream(ErrorCode.values())
+                        .filter(e -> e.getCode().equals(code))
+                        .findFirst()
+                        .map(CustomException::new)
+                        .orElse(new CustomException(ErrorCode.ERROR_SYSTEM, "user-service 충돌 오류"));
+            } catch (IOException e) {
+                log.warn("[FeignClientConfig] 409 응답 파싱 실패 - url: {}", response.request().url());
+                return new CustomException(ErrorCode.ERROR_SYSTEM, "user-service 충돌 오류");
+            }
         }
     }
 }

--- a/auth-service/src/main/java/com/t1/popcon/auth/client/user/config/FeignClientConfig.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/client/user/config/FeignClientConfig.java
@@ -54,7 +54,7 @@ public class FeignClientConfig {
             }
             // 409 응답의 에러 코드를 파싱하여 user-service 에러를 그대로 전파
             if (status == 409) {
-                return parseErrorCode(response);
+                return parseErrorCode(response, status);
             }
 
             return defaultDecoder.decode(methodKey, response);
@@ -64,8 +64,11 @@ public class FeignClientConfig {
          * 응답 본문에서 code 필드를 파싱하여 일치하는 ErrorCode로 CustomException 반환
          * 파싱 실패 시 S001 반환
          */
-        private CustomException parseErrorCode(Response response) {
+        private CustomException parseErrorCode(Response response, int status) {
             try {
+                if (response.body() == null) {
+                    return new CustomException(ErrorCode.ERROR_SYSTEM, "user-service 오류");
+                }
                 byte[] body = response.body().asInputStream().readAllBytes();
                 JsonNode node = objectMapper.readTree(new String(body, StandardCharsets.UTF_8));
                 String code = node.path("code").asText();
@@ -74,10 +77,10 @@ public class FeignClientConfig {
                         .filter(e -> e.getCode().equals(code))
                         .findFirst()
                         .map(CustomException::new)
-                        .orElse(new CustomException(ErrorCode.ERROR_SYSTEM, "user-service 충돌 오류"));
+                        .orElse(new CustomException(ErrorCode.ERROR_SYSTEM, "user-service 오류"));
             } catch (IOException e) {
-                log.warn("[FeignClientConfig] 409 응답 파싱 실패 - url: {}", response.request().url());
-                return new CustomException(ErrorCode.ERROR_SYSTEM, "user-service 충돌 오류");
+                log.warn("[FeignClientConfig] {}  응답 파싱 실패 - url: {}", status, response.request().url());
+                return new CustomException(ErrorCode.ERROR_SYSTEM, "user-service 오류");
             }
         }
     }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #230 

## 📝 작업 내용

> FeignClient ErrorDecoder 409 처리 추가 → user-service 에러코드 그대로 전파
> FeignClient parseErrorCode null 체크 및 상태코드 파라미터화

## ✅ 테스트 결과

<img width="707" height="380" alt="image" src="https://github.com/user-attachments/assets/d2afb453-1fe3-43c1-83d2-d56c27941035" />