### PR TITLE
fix: 낙찰시 결제 시각 수정 + 낙찰 내역 확인 페이지 시큐리티 설정 + 1인 1회 제한 정책

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/domain/Bid.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/domain/Bid.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +23,9 @@ import java.time.LocalTime;
 
 @Entity
 @Getter
-@Table(name = "bids")
+@Table(name = "bids", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"user_id", "auction_id"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted = false")
 public class Bid extends BaseSoftDeleteEntity {

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/domain/Bid.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/domain/Bid.java
@@ -24,7 +24,7 @@ import java.time.LocalTime;
 @Entity
 @Getter
 @Table(name = "bids", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"user_id", "auction_id"})
+    @UniqueConstraint(columnNames = {"user_id", "auction_id", "status"})
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted = false")

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
@@ -46,4 +46,6 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 		"WHERE b.userId = :userId AND b.status = :status AND b.deleted = false " +
 		"ORDER BY b.createdAt DESC")
 	List<Bid> findAllByUserIdAndStatusOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("status") BidStatus status);
+
+	boolean existsByUserIdAndAuctionIdAndStatus(Long userId, Long auctionId, BidStatus status);
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -218,7 +218,11 @@ public class BidService {
             boolean paymentAttempted = false;
 
             try {
-                bid = txManager.preparePendingBid(userId, option, currentServerPrice, merchantUid);
+                try {
+                    bid = txManager.preparePendingBid(userId, option, currentServerPrice, merchantUid);
+                } catch (DataIntegrityViolationException e) {
+                    throw new CustomException(ErrorCode.AUCTION_ALREADY_PARTICIPATED);
+                }
 
                 ApiResponse<BillingKeyInternalResponse> billingKeyResponse = userBillingClient.getDefaultBillingKey(userId);
                 if (billingKeyResponse == null || billingKeyResponse.getData() == null) {

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -29,6 +29,7 @@ import com.t1.popcon.common.infrastructure.portone.PortOneClient;
 import com.t1.popcon.common.response.ApiResponse;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
@@ -163,6 +164,10 @@ public class BidService {
     public BidResponse attemptBid(Long userId, BidRequest request) {
         AuctionOption option = auctionOptionRepository.findByIdWithAuction(request.auctionOptionId())
             .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_OPTION_NOT_FOUND));
+
+        if (bidRepository.existsByUserIdAndAuctionIdAndStatus(userId, option.getAuction().getId(), BidStatus.SUCCESS)) {
+            throw new CustomException(ErrorCode.AUCTION_ALREADY_PARTICIPATED);
+        }
 
         LocalDateTime now = LocalDateTime.now();
         validateAuctionOpen(option.getAuction(), now);
@@ -364,7 +369,9 @@ public class BidService {
             throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment completion timestamp is missing.");
         }
         try {
-            return OffsetDateTime.parse(paidAtStr).toLocalDateTime();
+            return OffsetDateTime.parse(paidAtStr)
+                .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                .toLocalDateTime();
         } catch (Exception e) {
             log.warn("Failed to parse paidAt value: {}", paidAtStr, e);
             throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Failed to parse payment completion timestamp.");

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -33,8 +33,11 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
@@ -58,6 +61,7 @@ public class BidService {
     private final BidTransactionManager txManager;
     private final TicketServiceClient ticketServiceClient;
     private final ReservationNoGenerator reservationNoGenerator;
+    private final RedissonClient redissonClient;
 
     public Long getAuctionIdByOptionId(Long optionId) {
         return auctionOptionRepository.findByIdWithAuction(optionId)
@@ -165,149 +169,193 @@ public class BidService {
         AuctionOption option = auctionOptionRepository.findByIdWithAuction(request.auctionOptionId())
             .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_OPTION_NOT_FOUND));
 
-        if (bidRepository.existsByUserIdAndAuctionIdAndStatus(userId, option.getAuction().getId(), BidStatus.SUCCESS)) {
-            throw new CustomException(ErrorCode.AUCTION_ALREADY_PARTICIPATED);
-        }
-
-        LocalDateTime now = LocalDateTime.now();
-        validateAuctionOpen(option.getAuction(), now);
-
-        AuctionStockService.PriceAnchor priceAnchor = auctionStockService.getPriceAnchor(option.getAuction().getId());
-        AuctionStatus auctionStatus = auctionPriceService.calculateStatus(
-            option.getAuction(),
-            now,
-            auctionStockService.hasAvailableStock(option.getAuction().getId())
-        );
-
-        Integer currentServerPrice = auctionPriceService.calculateCurrentPrice(
-            option.getAuction(),
-            auctionStatus,
-            now,
-            priceAnchor.soldOutPrice(),
-            priceAnchor.restockAnchorAt()
-        );
-        if (!request.bidPrice().equals(currentServerPrice)) {
-            throw new CustomException(ErrorCode.AUCTION_PRICE_MISMATCH);
-        }
-
-        Long remainingStock = bidRedisRepository.decrementStock(option.getId());
-        if (remainingStock < 0) {
-            throw new CustomException(ErrorCode.AUCTION_OPTION_SOLD_OUT);
-        }
-        if (remainingStock == 0 && !auctionStockService.hasAvailableStock(option.getAuction().getId())) {
-            auctionStockService.recordSoldOutIfAbsent(option.getAuction().getId(), currentServerPrice);
-        }
-
-        String timestamp = now.format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
-        String merchantUid = "order_no_" + timestamp + "_" + UUID.randomUUID().toString().substring(0, 8);
-
-        Bid bid = null;
-        boolean paymentAttempted = false;
+        Long auctionId = option.getAuction().getId();
+        RLock lock = redissonClient.getLock("lock:auction:bid:" + userId + ":" + auctionId);
 
         try {
-            bid = txManager.preparePendingBid(userId, option, currentServerPrice, merchantUid);
-
-            ApiResponse<BillingKeyInternalResponse> billingKeyResponse = userBillingClient.getDefaultBillingKey(userId);
-            if (billingKeyResponse == null || billingKeyResponse.getData() == null) {
-                throw new CustomException(ErrorCode.BILLING_KEY_NOT_FOUND);
+            if (!lock.tryLock(10, 20, TimeUnit.SECONDS)) {
+                throw new CustomException(ErrorCode.ERROR_SYSTEM, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
             }
-            String billingKey = billingKeyResponse.getData().customerUid();
 
-            paymentAttempted = true;
-            PortOnePaymentResponse paymentResponse = portOneClient.executePayment(
-                billingKey,
-                bid.getMerchantUid(),
-                bid.getBidPrice(),
-                PAYMENT_PRODUCT_NAME
+            // 1인 1회 제한: 이미 해당 경매에서 낙찰(SUCCESS)된 내역이 있는지 확인
+            if (bidRepository.existsByUserIdAndAuctionIdAndStatus(userId, auctionId, BidStatus.SUCCESS)) {
+                throw new CustomException(ErrorCode.AUCTION_ALREADY_PARTICIPATED);
+            }
+
+            LocalDateTime now = LocalDateTime.now();
+            validateAuctionOpen(option.getAuction(), now);
+
+            AuctionStockService.PriceAnchor priceAnchor = auctionStockService.getPriceAnchor(auctionId);
+            AuctionStatus auctionStatus = auctionPriceService.calculateStatus(
+                option.getAuction(),
+                now,
+                auctionStockService.hasAvailableStock(auctionId)
             );
 
-            if (!paymentResponse.isPaid()) {
-                log.error("Payment execution failed because paidAt is missing. merchantUid={}", bid.getMerchantUid());
-                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment was not completed.");
+            Integer currentServerPrice = auctionPriceService.calculateCurrentPrice(
+                option.getAuction(),
+                auctionStatus,
+                now,
+                priceAnchor.soldOutPrice(),
+                priceAnchor.restockAnchorAt()
+            );
+            if (!request.bidPrice().equals(currentServerPrice)) {
+                throw new CustomException(ErrorCode.AUCTION_PRICE_MISMATCH);
             }
 
-            String pgTxId = paymentResponse.getPgTxId();
-            if (pgTxId == null || pgTxId.isBlank()) {
-                log.error("Payment response is missing pgTxId. merchantUid={}", bid.getMerchantUid());
-                throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment transaction id is missing.");
+            Long remainingStock = bidRedisRepository.decrementStock(option.getId());
+            if (remainingStock < 0) {
+                throw new CustomException(ErrorCode.AUCTION_OPTION_SOLD_OUT);
+            }
+            if (remainingStock == 0 && !auctionStockService.hasAvailableStock(auctionId)) {
+                auctionStockService.recordSoldOutIfAbsent(auctionId, currentServerPrice);
             }
 
-            LocalDateTime paidAt = parsePaidAt(paymentResponse.payment().paidAt());
+            String timestamp = now.format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+            String merchantUid = "order_no_" + timestamp + "_" + UUID.randomUUID().toString().substring(0, 8);
 
-            String popupTitle = DEFAULT_POPUP_TITLE;
-            String popupAddress = DEFAULT_POPUP_ADDRESS;
-            String thumbnailUrl = null;
+            Bid bid = null;
+            boolean paymentAttempted = false;
 
             try {
-                ApiResponse<PopupInternalResponse> popupResponse =
-                    popupServiceClient.getPopupDetail(option.getAuction().getPopupId());
-                if (popupResponse != null && popupResponse.getData() != null) {
-                    PopupInternalResponse popupInfo = popupResponse.getData();
-                    if (popupInfo.title() != null) {
-                        popupTitle = popupInfo.title();
-                    }
-                    if (popupInfo.location() != null) {
-                        popupAddress = popupInfo.location();
-                    }
-                    if (popupInfo.vThumbnailUrl() != null) {
-                        thumbnailUrl = popupInfo.vThumbnailUrl();
-                    }
-                } else {
-                    log.warn("Popup detail response is empty. popupId={}", option.getAuction().getPopupId());
+                bid = txManager.preparePendingBid(userId, option, currentServerPrice, merchantUid);
+
+                ApiResponse<BillingKeyInternalResponse> billingKeyResponse = userBillingClient.getDefaultBillingKey(userId);
+                if (billingKeyResponse == null || billingKeyResponse.getData() == null) {
+                    throw new CustomException(ErrorCode.BILLING_KEY_NOT_FOUND);
                 }
-            } catch (Exception e) {
-                log.error("Popup detail lookup failed. popupId={}, error={}",
-                    option.getAuction().getPopupId(), e.getMessage());
-            }
+                String billingKey = billingKeyResponse.getData().customerUid();
 
-            String reservationNo = null;
-            int maxRetries = 3;
-            int retryCount = 0;
+                paymentAttempted = true;
+                PortOnePaymentResponse paymentResponse = portOneClient.executePayment(
+                    billingKey,
+                    bid.getMerchantUid(),
+                    bid.getBidPrice(),
+                    PAYMENT_PRODUCT_NAME
+                );
 
-            while (retryCount < maxRetries) {
+                if (!paymentResponse.isPaid()) {
+                    log.error("Payment execution failed because paidAt is missing. merchantUid={}", bid.getMerchantUid());
+                    throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment was not completed.");
+                }
+
+                String pgTxId = paymentResponse.getPgTxId();
+                if (pgTxId == null || pgTxId.isBlank()) {
+                    log.error("Payment response is missing pgTxId. merchantUid={}", bid.getMerchantUid());
+                    throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment transaction id is missing.");
+                }
+
+                LocalDateTime paidAt = parsePaidAt(paymentResponse.payment().paidAt());
+
+                String popupTitle = DEFAULT_POPUP_TITLE;
+                String popupAddress = DEFAULT_POPUP_ADDRESS;
+                String thumbnailUrl = null;
+
                 try {
-                    String currentReservationNo = reservationNoGenerator.generate();
-                    reservationNo = txManager.completeBidSuccess(
-                        bid.getId(),
-                        option.getId(),
-                        pgTxId,
-                        paidAt,
-                        currentReservationNo,
-                        popupTitle,
-                        popupAddress,
-                        thumbnailUrl,
-                        option.getEntryDate(),
-                        option.getEntryTime(),
-                        option.getAuction().getStartPrice()
-                    );
-                    break;
-                } catch (DataIntegrityViolationException e) {
-                    retryCount++;
-                    log.warn("Reservation number collision detected. retryCount={}, merchantUid={}",
-                        retryCount, bid.getMerchantUid());
-                    if (retryCount >= maxRetries) {
-                        throw e;
+                    ApiResponse<PopupInternalResponse> popupResponse =
+                        popupServiceClient.getPopupDetail(option.getAuction().getPopupId());
+                    if (popupResponse != null && popupResponse.getData() != null) {
+                        PopupInternalResponse popupInfo = popupResponse.getData();
+                        if (popupInfo.title() != null) {
+                            popupTitle = popupInfo.title();
+                        }
+                        if (popupInfo.location() != null) {
+                            popupAddress = popupInfo.location();
+                        }
+                        if (popupInfo.vThumbnailUrl() != null) {
+                            thumbnailUrl = popupInfo.vThumbnailUrl();
+                        }
+                    } else {
+                        log.warn("Popup detail response is empty. popupId={}", option.getAuction().getPopupId());
+                    }
+                } catch (Exception e) {
+                    log.error("Popup detail lookup failed. popupId={}, error={}",
+                        option.getAuction().getPopupId(), e.getMessage());
+                }
+
+                String reservationNo = null;
+                int maxRetries = 3;
+                int retryCount = 0;
+
+                while (retryCount < maxRetries) {
+                    try {
+                        String currentReservationNo = reservationNoGenerator.generate();
+                        reservationNo = txManager.completeBidSuccess(
+                            bid.getId(),
+                            option.getId(),
+                            pgTxId,
+                            paidAt,
+                            currentReservationNo,
+                            popupTitle,
+                            popupAddress,
+                            thumbnailUrl,
+                            option.getEntryDate(),
+                            option.getEntryTime(),
+                            option.getAuction().getStartPrice()
+                        );
+                        break;
+                    } catch (DataIntegrityViolationException e) {
+                        retryCount++;
+                        log.warn("Reservation number collision detected. retryCount={}, merchantUid={}",
+                            retryCount, bid.getMerchantUid());
+                        if (retryCount >= maxRetries) {
+                            throw e;
+                        }
                     }
                 }
-            }
 
-            if (reservationNo == null) {
-                reservationNo = bidRepository.findById(bid.getId())
-                    .map(Bid::getReservationNo)
-                    .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
-            }
+                if (reservationNo == null) {
+                    reservationNo = bidRepository.findById(bid.getId())
+                        .map(Bid::getReservationNo)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
+                }
 
-            issueAuctionWinTicket(bid, option, reservationNo);
-            return new BidResponse(bid.getId(), BidStatus.SUCCESS, "Bid completed successfully.", reservationNo);
+                issueAuctionWinTicket(bid, option, reservationNo);
+                return new BidResponse(bid.getId(), BidStatus.SUCCESS, "Bid completed successfully.", reservationNo);
 
-        } catch (Exception e) {
-            log.error("Bid processing failed. userId={}, optionId={}, error={}", userId, option.getId(), e.getMessage());
+            } catch (Exception e) {
+                log.error("Bid processing failed. userId={}, optionId={}, error={}", userId, option.getId(), e.getMessage());
 
-            if (!paymentAttempted) {
-                bidRedisRepository.incrementAvailableStock(option.getId(), 1L);
+                if (!paymentAttempted) {
+                    bidRedisRepository.incrementAvailableStock(option.getId(), 1L);
 
-                if (bid != null) {
+                    if (bid != null) {
+                        txManager.completeBidFailure(bid.getId());
+                    }
+
+                    if (e instanceof CustomException customException) {
+                        throw customException;
+                    }
+                    throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, e);
+                }
+
+                boolean cancelConfirmed = false;
+
+                try {
+                    PortOneCancelResponse cancelResponse = portOneClient.cancelPayment(merchantUid, bid.getBidPrice());
+                    if (cancelResponse.isSucceeded()) {
+                        bidRedisRepository.addPendingRestock(option.getId(), 1L);
+                        cancelConfirmed = true;
+                        log.info("Compensation completed. Payment cancel succeeded. merchantUid={}", merchantUid);
+                    } else if (cancelResponse.isRequested()) {
+                        log.warn("Compensation pending. Payment cancel request accepted. merchantUid={}", merchantUid);
+                    } else {
+                        log.error("Compensation failed. Payment cancel failed. merchantUid={}, reason={}",
+                            merchantUid, cancelResponse.reason());
+                    }
+                } catch (Exception cancelEx) {
+                    log.error("Critical error while calling payment cancel API. merchantUid={}", merchantUid, cancelEx);
+                }
+
+                if (cancelConfirmed && bid != null) {
                     txManager.completeBidFailure(bid.getId());
+                }
+
+                if (!cancelConfirmed) {
+                    throw new CustomException(
+                        ErrorCode.PAYMENT_EXECUTION_FAILED,
+                        "Payment cancellation is not confirmed, so recovery is deferred."
+                    );
                 }
 
                 if (e instanceof CustomException customException) {
@@ -315,40 +363,13 @@ public class BidService {
                 }
                 throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, e);
             }
-
-            boolean cancelConfirmed = false;
-
-            try {
-                PortOneCancelResponse cancelResponse = portOneClient.cancelPayment(merchantUid, bid.getBidPrice());
-                if (cancelResponse.isSucceeded()) {
-                    bidRedisRepository.addPendingRestock(option.getId(), 1L);
-                    cancelConfirmed = true;
-                    log.info("Compensation completed. Payment cancel succeeded. merchantUid={}", merchantUid);
-                } else if (cancelResponse.isRequested()) {
-                    log.warn("Compensation pending. Payment cancel request accepted. merchantUid={}", merchantUid);
-                } else {
-                    log.error("Compensation failed. Payment cancel failed. merchantUid={}, reason={}",
-                        merchantUid, cancelResponse.reason());
-                }
-            } catch (Exception cancelEx) {
-                log.error("Critical error while calling payment cancel API. merchantUid={}", merchantUid, cancelEx);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.ERROR_SYSTEM, "인증 처리 중 오류가 발생했습니다.");
+        } finally {
+            if (lock != null && lock.isHeldByCurrentThread()) {
+                lock.unlock();
             }
-
-            if (cancelConfirmed && bid != null) {
-                txManager.completeBidFailure(bid.getId());
-            }
-
-            if (!cancelConfirmed) {
-                throw new CustomException(
-                    ErrorCode.PAYMENT_EXECUTION_FAILED,
-                    "Payment cancellation is not confirmed, so recovery is deferred."
-                );
-            }
-
-            if (e instanceof CustomException customException) {
-                throw customException;
-            }
-            throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, e);
         }
     }
 

--- a/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
@@ -49,9 +49,11 @@ public class AuctionSecurityConfig extends CommonSecurityConfig {
                 // 1. 상세 조회 제외
                 if (method.equals("GET") && path.matches("^/auctions/\\d+$")) return true;
                 if (method.equals("GET") && path.matches("^/auctions/\\d+/stream$")) return true;
-                // 2. 어드민 및 내부 API 제외
+                // 2. 예약 상세 조회 제외
+                if (method.equals("GET") && path.startsWith("/auctions/reservations/")) return true;
+                // 3. 어드민 및 내부 API 제외
                 if (path.startsWith("/admin/") || path.startsWith("/internal/")) return true;
-                // 3. 헬스체크 등 공용 API 제외
+                // 4. 헬스체크 등 공용 API 제외
                 return path.equals("/health") || path.startsWith("/actuator/");
             }
         };

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -11,6 +11,7 @@ import com.t1.popcon.auction.bid.domain.BidStatus;
 import com.t1.popcon.auction.bid.dto.BidRequest;
 import com.t1.popcon.auction.bid.dto.BidResponse;
 import com.t1.popcon.auction.bid.infrastructure.BidRedisRepository;
+import com.t1.popcon.auction.bid.repository.BidRepository;
 import com.t1.popcon.auction.domain.Auction;
 import com.t1.popcon.auction.domain.AuctionOption;
 import com.t1.popcon.auction.domain.AuctionStatus;
@@ -49,6 +50,8 @@ public class BidServiceTest {
 	@Mock
 	private BidRedisRepository bidRedisRepository;
 	@Mock
+	private BidRepository bidRepository;
+	@Mock
 	private AuctionOptionRepository auctionOptionRepository;
 	@Mock
 	private AuctionPriceService auctionPriceService;
@@ -82,6 +85,7 @@ public class BidServiceTest {
 		option = mock(AuctionOption.class);
 		given(option.getId()).willReturn(optionId);
 		given(option.getAuction()).willReturn(auction);
+		given(auction.getId()).willReturn(1L);
 	}
 
 	@Test
@@ -90,6 +94,7 @@ public class BidServiceTest {
 		// given
 		BidRequest request = new BidRequest(optionId, bidPrice);
 		given(auctionOptionRepository.findByIdWithAuction(optionId)).willReturn(Optional.of(option));
+		given(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).willReturn(false);
 		given(auctionStockService.hasAvailableStock(anyLong())).willReturn(true);
 		given(auctionStockService.getPriceAnchor(anyLong())).willReturn(new AuctionStockService.PriceAnchor(null, null));
 		given(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).willReturn(AuctionStatus.OPEN);
@@ -160,6 +165,7 @@ public class BidServiceTest {
 		// given
 		BidRequest request = new BidRequest(optionId, bidPrice);
 		given(auctionOptionRepository.findByIdWithAuction(optionId)).willReturn(Optional.of(option));
+		given(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).willReturn(false);
 		given(auctionStockService.hasAvailableStock(anyLong())).willReturn(true);
 		given(auctionStockService.getPriceAnchor(anyLong())).willReturn(new AuctionStockService.PriceAnchor(null, null));
 		given(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).willReturn(AuctionStatus.OPEN);
@@ -178,6 +184,7 @@ public class BidServiceTest {
 		// given
 		BidRequest request = new BidRequest(optionId, bidPrice);
 		given(auctionOptionRepository.findByIdWithAuction(optionId)).willReturn(Optional.of(option));
+		given(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).willReturn(false);
 		given(auctionStockService.hasAvailableStock(anyLong())).willReturn(true);
 		given(auctionStockService.getPriceAnchor(anyLong())).willReturn(new AuctionStockService.PriceAnchor(null, null));
 		given(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).willReturn(AuctionStatus.OPEN);
@@ -210,5 +217,20 @@ public class BidServiceTest {
 		verify(portOneClient).cancelPayment(anyString(), anyInt());
 		verify(bidRedisRepository).addPendingRestock(optionId, 1L);
 		verify(txManager).completeBidFailure(any());
+	}
+
+	@Test
+	@DisplayName("낙찰 시도 실패 - 이미 해당 경매에 낙찰된 내역이 있음")
+	void attemptBid_Fail_AlreadyParticipated() {
+		// given
+		BidRequest request = new BidRequest(optionId, bidPrice);
+		given(auctionOptionRepository.findByIdWithAuction(optionId)).willReturn(Optional.of(option));
+		// 이미 낙찰 성공 내역이 있다고 가정 (true)
+		given(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), eq(BidStatus.SUCCESS))).willReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> bidService.attemptBid(userId, request))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.AUCTION_ALREADY_PARTICIPATED.getMessage());
 	}
 }

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -41,7 +43,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,6 +70,10 @@ public class BidServiceTest {
 	private BidTransactionManager txManager;
 	@Mock
 	private ReservationNoGenerator reservationNoGenerator;
+	@Mock
+	private RedissonClient redissonClient;
+	@Mock
+	private RLock lock;
 
 	@InjectMocks
 	private BidService bidService;
@@ -80,12 +85,17 @@ public class BidServiceTest {
 	private AuctionOption option;
 
 	@BeforeEach
-	void setUp() {
+	void setUp() throws InterruptedException {
 		auction = mock(Auction.class);
 		option = mock(AuctionOption.class);
+		
 		lenient().when(option.getId()).thenReturn(optionId);
 		lenient().when(option.getAuction()).thenReturn(auction);
 		lenient().when(auction.getId()).thenReturn(1L);
+
+		// Redisson Lock 모킹: 항상 락 획득 성공으로 설정
+		lenient().when(redissonClient.getLock(anyString())).thenReturn(lock);
+		lenient().when(lock.tryLock(anyLong(), anyLong(), any())).thenReturn(true);
 	}
 
 	@Test
@@ -93,13 +103,13 @@ public class BidServiceTest {
 	void attemptBid_Success() {
 		// given
 		BidRequest request = new BidRequest(optionId, bidPrice);
-		given(auctionOptionRepository.findByIdWithAuction(optionId)).willReturn(Optional.of(option));
-		given(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).willReturn(false);
-		given(auctionStockService.hasAvailableStock(anyLong())).willReturn(true);
-		given(auctionStockService.getPriceAnchor(anyLong())).willReturn(new AuctionStockService.PriceAnchor(null, null));
-		given(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).willReturn(AuctionStatus.OPEN);
-		given(auctionPriceService.calculateCurrentPrice(any(), any(), any(), any(), any())).willReturn(bidPrice);
-		given(bidRedisRepository.decrementStock(optionId)).willReturn(5L);
+		when(auctionOptionRepository.findByIdWithAuction(optionId)).thenReturn(Optional.of(option));
+		when(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).thenReturn(false);
+		when(auctionStockService.hasAvailableStock(anyLong())).thenReturn(true);
+		when(auctionStockService.getPriceAnchor(anyLong())).thenReturn(new AuctionStockService.PriceAnchor(null, null));
+		when(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).thenReturn(AuctionStatus.OPEN);
+		when(auctionPriceService.calculateCurrentPrice(any(), any(), any(), any(), any())).thenReturn(bidPrice);
+		when(bidRedisRepository.decrementStock(optionId)).thenReturn(5L);
 
 		String merchantUid = "merchant_123";
 		Bid bid = Bid.builder()
@@ -109,33 +119,26 @@ public class BidServiceTest {
 			.merchantUid(merchantUid)
 			.build();
 		ReflectionTestUtils.setField(bid, "id", 1L);
-		given(txManager.preparePendingBid(anyLong(), any(), anyInt(), anyString())).willReturn(bid);
+		when(txManager.preparePendingBid(anyLong(), any(), anyInt(), anyString())).thenReturn(bid);
 
 		BillingKeyInternalResponse billingKey = new BillingKeyInternalResponse("billing_key_abc");
-		given(userBillingClient.getDefaultBillingKey(userId)).willReturn(ApiResponse.ok(billingKey));
+		when(userBillingClient.getDefaultBillingKey(userId)).thenReturn(ApiResponse.ok(billingKey));
 
 		PortOnePaymentResponse.Payment paymentDetail = new PortOnePaymentResponse.Payment("pg_tx_123", "2023-11-20T15:30:00Z");
 		PortOnePaymentResponse paymentResponse = new PortOnePaymentResponse(paymentDetail);
-		given(portOneClient.executePayment(anyString(), anyString(), anyInt(), anyString())).willReturn(paymentResponse);
+		when(portOneClient.executePayment(anyString(), anyString(), anyInt(), anyString())).thenReturn(paymentResponse);
 
 		PopupInternalResponse popupInfo = new PopupInternalResponse(1L, "Pop-up Title", "Location", "h_thumbnail.url", "v_thumbnail.url");
-		given(auction.getPopupId()).willReturn(1L);
-		given(popupServiceClient.getPopupDetail(anyLong())).willReturn(ApiResponse.ok(popupInfo));
-		given(option.getEntryDate()).willReturn(LocalDate.now());
-		given(option.getEntryTime()).willReturn(LocalTime.now());
-		given(auction.getStartPrice()).willReturn(10000);
-		given(reservationNoGenerator.generate()).willReturn("TKT123456789012");
-		given(txManager.completeBidSuccess(anyLong(), anyLong(), anyString(), any(), anyString(), anyString(), anyString(), anyString(), any(), any(), anyInt()))
-			.willReturn("TKT123456789012");
-		given(ticketServiceClient.issueTicket(any())).willReturn(
-			ApiResponse.ok(new TicketIssueResponse(
-				1L,
-				"TKT00000001",
-				"TKT123456789012",
-				"ISSUED",
-				"AUCTION",
-				1L
-			))
+		when(auction.getPopupId()).thenReturn(1L);
+		when(popupServiceClient.getPopupDetail(anyLong())).thenReturn(ApiResponse.ok(popupInfo));
+		when(option.getEntryDate()).thenReturn(LocalDate.now());
+		when(option.getEntryTime()).thenReturn(LocalTime.now());
+		when(auction.getStartPrice()).thenReturn(10000);
+		when(reservationNoGenerator.generate()).thenReturn("TKT123456789012");
+		when(txManager.completeBidSuccess(anyLong(), anyLong(), anyString(), any(), anyString(), anyString(), anyString(), anyString(), any(), any(), anyInt()))
+			.thenReturn("TKT123456789012");
+		when(ticketServiceClient.issueTicket(any())).thenReturn(
+			ApiResponse.ok(new TicketIssueResponse(1L, "TKT00000001", "TKT123456789012", "ISSUED", "AUCTION", 1L))
 		);
 
 		// when
@@ -144,19 +147,10 @@ public class BidServiceTest {
 		// then
 		assertThat(response.status()).isEqualTo(BidStatus.SUCCESS);
 		verify(txManager).completeBidSuccess(
-			eq(bid.getId()),
-			eq(optionId),
-			eq("pg_tx_123"),
-			any(LocalDateTime.class),
-			eq("TKT123456789012"),
-			eq("Pop-up Title"),
-			eq("Location"),
-			eq("v_thumbnail.url"),
-			any(LocalDate.class),
-			any(LocalTime.class),
-			eq(10000)
+			eq(bid.getId()), eq(optionId), eq("pg_tx_123"), any(LocalDateTime.class),
+			eq("TKT123456789012"), eq("Pop-up Title"), eq("Location"), eq("v_thumbnail.url"),
+			any(LocalDate.class), any(LocalTime.class), eq(10000)
 		);
-		verify(ticketServiceClient).issueTicket(any());
 	}
 
 	@Test
@@ -164,13 +158,13 @@ public class BidServiceTest {
 	void attemptBid_Fail_SoldOut() {
 		// given
 		BidRequest request = new BidRequest(optionId, bidPrice);
-		given(auctionOptionRepository.findByIdWithAuction(optionId)).willReturn(Optional.of(option));
-		given(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).willReturn(false);
-		given(auctionStockService.hasAvailableStock(anyLong())).willReturn(true);
-		given(auctionStockService.getPriceAnchor(anyLong())).willReturn(new AuctionStockService.PriceAnchor(null, null));
-		given(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).willReturn(AuctionStatus.OPEN);
-		given(auctionPriceService.calculateCurrentPrice(any(), any(), any(), any(), any())).willReturn(bidPrice);
-		given(bidRedisRepository.decrementStock(optionId)).willReturn(-1L);
+		when(auctionOptionRepository.findByIdWithAuction(optionId)).thenReturn(Optional.of(option));
+		when(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).thenReturn(false);
+		when(auctionStockService.hasAvailableStock(anyLong())).thenReturn(true);
+		when(auctionStockService.getPriceAnchor(anyLong())).thenReturn(new AuctionStockService.PriceAnchor(null, null));
+		when(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).thenReturn(AuctionStatus.OPEN);
+		when(auctionPriceService.calculateCurrentPrice(any(), any(), any(), any(), any())).thenReturn(bidPrice);
+		when(bidRedisRepository.decrementStock(optionId)).thenReturn(-1L);
 
 		// when & then
 		assertThatThrownBy(() -> bidService.attemptBid(userId, request))
@@ -183,13 +177,13 @@ public class BidServiceTest {
 	void attemptBid_Fail_PaymentError() {
 		// given
 		BidRequest request = new BidRequest(optionId, bidPrice);
-		given(auctionOptionRepository.findByIdWithAuction(optionId)).willReturn(Optional.of(option));
-		given(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).willReturn(false);
-		given(auctionStockService.hasAvailableStock(anyLong())).willReturn(true);
-		given(auctionStockService.getPriceAnchor(anyLong())).willReturn(new AuctionStockService.PriceAnchor(null, null));
-		given(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).willReturn(AuctionStatus.OPEN);
-		given(auctionPriceService.calculateCurrentPrice(any(), any(), any(), any(), any())).willReturn(bidPrice);
-		given(bidRedisRepository.decrementStock(optionId)).willReturn(5L);
+		when(auctionOptionRepository.findByIdWithAuction(optionId)).thenReturn(Optional.of(option));
+		when(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), any())).thenReturn(false);
+		when(auctionStockService.hasAvailableStock(anyLong())).thenReturn(true);
+		when(auctionStockService.getPriceAnchor(anyLong())).thenReturn(new AuctionStockService.PriceAnchor(null, null));
+		when(auctionPriceService.calculateStatus(any(), any(), anyBoolean())).thenReturn(AuctionStatus.OPEN);
+		when(auctionPriceService.calculateCurrentPrice(any(), any(), any(), any(), any())).thenReturn(bidPrice);
+		when(bidRedisRepository.decrementStock(optionId)).thenReturn(5L);
 
 		Bid bid = Bid.builder()
 			.userId(userId)
@@ -198,15 +192,15 @@ public class BidServiceTest {
 			.merchantUid("merchant_123")
 			.build();
 		ReflectionTestUtils.setField(bid, "id", 1L);
-		given(txManager.preparePendingBid(anyLong(), any(), anyInt(), anyString())).willReturn(bid);
+		when(txManager.preparePendingBid(anyLong(), any(), anyInt(), anyString())).thenReturn(bid);
 
 		BillingKeyInternalResponse billingKey = new BillingKeyInternalResponse("billing_key_abc");
-		given(userBillingClient.getDefaultBillingKey(userId)).willReturn(ApiResponse.ok(billingKey));
+		when(userBillingClient.getDefaultBillingKey(userId)).thenReturn(ApiResponse.ok(billingKey));
 
-		given(portOneClient.executePayment(anyString(), anyString(), anyInt(), anyString()))
-			.willThrow(new RuntimeException("Payment API Error"));
-		given(portOneClient.cancelPayment(anyString(), anyInt()))
-			.willReturn(new PortOneCancelResponse(
+		when(portOneClient.executePayment(anyString(), anyString(), anyInt(), anyString()))
+			.thenThrow(new RuntimeException("Payment API Error"));
+		when(portOneClient.cancelPayment(anyString(), anyInt()))
+			.thenReturn(new PortOneCancelResponse(
 				new PortOneCancelResponse.Cancellation("SUCCEEDED", "cancel_1", "pg_cancel_1", bidPrice, "test", "2026-03-30T00:00:00Z")
 			));
 
@@ -224,9 +218,8 @@ public class BidServiceTest {
 	void attemptBid_Fail_AlreadyParticipated() {
 		// given
 		BidRequest request = new BidRequest(optionId, bidPrice);
-		given(auctionOptionRepository.findByIdWithAuction(optionId)).willReturn(Optional.of(option));
-		// 이미 낙찰 성공 내역이 있다고 가정 (true)
-		given(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), eq(BidStatus.SUCCESS))).willReturn(true);
+		when(auctionOptionRepository.findByIdWithAuction(optionId)).thenReturn(Optional.of(option));
+		when(bidRepository.existsByUserIdAndAuctionIdAndStatus(anyLong(), anyLong(), eq(BidStatus.SUCCESS))).thenReturn(true);
 
 		// when & then
 		assertThatThrownBy(() -> bidService.attemptBid(userId, request))

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -226,4 +226,20 @@ public class BidServiceTest {
 			.isInstanceOf(CustomException.class)
 			.hasMessageContaining(ErrorCode.AUCTION_ALREADY_PARTICIPATED.getMessage());
 	}
+
+	@Test
+	@DisplayName("낙찰 시도 실패 - 락 획득 실패")
+	void attemptBid_Fail_LockNotAcquired() throws InterruptedException {
+		// given
+		BidRequest request = new BidRequest(optionId, bidPrice);
+		when(auctionOptionRepository.findByIdWithAuction(optionId)).thenReturn(Optional.of(option));
+		when(redissonClient.getLock(anyString())).thenReturn(lock);
+		// 락 획득 실패 모킹 (기존 lenient 설정을 덮어씀)
+		when(lock.tryLock(anyLong(), anyLong(), any())).thenReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> bidService.attemptBid(userId, request))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining("요청이 너무 많습니다");
+	}
 }

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -83,9 +83,9 @@ public class BidServiceTest {
 	void setUp() {
 		auction = mock(Auction.class);
 		option = mock(AuctionOption.class);
-		given(option.getId()).willReturn(optionId);
-		given(option.getAuction()).willReturn(auction);
-		given(auction.getId()).willReturn(1L);
+		lenient().when(option.getId()).thenReturn(optionId);
+		lenient().when(option.getAuction()).thenReturn(auction);
+		lenient().when(auction.getId()).thenReturn(1L);
 	}
 
 	@Test

--- a/common/src/main/java/com/t1/popcon/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/t1/popcon/common/exception/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
     AUCTION_OPTION_STOCK_INVALID("AU008", HttpStatus.BAD_REQUEST, "경매 옵션 재고 값이 올바르지 않습니다."),
     AUCTION_PRICE_MISMATCH("AU009", HttpStatus.BAD_REQUEST, "요청하신 입찰 가격이 현재 경매가와 일치하지 않습니다."),
     BID_NOT_FOUND("AU010", HttpStatus.NOT_FOUND, "존재하지 않는 입찰 정보입니다."),
+    AUCTION_ALREADY_PARTICIPATED("AU011", HttpStatus.CONFLICT, "이미 해당 경매에 낙찰된 내역이 있습니다."),
 
     // Draw
     DRAW_NOT_FOUND("D001", HttpStatus.NOT_FOUND, "존재하지 않는 드로우입니다."),

--- a/draw-service/src/main/java/com/t1/popcon/draw/domain/DrawEntry.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/domain/DrawEntry.java
@@ -27,6 +27,10 @@ import org.hibernate.annotations.SQLRestriction;
         @UniqueConstraint(
             name = "uk_user_draw_option",
             columnNames = {"user_id", "draw_option_id", "deleted"}
+        ),
+        @UniqueConstraint(
+            name = "uk_user_draw",
+            columnNames = {"user_id", "draw_id", "deleted"}
         )
     }
 )
@@ -35,9 +39,13 @@ import org.hibernate.annotations.SQLRestriction;
 public class DrawEntry extends BaseSoftDeleteEntity {
 
     public static final String UNIQUE_CONSTRAINT_NAME = "uk_user_draw_option";
+    public static final String DRAW_UNIQUE_CONSTRAINT_NAME = "uk_user_draw";
 
     @Column(nullable = false)
     private Long userId;
+
+    @Column(name = "draw_id", nullable = false)
+    private Long drawId;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "draw_option_id", nullable = false)
@@ -79,6 +87,7 @@ public class DrawEntry extends BaseSoftDeleteEntity {
         validate(userId, drawOption, encryptedName, encryptedPhoneNumber);
 
         this.userId = userId;
+        this.drawId = drawOption.getDraw().getId();
         this.drawOption = drawOption;
         this.encryptedName = encryptedName;
         this.encryptedPhoneNumber = encryptedPhoneNumber;

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Slice;
 public interface DrawEntryRepository extends JpaRepository<DrawEntry, Long> {
 	boolean existsByUserIdAndDrawOption_Id(Long userId, Long drawOptionId);
 
+	boolean existsByUserIdAndDrawOption_Draw_Id(Long userId, Long drawId);
+
 	Slice<DrawEntry> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     List<DrawEntry> findAllByDrawOption_IdAndStatusOrderByIdAsc(Long drawOptionId, DrawEntryStatus status);

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.domain.Slice;
 public interface DrawEntryRepository extends JpaRepository<DrawEntry, Long> {
 	boolean existsByUserIdAndDrawOption_Id(Long userId, Long drawOptionId);
 
-	boolean existsByUserIdAndDrawOption_Draw_Id(Long userId, Long drawId);
+	boolean existsByUserIdAndDrawId(Long userId, Long drawId);
 
 	Slice<DrawEntry> findAllByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -63,7 +63,7 @@ public class DrawEntryService {
         validateDrawOption(drawId, drawOption);
         validateEntryWindow(drawOption.getDraw());
 
-        if (drawEntryRepository.existsByUserIdAndDrawOption_Id(userId, drawOptionId)) {
+        if (drawEntryRepository.existsByUserIdAndDrawOption_Draw_Id(userId, drawId)) {
             throw new CustomException(ErrorCode.DRAW_ALREADY_APPLIED);
         }
 

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -63,7 +63,7 @@ public class DrawEntryService {
         validateDrawOption(drawId, drawOption);
         validateEntryWindow(drawOption.getDraw());
 
-        if (drawEntryRepository.existsByUserIdAndDrawOption_Draw_Id(userId, drawId)) {
+        if (drawEntryRepository.existsByUserIdAndDrawId(userId, drawId)) {
             throw new CustomException(ErrorCode.DRAW_ALREADY_APPLIED);
         }
 
@@ -292,7 +292,8 @@ public class DrawEntryService {
     private boolean isDuplicateEntryViolation(DataIntegrityViolationException e) {
         Throwable root = e.getMostSpecificCause();
         String message = root != null ? root.getMessage() : e.getMessage();
-        return message != null && message.contains(DrawEntry.UNIQUE_CONSTRAINT_NAME);
+        return message != null && (message.contains(DrawEntry.UNIQUE_CONSTRAINT_NAME) 
+            || message.contains(DrawEntry.DRAW_UNIQUE_CONSTRAINT_NAME));
     }
 
     /** 전화번호를 010-XXXX-XXXX 형식으로 변환 */

--- a/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
@@ -103,8 +103,8 @@ public class VqaService {
 
             int totalScore = antiMacroScoreRepository.getTotalScore(userId);
 
-            // 4. 레벨 0 (0~20점): 면제
-            if (totalScore <= 20) {
+            // 4. 레벨 0 (0~20점): 면제 (단, 경매의 경우 점수가 낮아도 면제 없이 퀴즈를 진행함)
+            if (totalScore <= 20 && !"auction".equals(phaseType)) {
                 String quizPassedToken = generateAndSaveQuizPassedToken(tokenInfo);
                 return VqaStartResponse.exempt(quizPassedToken);
             }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #232 

## 📝 작업 내용

>  경매 관련 수정 작업 진행했습니다 + 보안퀴즈 수정도 함께 포함했습니다
- `BidService.java` 결제 완료 시각 수정
- `AuctionSecurityConfig.java` 낙찰 예약 상세 조회 API 퀴즈 토큰 제외
- `BidService.java`, `BidRepository.java` 경매 중복 참여 제한 로직 추가
- `VqaService.java` 경매 참여는 20점 아래여도 보안퀴즈 실행

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> 