### PR TITLE
chore(anti-macro): 점수 집계 디버깅 로그 추가

### DIFF
--- a/anti-macro-service/src/services/score-aggregator.ts
+++ b/anti-macro-service/src/services/score-aggregator.ts
@@ -26,13 +26,21 @@ export async function updatePageScore(
 ): Promise<void> {
   const key = `${KEY_PREFIX}${identityKey}`;
 
+  console.log(`[updatePageScore] key=${key} page=${page} incoming=${score}`);
+
   if (APPLICATION_PAGES.has(page)) {
-    await redis.hsetnx(key, page, score.toString());
+    const res = await redis.hsetnx(key, page, score.toString());
+    console.log(`[updatePageScore] HSETNX result=${res} (1=written, 0=already exists)`);
   } else {
     const existingStr = await redis.hget(key, page);
     const existing = existingStr !== null ? Number(existingStr) : -Infinity;
-    if (score > existing) {
+    const willWrite = score > existing;
+    console.log(
+      `[updatePageScore] existing=${existingStr === null ? 'null' : existing} willWrite=${willWrite}`,
+    );
+    if (willWrite) {
       await redis.hset(key, page, score.toString());
+      console.log(`[updatePageScore] HSET ${key} ${page} ${score}`);
     }
   }
 
@@ -56,16 +64,35 @@ export async function mergeScores(visitorId: string, userId: string): Promise<vo
   const visitorKey = `${KEY_PREFIX}${visitorId}`;
   const userKey = `${KEY_PREFIX}${userId}`;
 
+  console.log(`[merge] start visitorKey=${visitorKey} userKey=${userKey}`);
+
   const visitorScores = await redis.hgetall(visitorKey);
-  if (Object.keys(visitorScores).length === 0) return;
+  console.log(`[merge] visitorScores=`, visitorScores);
+
+  if (Object.keys(visitorScores).length === 0) {
+    console.log(`[merge] skip: visitor hash empty`);
+    return;
+  }
+
+  const userScoresBefore = await redis.hgetall(userKey);
+  console.log(`[merge] userScores(before)=`, userScoresBefore);
 
   for (const [page, scoreStr] of Object.entries(visitorScores)) {
     const incoming = Number(scoreStr);
     const existingStr = await redis.hget(userKey, page);
     const existing = existingStr !== null ? Number(existingStr) : -Infinity;
-    if (incoming > existing) {
+    const willWrite = incoming > existing;
+    console.log(
+      `[merge] field=${page} incoming=${incoming} existing=${existingStr === null ? 'null' : existing} willWrite=${willWrite}`,
+    );
+    if (willWrite) {
       await redis.hset(userKey, page, incoming.toString());
+      console.log(`[merge] HSET ${userKey} ${page} ${incoming}`);
     }
   }
   await redis.expire(userKey, SCORE_TTL);
+
+  const userScoresAfter = await redis.hgetall(userKey);
+  console.log(`[merge] userScores(after)=`, userScoresAfter);
+  console.log(`[merge] done`);
 }


### PR DESCRIPTION
## Summary
- `updatePageScore`에 key/page/incoming/existing/willWrite + HSET(NX) 결과 로그 추가
- `mergeScores`에 visitor/user hash 전후 스냅샷 + 필드별 비교 로그 추가

## Context
max-merge 전환 후 배포된 상태에서 `score:{userId}`의 `login` 필드가 계속 0에 고착되는 현상 관찰됨. MONITOR 로그로는 HSET 생략 여부만 보이고 어느 단계에서 점수가 유실되는지 추적이 안 돼서, 각 분기에 상세 로그를 넣어 원인을 좁히기 위한 변경.

로그 기준 가능한 분기:
- 로그인 페이지 요청 자체에서 `incoming=0`으로 들어오면 → anti-macro 분석 단계(honeypot signal 미탐지) 문제
- merge 시점 `visitorScores.login='0'`이면 → visitor hash에 애초에 안 쌓인 것
- merge에서 `willWrite=false`면 → user hash에 이미 더 큰 값 존재

## Test plan
- [ ] 배포 후 허니팟 로그인 → `[updatePageScore] HSET ... login 40` 확인
- [ ] 상세페이지 진입 → `[merge] HSET score:{user} login 40` 확인
- [ ] `HGETALL score:{user}`에 login=40 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)