### PR TITLE
fix: 티켓/드로우 응답의 전화번호 하이픈 형식 누락 수정

### DIFF
--- a/auth-service/src/main/java/com/t1/popcon/auth/identity/service/PhoneChangeService.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/identity/service/PhoneChangeService.java
@@ -84,10 +84,7 @@ public class PhoneChangeService {
         }
     }
 
-    /**
-     * 전화번호를 010-XXXX-XXXX 형식으로 변환
-     * PortOne 응답은 하이픈 없는 숫자열로 반환될 수 있음
-     */
+    /** 전화번호를 010-XXXX-XXXX 형식으로 변환 */
     private String formatPhone(String phone) {
         if (phone == null || phone.isBlank()) {
             return phone;

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -117,7 +117,8 @@ public class DrawEntryService {
             .entryDate(entry.getDrawOption().getEntryDate())
             .entryTime(entry.getDrawOption().getEntryTime())
             .userName(encryptionService.decrypt(entry.getEncryptedName()))
-            .userPhoneNumber(encryptionService.decrypt(entry.getEncryptedPhoneNumber()))
+            // 복호화된 전화번호를 하이픈 형식으로 포맷
+            .userPhoneNumber(formatPhone(encryptionService.decrypt(entry.getEncryptedPhoneNumber())))
             .paidAt(entry.getPaidAt())
             .status(entry.getStatus().name())
             .ticketIssuedAt(entry.getTicketIssuedAt())
@@ -134,7 +135,8 @@ public class DrawEntryService {
             .entryDate(drawOption.getEntryDate())
             .entryTime(drawOption.getEntryTime())
             .userName(encryptionService.decrypt(userInfo.encryptedName()))
-            .userPhoneNumber(encryptionService.decrypt(userInfo.encryptedPhoneNumber()))
+            // 복호화된 전화번호를 하이픈 형식으로 포맷
+            .userPhoneNumber(formatPhone(encryptionService.decrypt(userInfo.encryptedPhoneNumber())))
             .build();
     }
 
@@ -291,5 +293,20 @@ public class DrawEntryService {
         Throwable root = e.getMostSpecificCause();
         String message = root != null ? root.getMessage() : e.getMessage();
         return message != null && message.contains(DrawEntry.UNIQUE_CONSTRAINT_NAME);
+    }
+
+    /** 전화번호를 010-XXXX-XXXX 형식으로 변환 */
+    private static String formatPhone(String phone) {
+        if (phone == null || phone.isBlank()) {
+            return phone;
+        }
+        String trimmed = phone.trim();
+        if (trimmed.contains("-")) {
+            return trimmed;
+        }
+        if (trimmed.length() == 11 && trimmed.matches("\\d+")) {
+            return trimmed.substring(0, 3) + "-" + trimmed.substring(3, 7) + "-" + trimmed.substring(7);
+        }
+        return trimmed;
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/dto/UserProfileResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/UserProfileResponse.java
@@ -35,12 +35,16 @@ public record UserProfileResponse(
 
     /** 전화번호를 010-XXXX-XXXX 형식으로 변환 */
     private static String formatPhone(String phone) {
-        if (phone == null || phone.isBlank() || phone.contains("-")) {
+        if (phone == null || phone.isBlank()) {
             return phone;
         }
-        if (phone.length() == 11) {
-            return phone.substring(0, 3) + "-" + phone.substring(3, 7) + "-" + phone.substring(7);
+        String trimmed = phone.trim();
+        if (trimmed.contains("-")) {
+            return trimmed;
         }
-        return phone;
+        if (trimmed.length() == 11 && trimmed.matches("\\d+")) {
+            return trimmed.substring(0, 3) + "-" + trimmed.substring(3, 7) + "-" + trimmed.substring(7);
+        }
+        return trimmed;
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -78,7 +78,8 @@ public class UserService {
         return new TicketPurchaserProfileResponse(
             user.getId(),
             encryptionService.decrypt(user.getEncryptedName()),
-            encryptionService.decrypt(user.getEncryptedPhoneNumber()),
+            // 복호화된 전화번호를 하이픈 형식으로 포맷
+            formatPhone(encryptionService.decrypt(user.getEncryptedPhoneNumber())),
             user.getEmail(),
             billingKeyInfo.map(BillingKeyInfoResponse::cardName).orElse(null),
             billingKeyInfo.map(BillingKeyInfoResponse::cardNumber).orElse(null)
@@ -308,5 +309,20 @@ public class UserService {
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /** 전화번호를 010-XXXX-XXXX 형식으로 변환 */
+    private static String formatPhone(String phone) {
+        if (phone == null || phone.isBlank()) {
+            return phone;
+        }
+        String trimmed = phone.trim();
+        if (trimmed.contains("-")) {
+            return trimmed;
+        }
+        if (trimmed.length() == 11 && trimmed.matches("\\d+")) {
+            return trimmed.substring(0, 3) + "-" + trimmed.substring(3, 7) + "-" + trimmed.substring(7);
+        }
+        return trimmed;
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #233 

## 📝 작업 내용

> 전화번호를 응답하는 API 중 일부에서 하이픈 없이 반환되는 불일치 문제 수정
- `UserService.getTicketPurchaserProfile()` — 티켓 구매자 전화번호 포맷 적용
- `DrawEntryService.getEntryDetail()` — 드로우 상세 조회 전화번호 포맷 적용
- `DrawEntryService.buildApplyResult()` — 드로우 신청 결과 전화번호 포맷 적용
- `formatPhone()` 구현 방식 및 주석을 `PhoneChangeService` 기준으로 전체 통일

## ✅ 테스트 결과

- Before: `01012345678`
- After: `010-1234-5678`