### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/auth-service/src/main/java/com/t1/popcon/auth/config/AuthSecurityConfig.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/config/AuthSecurityConfig.java
@@ -27,6 +27,7 @@ public class AuthSecurityConfig extends CommonSecurityConfig {
 		super.configureCommonSettings(http);
 
 		http.authorizeHttpRequests(auth -> auth
+			.requestMatchers("/auth/logout").authenticated()
 			.requestMatchers("/auth/identity/phone-change").authenticated()
 			.requestMatchers(
 				"/auth/**",          // 로그인, 회원가입, 토큰 재발급 등

--- a/auth-service/src/main/java/com/t1/popcon/auth/controller/LogoutController.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/controller/LogoutController.java
@@ -1,0 +1,45 @@
+package com.t1.popcon.auth.controller;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.t1.popcon.auth.token.service.TokenService;
+import com.t1.popcon.auth.token.util.CookieProvider;
+import com.t1.popcon.common.auth.domain.AuthUser;
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.common.response.ApiResponse;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class LogoutController {
+
+	private final TokenService tokenService;
+	private final CookieProvider cookieProvider;
+
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Void>> logout(
+		@AuthenticationPrincipal AuthUser authUser,
+		HttpServletResponse response
+	) {
+		if (authUser == null || authUser.id() == null) {
+			throw new CustomException(ErrorCode.INVALID_TOKEN);
+		}
+
+		tokenService.logout(authUser.id());
+
+		ResponseCookie clearCookie = cookieProvider.removeRefreshTokenCookie();
+		response.addHeader(HttpHeaders.SET_COOKIE, clearCookie.toString());
+
+		return ResponseEntity.ok(ApiResponse.ok("로그아웃되었습니다."));
+	}
+}

--- a/auth-service/src/main/java/com/t1/popcon/auth/token/service/TokenService.java
+++ b/auth-service/src/main/java/com/t1/popcon/auth/token/service/TokenService.java
@@ -65,6 +65,15 @@ public class TokenService {
 		return new TokenReissueResult(newAccessToken, newRefreshToken, jwtProperties.getAccessTokenExpiration() / 1000);
 	}
 
+	@Transactional
+	public void logout(Long userId) {
+		if (userId == null) {
+			throw new CustomException(ErrorCode.INVALID_TOKEN);
+		}
+
+		refreshTokenRepository.deleteById(String.valueOf(userId));
+	}
+
 	public record TokenReissueResult(
 		String accessToken,
 		String refreshToken,


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #225 

## 📝 작업 내용

> 로그아웃 기능을 auth-service에 추가했습니다.

- 주요 변경 사항:
  - POST /auth/logout 엔드포인트를 추가했습니다.
  - /auth/logout 경로는 인증된 사용자만 호출할 수 있도록 보안 설정을 분리했습니다.
  - 로그아웃 시 현재 로그인한 사용자의 Redis refresh token을 삭제하도록 구현했습니다.
  - 응답 시 refresh_token 쿠키를 만료 처리하도록 적용했습니다.
  - 현재 구조상 access token은 stateless JWT이므로 서버에서 직접 무효화하지 않고, 프론트에서 별도로 제거하는 방식을 전제로 합니다.

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>
<img width="1403" height="576" alt="로그아웃 구현 성공 응답" src="https://github.com/user-attachments/assets/d70f1e18-dc5f-43ca-93c3-df5db4c4925a" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?