### PR TITLE
feat: 테스트용 팝업 데이터 통합 초기화 구현

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/DrawServiceClient.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/DrawServiceClient.java
@@ -1,0 +1,20 @@
+// 드로우 서비스 내부 호출용 Feign 클라이언트
+package com.t1.popcon.auction.bid.client;
+
+import com.t1.popcon.auction.bid.client.config.FeignClientConfig;
+import com.t1.popcon.common.response.ApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+    name = "draw-service",
+    url = "${services.draw-service.url:http://localhost:8084}",
+    configuration = FeignClientConfig.class
+)
+public interface DrawServiceClient {
+
+    // 테스트 초기화용: popupId 기준 드로우 데이터 + 대기열 Redis 초기화
+    @PostMapping("/internal/admin/draws/reset/{popupId}")
+    ApiResponse<Void> resetDraw(@PathVariable("popupId") Long popupId);
+}

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/TicketServiceClient.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/TicketServiceClient.java
@@ -5,6 +5,8 @@ import com.t1.popcon.auction.bid.client.dto.TicketIssueRequest;
 import com.t1.popcon.auction.bid.client.dto.TicketIssueResponse;
 import com.t1.popcon.common.response.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -17,4 +19,8 @@ public interface TicketServiceClient {
 
     @PostMapping("/internal/tickets")
     ApiResponse<TicketIssueResponse> issueTicket(@RequestBody TicketIssueRequest request);
+
+    // 테스트 초기화용: popupId 기준 티켓 전체 삭제
+    @DeleteMapping("/internal/admin/tickets/{popupId}")
+    ApiResponse<Void> deleteTicketsByPopupId(@PathVariable("popupId") Long popupId);
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
@@ -48,4 +48,9 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 	List<Bid> findAllByUserIdAndStatusOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("status") BidStatus status);
 
 	boolean existsByUserIdAndAuctionIdAndStatus(Long userId, Long auctionId, BidStatus status);
+
+    // 테스트 초기화용: auctionId 기준 입찰 내역 하드 딜리트
+    @Modifying
+    @Query(value = "DELETE FROM bids WHERE auction_id = :auctionId", nativeQuery = true)
+    void deleteAllByAuctionId(@Param("auctionId") Long auctionId);
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
@@ -59,11 +59,13 @@ public class AuctionSecurityConfig extends CommonSecurityConfig {
         };
 
         http
-          .securityMatcher("/auctions/**", "/bids/**", "/admin/auctions/**", "/internal/**")
+          .securityMatcher("/auctions/**", "/bids/**", "/admin/**", "/internal/**")
           .authorizeHttpRequests(auth -> auth
             .requestMatchers("/internal/**").permitAll()
             .requestMatchers(HttpMethod.GET,"/auctions/{auctionId}").permitAll()
             .requestMatchers(HttpMethod.GET,"/auctions/{auctionId}/stream").permitAll()
+            .requestMatchers("/admin/popups/*/reset").permitAll()
+            .requestMatchers("/admin/**").authenticated()
             .requestMatchers("/auctions/**", "/bids/**").authenticated() // 나머지는 퀴즈 토큰 필요
             .anyRequest().authenticated()
           )

--- a/auction-service/src/main/java/com/t1/popcon/auction/controller/PopupResetController.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/controller/PopupResetController.java
@@ -1,0 +1,32 @@
+// 테스트용 팝업 데이터 통합 초기화 컨트롤러
+package com.t1.popcon.auction.controller;
+
+import com.t1.popcon.auction.service.PopupResetService;
+import com.t1.popcon.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/popups")
+@RequiredArgsConstructor
+public class PopupResetController {
+
+    private final PopupResetService popupResetService;
+
+    /**
+     * 팝업 전체 데이터 초기화 (부하 테스트용)
+     * - DB: bids, draw_entries 삭제 / AuctionOption.remainingStock, DrawOption.processed 원복 / Auction 상태 원복
+     * - Redis: 경매 재고 키, 대기열 키 삭제 (auction + draw 양쪽)
+     * - tickets: ticket-service Feign으로 삭제
+     */
+    @PostMapping("/{popupId}/reset")
+    public ResponseEntity<ApiResponse<Void>> reset(@PathVariable Long popupId) {
+        popupResetService.reset(popupId);
+        popupResetService.resetRedisAndDraw(popupId);
+        return ResponseEntity.ok(ApiResponse.ok("팝업 초기화 완료 (popupId: " + popupId + ")"));
+    }
+}

--- a/auction-service/src/main/java/com/t1/popcon/auction/domain/Auction.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/domain/Auction.java
@@ -113,6 +113,12 @@ public class Auction extends BaseSoftDeleteEntity {
         this.status = status;
     }
 
+    // 테스트 초기화용: 경매 상태 및 완판 정보 원복
+    public void resetForTest() {
+        this.status = AuctionStatus.OPEN;
+        this.soldAt = null;
+    }
+
     private void validatePricePolicy(
             Long popupId,
             Integer startPrice,

--- a/auction-service/src/main/java/com/t1/popcon/auction/repository/AuctionOptionRepository.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/repository/AuctionOptionRepository.java
@@ -33,4 +33,9 @@ public interface AuctionOptionRepository extends JpaRepository<AuctionOption, Lo
     @Modifying
     @Query("UPDATE AuctionOption ao SET ao.remainingStock = ao.remainingStock - 1, ao.version = ao.version + 1 WHERE ao.id = :id AND ao.remainingStock > 0")
     int decreaseStockAtomic(@Param("id") Long id);
+
+    // 테스트 초기화용: auctionId 기준 remainingStock 원복 (auction.stockPerOption 기준)
+    @Modifying
+    @Query(value = "UPDATE auction_options ao JOIN auctions a ON ao.auction_id = a.id SET ao.remaining_stock = a.stock_per_option WHERE ao.auction_id = :auctionId AND ao.deleted = false", nativeQuery = true)
+    int resetRemainingStockByAuctionId(@Param("auctionId") Long auctionId);
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/repository/AuctionRepository.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/repository/AuctionRepository.java
@@ -5,7 +5,11 @@ import com.t1.popcon.auction.domain.AuctionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
     List<Auction> findAllByStatusIn(List<AuctionStatus> statuses);
+
+    // popupId로 경매 조회
+    Optional<Auction> findByPopupId(Long popupId);
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionQueueResetService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionQueueResetService.java
@@ -2,7 +2,6 @@
 package com.t1.popcon.auction.service;
 
 import com.t1.popcon.queue.common.redis.QueueRedisKeys;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,25 +43,39 @@ public class AuctionQueueResetService {
         redisTemplate.delete(keys);
     }
 
-    // SCAN으로 패턴 매칭 키 수집 후 일괄 삭제
-    private void scanAndDelete(String pattern) {
-        // 1. 검색 옵션: 패턴에 맞는 키를 한 번에 200개씩 가져오도록 설정 (부하 방지)
-        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(200).build();
-        List<String> keys = new ArrayList<>();
+    private static final int BATCH_SIZE = 1000;
 
-        // 2. Redis 하위 커넥션을 열고 Cursor를 이용해 키를 순회하며 List에 수집
+    // SCAN으로 패턴 매칭 키를 배치 단위로 즉시 삭제 (전체 수집 시 OOM 방지)
+    private void scanAndDelete(String pattern) {
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(200).build();
+
         redisTemplate.execute((RedisCallback<Void>) (RedisConnection connection) -> {
             try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
-                // 바이트 배열로 넘어온 키 값을 UTF-8 문자열로 변환하여 저장
-                cursor.forEachRemaining(k -> keys.add(new String(k, StandardCharsets.UTF_8)));
+                List<byte[]> batch = new ArrayList<>();
+                int totalDeleted = 0;
+
+                while (cursor.hasNext()) {
+                    batch.add(cursor.next());
+
+                    // 배치가 가득 차면 즉시 삭제 후 초기화
+                    if (batch.size() >= BATCH_SIZE) {
+                        connection.keyCommands().del(batch.toArray(new byte[0][]));
+                        totalDeleted += batch.size();
+                        batch.clear();
+                    }
+                }
+
+                // 커서 종료 후 남은 키 삭제
+                if (!batch.isEmpty()) {
+                    connection.keyCommands().del(batch.toArray(new byte[0][]));
+                    totalDeleted += batch.size();
+                }
+
+                if (totalDeleted > 0) {
+                    log.info(">>>> [TestReset] 패턴={} 키 {}개 삭제", pattern, totalDeleted);
+                }
             }
             return null;
         });
-
-        // 3. 수집된 키가 존재할 경우 한 번에 일괄 삭제 처리
-        if (!keys.isEmpty()) {
-            redisTemplate.delete(keys);
-            log.info(">>>> [TestReset] 패턴={} 키 {}개 삭제", pattern, keys.size());
-        }
     }
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionQueueResetService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionQueueResetService.java
@@ -46,16 +46,20 @@ public class AuctionQueueResetService {
 
     // SCAN으로 패턴 매칭 키 수집 후 일괄 삭제
     private void scanAndDelete(String pattern) {
+        // 1. 검색 옵션: 패턴에 맞는 키를 한 번에 200개씩 가져오도록 설정 (부하 방지)
         ScanOptions options = ScanOptions.scanOptions().match(pattern).count(200).build();
         List<String> keys = new ArrayList<>();
 
+        // 2. Redis 하위 커넥션을 열고 Cursor를 이용해 키를 순회하며 List에 수집
         redisTemplate.execute((RedisCallback<Void>) (RedisConnection connection) -> {
             try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
+                // 바이트 배열로 넘어온 키 값을 UTF-8 문자열로 변환하여 저장
                 cursor.forEachRemaining(k -> keys.add(new String(k, StandardCharsets.UTF_8)));
             }
             return null;
         });
 
+        // 3. 수집된 키가 존재할 경우 한 번에 일괄 삭제 처리
         if (!keys.isEmpty()) {
             redisTemplate.delete(keys);
             log.info(">>>> [TestReset] 패턴={} 키 {}개 삭제", pattern, keys.size());

--- a/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionQueueResetService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionQueueResetService.java
@@ -1,0 +1,64 @@
+// 테스트용 경매 대기열 Redis 초기화 서비스
+package com.t1.popcon.auction.service;
+
+import com.t1.popcon.queue.common.redis.QueueRedisKeys;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuctionQueueResetService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * phaseType/phaseId에 해당하는 대기열 Redis 키 전체 삭제
+     * - 고정 키(waiting, heartbeat, active, seq): DEL
+     * - 사용자별 키(user:*, block:*): SCAN → DEL
+     */
+    public void reset(String phaseType, long phaseId) {
+        deleteFixedKeys(phaseType, phaseId);
+        scanAndDelete("queue:user:" + phaseType + ":" + phaseId + ":*");
+        scanAndDelete("queue:block:" + phaseType + ":" + phaseId + ":*");
+        log.info(">>>> [TestReset] {}:{} 대기열 Redis 초기화 완료", phaseType, phaseId);
+    }
+
+    // 고정 키 일괄 삭제
+    private void deleteFixedKeys(String phaseType, long phaseId) {
+        List<String> keys = List.of(
+            QueueRedisKeys.waiting(phaseType, phaseId),
+            QueueRedisKeys.heartbeat(phaseType, phaseId),
+            QueueRedisKeys.active(phaseType, phaseId),
+            QueueRedisKeys.seq(phaseType, phaseId)
+        );
+        redisTemplate.delete(keys);
+    }
+
+    // SCAN으로 패턴 매칭 키 수집 후 일괄 삭제
+    private void scanAndDelete(String pattern) {
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(200).build();
+        List<String> keys = new ArrayList<>();
+
+        redisTemplate.execute((RedisCallback<Void>) (RedisConnection connection) -> {
+            try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
+                cursor.forEachRemaining(k -> keys.add(new String(k, StandardCharsets.UTF_8)));
+            }
+            return null;
+        });
+
+        if (!keys.isEmpty()) {
+            redisTemplate.delete(keys);
+            log.info(">>>> [TestReset] 패턴={} 키 {}개 삭제", pattern, keys.size());
+        }
+    }
+}

--- a/auction-service/src/main/java/com/t1/popcon/auction/service/PopupResetService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/service/PopupResetService.java
@@ -17,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -51,9 +53,14 @@ public class PopupResetService {
             .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_NOT_FOUND));
         long auctionId = auction.getId();
 
-        // 1. 티켓 삭제 (Feign - ticket-service)
-        ticketServiceClient.deleteTicketsByPopupId(popupId);
-        log.info(">>>> [TestReset] popupId={} 티켓 삭제 완료", popupId);
+        // 1. 티켓 삭제 (Feign - ticket-service) — 트랜잭션 커밋 후 실행하여 외부 호출이 롤백에 영향받지 않도록 처리
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                ticketServiceClient.deleteTicketsByPopupId(popupId);
+                log.info(">>>> [TestReset] popupId={} 티켓 삭제 완료", popupId);
+            }
+        });
 
         // 2. 입찰 내역 하드 딜리트
         bidRepository.deleteAllByAuctionId(auctionId);
@@ -97,9 +104,14 @@ public class PopupResetService {
         // Redis 경매 대기열 키 초기화
         auctionQueueResetService.reset("auction", auctionId);
 
-        // 드로우 초기화 (Feign - draw-service)
-        drawServiceClient.resetDraw(popupId);
-        log.info(">>>> [TestReset] popupId={} 드로우 초기화 완료 (draw-service)", popupId);
+        // 드로우 초기화 (Feign - draw-service) — 실패 시 경고 로그 후 예외 전파
+        try {
+            drawServiceClient.resetDraw(popupId);
+            log.info(">>>> [TestReset] popupId={} 드로우 초기화 완료 (draw-service)", popupId);
+        } catch (Exception e) {
+            log.warn(">>>> [TestReset] popupId={} 드로우 초기화 실패 (draw-service): {}", popupId, e.getMessage());
+            throw e;
+        }
 
         log.info(">>>> [TestReset] popupId={} 통합 초기화 완료", popupId);
     }

--- a/auction-service/src/main/java/com/t1/popcon/auction/service/PopupResetService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/service/PopupResetService.java
@@ -35,15 +35,12 @@ public class PopupResetService {
     private final StringRedisTemplate redisTemplate;
 
     /**
-     * popupId 기준 팝업 전체 데이터 초기화
-     * 처리 순서:
-     * 1. 티켓 삭제 (ticket-service Feign) — popupId 기준 한 번에 처리
+     * popupId 기준 DB 데이터 초기화 (steps 1–4)
+     * 1. 티켓 삭제 — ticket-service Feign, afterCommit 훅으로 실행
      * 2. 입찰 내역 하드 딜리트
      * 3. AuctionOption.remainingStock 원복
      * 4. Auction.status/soldAt 원복
-     * 5. Redis 경매 재고 키 초기화
-     * 6. Redis 경매 대기열 키 초기화
-     * 7. 드로우 데이터 + 대기열 초기화 (draw-service Feign)
+     * Redis 및 드로우 초기화는 resetRedisAndDraw() 에서 처리
      */
     @Transactional
     public void reset(Long popupId) {
@@ -78,10 +75,10 @@ public class PopupResetService {
     }
 
     /**
-     * Redis 초기화 (트랜잭션 밖에서 호출)
-     * - 경매 재고/메타 키 삭제
-     * - 경매 대기열 키 삭제
-     * - 드로우 초기화 (draw-service Feign)
+     * Redis 및 드로우 초기화 (steps 5–7), reset() 커밋 후 호출
+     * 5. Redis 경매 재고 키 초기화
+     * 6. Redis 경매 대기열 키 초기화
+     * 7. 드로우 데이터 + 대기열 초기화 — draw-service Feign
      */
     public void resetRedisAndDraw(Long popupId) {
         Auction auction = auctionRepository.findByPopupId(popupId)

--- a/auction-service/src/main/java/com/t1/popcon/auction/service/PopupResetService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/service/PopupResetService.java
@@ -1,0 +1,106 @@
+// 테스트용 팝업 데이터 통합 초기화 서비스
+package com.t1.popcon.auction.service;
+
+import com.t1.popcon.auction.bid.client.DrawServiceClient;
+import com.t1.popcon.auction.bid.client.TicketServiceClient;
+import com.t1.popcon.auction.bid.infrastructure.BidRedisRepository;
+import com.t1.popcon.auction.bid.repository.BidRepository;
+import com.t1.popcon.auction.domain.Auction;
+import com.t1.popcon.auction.domain.AuctionOption;
+import com.t1.popcon.auction.repository.AuctionOptionRepository;
+import com.t1.popcon.auction.repository.AuctionRepository;
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PopupResetService {
+
+    private final AuctionRepository auctionRepository;
+    private final AuctionOptionRepository auctionOptionRepository;
+    private final BidRepository bidRepository;
+    private final BidRedisRepository bidRedisRepository;
+    private final AuctionQueueResetService auctionQueueResetService;
+    private final DrawServiceClient drawServiceClient;
+    private final TicketServiceClient ticketServiceClient;
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * popupId 기준 팝업 전체 데이터 초기화
+     * 처리 순서:
+     * 1. 티켓 삭제 (ticket-service Feign) — popupId 기준 한 번에 처리
+     * 2. 입찰 내역 하드 딜리트
+     * 3. AuctionOption.remainingStock 원복
+     * 4. Auction.status/soldAt 원복
+     * 5. Redis 경매 재고 키 초기화
+     * 6. Redis 경매 대기열 키 초기화
+     * 7. 드로우 데이터 + 대기열 초기화 (draw-service Feign)
+     */
+    @Transactional
+    public void reset(Long popupId) {
+        log.info(">>>> [TestReset] popupId={} 통합 초기화 시작", popupId);
+
+        Auction auction = auctionRepository.findByPopupId(popupId)
+            .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_NOT_FOUND));
+        long auctionId = auction.getId();
+
+        // 1. 티켓 삭제 (Feign - ticket-service)
+        ticketServiceClient.deleteTicketsByPopupId(popupId);
+        log.info(">>>> [TestReset] popupId={} 티켓 삭제 완료", popupId);
+
+        // 2. 입찰 내역 하드 딜리트
+        bidRepository.deleteAllByAuctionId(auctionId);
+        log.info(">>>> [TestReset] auctionId={} 입찰 내역 삭제 완료", auctionId);
+
+        // 3. AuctionOption.remainingStock 원복
+        int resetCount = auctionOptionRepository.resetRemainingStockByAuctionId(auctionId);
+        log.info(">>>> [TestReset] auctionId={} AuctionOption {} 개 재고 원복 완료", auctionId, resetCount);
+
+        // 4. Auction 상태 원복
+        auction.resetForTest();
+        log.info(">>>> [TestReset] auctionId={} 상태 원복 완료 (OPEN, soldAt=null)", auctionId);
+
+        log.info(">>>> [TestReset] auctionId={} DB 초기화 완료", auctionId);
+    }
+
+    /**
+     * Redis 초기화 (트랜잭션 밖에서 호출)
+     * - 경매 재고/메타 키 삭제
+     * - 경매 대기열 키 삭제
+     * - 드로우 초기화 (draw-service Feign)
+     */
+    public void resetRedisAndDraw(Long popupId) {
+        Auction auction = auctionRepository.findByPopupId(popupId)
+            .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_NOT_FOUND));
+        long auctionId = auction.getId();
+
+        // Redis 경매 재고 키 초기화
+        List<AuctionOption> options = auctionOptionRepository
+            .findByAuction_IdOrderByEntryDateAscEntryTimeAsc(auctionId);
+
+        for (AuctionOption option : options) {
+            // DB에서 원복된 remainingStock 기준으로 Redis 재고 초기화
+            bidRedisRepository.setAvailableStock(option.getId(), auction.getStockPerOption());
+            redisTemplate.delete("auction:option:" + option.getId() + ":pending-restock");
+        }
+        redisTemplate.delete("auction:" + auctionId + ":sold-out-price");
+        redisTemplate.delete("auction:" + auctionId + ":restock-anchor-at");
+        log.info(">>>> [TestReset] auctionId={} Redis 경매 재고 초기화 완료", auctionId);
+
+        // Redis 경매 대기열 키 초기화
+        auctionQueueResetService.reset("auction", auctionId);
+
+        // 드로우 초기화 (Feign - draw-service)
+        drawServiceClient.resetDraw(popupId);
+        log.info(">>>> [TestReset] popupId={} 드로우 초기화 완료 (draw-service)", popupId);
+
+        log.info(">>>> [TestReset] popupId={} 통합 초기화 완료", popupId);
+    }
+}

--- a/auction-service/src/main/resources/application-local.yml
+++ b/auction-service/src/main/resources/application-local.yml
@@ -16,7 +16,7 @@ spring:
         format_sql: true
         jdbc:
           time_zone: Asia/Seoul
-    show-sql: true
+    show-sql: false
     defer-datasource-initialization: true
 
   jackson:
@@ -30,8 +30,8 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+    org.hibernate.SQL: off
+    org.hibernate.orm.jdbc.bind: off
 
 jwt:
   secret: ${JWT_SECRET}

--- a/auction-service/src/main/resources/application-staging.yml
+++ b/auction-service/src/main/resources/application-staging.yml
@@ -41,7 +41,7 @@ server:
 logging:
   level:
     root: info
-    org.hibernate: warn
+    org.hibernate: off
     org.hibernate.SQL: off
     org.hibernate.orm.jdbc.bind: off
 

--- a/draw-service/src/main/java/com/t1/popcon/draw/client/TicketServiceClient.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/client/TicketServiceClient.java
@@ -5,6 +5,8 @@ import com.t1.popcon.draw.client.config.FeignClientConfig;
 import com.t1.popcon.draw.client.dto.TicketIssueRequest;
 import com.t1.popcon.draw.client.dto.TicketIssueResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -17,4 +19,8 @@ public interface TicketServiceClient {
 
     @PostMapping("/internal/tickets")
     ApiResponse<TicketIssueResponse> issueTicket(@RequestBody TicketIssueRequest request);
+
+    // 테스트 초기화용: popupId 기준 티켓 전체 삭제
+    @DeleteMapping("/internal/admin/tickets/{popupId}")
+    ApiResponse<Void> deleteTicketsByPopupId(@PathVariable("popupId") Long popupId);
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/controller/InternalDrawResetController.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/controller/InternalDrawResetController.java
@@ -20,8 +20,7 @@ public class InternalDrawResetController {
     // popupId 기준 드로우 데이터 + 대기열 Redis 초기화
     @PostMapping("/reset/{popupId}")
     public ResponseEntity<ApiResponse<Void>> reset(@PathVariable Long popupId) {
-        internalDrawResetService.resetByPopupId(popupId);
-        internalDrawResetService.resetQueueByPopupId(popupId);
+        internalDrawResetService.resetAllByPopupId(popupId);
         return ResponseEntity.ok(ApiResponse.ok("드로우 초기화 완료 (popupId: " + popupId + ")"));
     }
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/controller/InternalDrawResetController.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/controller/InternalDrawResetController.java
@@ -1,0 +1,27 @@
+// 테스트용 드로우 초기화 컨트롤러 (내부 호출 전용)
+package com.t1.popcon.draw.controller;
+
+import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.draw.service.InternalDrawResetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/admin/draws")
+@RequiredArgsConstructor
+public class InternalDrawResetController {
+
+    private final InternalDrawResetService internalDrawResetService;
+
+    // popupId 기준 드로우 데이터 + 대기열 Redis 초기화
+    @PostMapping("/reset/{popupId}")
+    public ResponseEntity<ApiResponse<Void>> reset(@PathVariable Long popupId) {
+        internalDrawResetService.resetByPopupId(popupId);
+        internalDrawResetService.resetQueueByPopupId(popupId);
+        return ResponseEntity.ok(ApiResponse.ok("드로우 초기화 완료 (popupId: " + popupId + ")"));
+    }
+}

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
@@ -5,6 +5,9 @@ import com.t1.popcon.draw.domain.DrawEntryStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -23,4 +26,9 @@ public interface DrawEntryRepository extends JpaRepository<DrawEntry, Long> {
     boolean existsByDrawOption_IdAndStatus(Long drawOptionId, DrawEntryStatus status);
 
     Optional<DrawEntry> findByIdAndUserId(Long id, Long userId);
+
+    // 테스트 초기화용: drawId 기준 응모 내역 하드 딜리트
+    @Modifying
+    @Query(value = "DELETE FROM draw_entries WHERE draw_option_id IN (SELECT id FROM draw_options WHERE draw_id = :drawId AND deleted = false)", nativeQuery = true)
+    void deleteAllByDrawId(@Param("drawId") Long drawId);
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
@@ -27,8 +27,8 @@ public interface DrawEntryRepository extends JpaRepository<DrawEntry, Long> {
 
     Optional<DrawEntry> findByIdAndUserId(Long id, Long userId);
 
-    // 테스트 초기화용: drawId 기준 응모 내역 하드 딜리트
+    // 테스트 초기화용: drawId 기준 응모 내역 하드 딜리트 (소프트 딜리트된 옵션의 응모도 포함)
     @Modifying
-    @Query(value = "DELETE FROM draw_entries WHERE draw_option_id IN (SELECT id FROM draw_options WHERE draw_id = :drawId AND deleted = false)", nativeQuery = true)
+    @Query(value = "DELETE FROM draw_entries WHERE draw_option_id IN (SELECT id FROM draw_options WHERE draw_id = :drawId)", nativeQuery = true)
     void deleteAllByDrawId(@Param("drawId") Long drawId);
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawOptionRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawOptionRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +23,9 @@ public interface DrawOptionRepository extends JpaRepository<DrawOption, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select drawOption from DrawOption drawOption join fetch drawOption.draw where drawOption.id = :drawOptionId")
     Optional<DrawOption> findByIdForUpdate(@Param("drawOptionId") Long drawOptionId);
+
+    // 테스트 초기화용: drawId 기준 processed 원복
+    @Modifying
+    @Query("UPDATE DrawOption o SET o.processed = false, o.processedAt = null WHERE o.draw.id = :drawId AND o.deleted = false")
+    int resetProcessedByDrawId(@Param("drawId") Long drawId);
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface DrawRepository extends JpaRepository<Draw, Long> {
 
+    // popupId로 드로우 조회
+    Optional<Draw> findByPopupId(Long popupId);
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawQueueResetService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawQueueResetService.java
@@ -46,16 +46,20 @@ public class DrawQueueResetService {
 
     // SCAN으로 패턴 매칭 키 수집 후 일괄 삭제
     private void scanAndDelete(String pattern) {
+        // 1. 검색 옵션: 패턴에 맞는 키를 한 번에 200개씩 가져오도록 설정 (부하 방지)
         ScanOptions options = ScanOptions.scanOptions().match(pattern).count(200).build();
         List<String> keys = new ArrayList<>();
 
+        // 2. Redis 하위 커넥션을 열고 Cursor를 이용해 키를 순회하며 List에 수집
         redisTemplate.execute((RedisCallback<Void>) (RedisConnection connection) -> {
             try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
+                // 바이트 배열로 넘어온 키 값을 UTF-8 문자열로 변환하여 저장
                 cursor.forEachRemaining(k -> keys.add(new String(k, StandardCharsets.UTF_8)));
             }
             return null;
         });
 
+        // 3. 수집된 키가 존재할 경우 한 번에 일괄 삭제 처리
         if (!keys.isEmpty()) {
             redisTemplate.delete(keys);
             log.info(">>>> [TestReset] 패턴={} 키 {}개 삭제", pattern, keys.size());

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawQueueResetService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawQueueResetService.java
@@ -2,7 +2,6 @@
 package com.t1.popcon.draw.service;
 
 import com.t1.popcon.queue.common.redis.QueueRedisKeys;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,25 +43,39 @@ public class DrawQueueResetService {
         redisTemplate.delete(keys);
     }
 
-    // SCAN으로 패턴 매칭 키 수집 후 일괄 삭제
-    private void scanAndDelete(String pattern) {
-        // 1. 검색 옵션: 패턴에 맞는 키를 한 번에 200개씩 가져오도록 설정 (부하 방지)
-        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(200).build();
-        List<String> keys = new ArrayList<>();
+    private static final int BATCH_SIZE = 1000;
 
-        // 2. Redis 하위 커넥션을 열고 Cursor를 이용해 키를 순회하며 List에 수집
+    // SCAN으로 패턴 매칭 키를 배치 단위로 즉시 삭제 (전체 수집 시 OOM 방지)
+    private void scanAndDelete(String pattern) {
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(200).build();
+
         redisTemplate.execute((RedisCallback<Void>) (RedisConnection connection) -> {
             try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
-                // 바이트 배열로 넘어온 키 값을 UTF-8 문자열로 변환하여 저장
-                cursor.forEachRemaining(k -> keys.add(new String(k, StandardCharsets.UTF_8)));
+                List<byte[]> batch = new ArrayList<>();
+                int totalDeleted = 0;
+
+                while (cursor.hasNext()) {
+                    batch.add(cursor.next());
+
+                    // 배치가 가득 차면 즉시 삭제 후 초기화
+                    if (batch.size() >= BATCH_SIZE) {
+                        connection.keyCommands().del(batch.toArray(new byte[0][]));
+                        totalDeleted += batch.size();
+                        batch.clear();
+                    }
+                }
+
+                // 커서 종료 후 남은 키 삭제
+                if (!batch.isEmpty()) {
+                    connection.keyCommands().del(batch.toArray(new byte[0][]));
+                    totalDeleted += batch.size();
+                }
+
+                if (totalDeleted > 0) {
+                    log.info(">>>> [TestReset] 패턴={} 키 {}개 삭제", pattern, totalDeleted);
+                }
             }
             return null;
         });
-
-        // 3. 수집된 키가 존재할 경우 한 번에 일괄 삭제 처리
-        if (!keys.isEmpty()) {
-            redisTemplate.delete(keys);
-            log.info(">>>> [TestReset] 패턴={} 키 {}개 삭제", pattern, keys.size());
-        }
     }
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawQueueResetService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawQueueResetService.java
@@ -1,0 +1,64 @@
+// 테스트용 드로우 대기열 Redis 초기화 서비스
+package com.t1.popcon.draw.service;
+
+import com.t1.popcon.queue.common.redis.QueueRedisKeys;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DrawQueueResetService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * phaseType/phaseId에 해당하는 대기열 Redis 키 전체 삭제
+     * - 고정 키(waiting, heartbeat, active, seq): DEL
+     * - 사용자별 키(user:*, block:*): SCAN → DEL
+     */
+    public void reset(String phaseType, long phaseId) {
+        deleteFixedKeys(phaseType, phaseId);
+        scanAndDelete("queue:user:" + phaseType + ":" + phaseId + ":*");
+        scanAndDelete("queue:block:" + phaseType + ":" + phaseId + ":*");
+        log.info(">>>> [TestReset] {}:{} 대기열 Redis 초기화 완료", phaseType, phaseId);
+    }
+
+    // 고정 키 일괄 삭제
+    private void deleteFixedKeys(String phaseType, long phaseId) {
+        List<String> keys = List.of(
+            QueueRedisKeys.waiting(phaseType, phaseId),
+            QueueRedisKeys.heartbeat(phaseType, phaseId),
+            QueueRedisKeys.active(phaseType, phaseId),
+            QueueRedisKeys.seq(phaseType, phaseId)
+        );
+        redisTemplate.delete(keys);
+    }
+
+    // SCAN으로 패턴 매칭 키 수집 후 일괄 삭제
+    private void scanAndDelete(String pattern) {
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(200).build();
+        List<String> keys = new ArrayList<>();
+
+        redisTemplate.execute((RedisCallback<Void>) (RedisConnection connection) -> {
+            try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
+                cursor.forEachRemaining(k -> keys.add(new String(k, StandardCharsets.UTF_8)));
+            }
+            return null;
+        });
+
+        if (!keys.isEmpty()) {
+            redisTemplate.delete(keys);
+            log.info(">>>> [TestReset] 패턴={} 키 {}개 삭제", pattern, keys.size());
+        }
+    }
+}

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/InternalDrawResetService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/InternalDrawResetService.java
@@ -60,4 +60,10 @@ public class InternalDrawResetService {
 
         drawQueueResetService.reset("draw", draw.getId());
     }
+
+    // DB 초기화 + Redis 대기열 초기화를 단일 진입점으로 묶어 컨트롤러 단순화
+    public void resetAllByPopupId(Long popupId) {
+        resetByPopupId(popupId);
+        resetQueueByPopupId(popupId);
+    }
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/InternalDrawResetService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/InternalDrawResetService.java
@@ -25,11 +25,10 @@ public class InternalDrawResetService {
     private final TicketServiceClient ticketServiceClient;
 
     /**
-     * popupId 기준 드로우 데이터 전체 초기화
-     * 처리 순서:
+     * popupId 기준 드로우 DB 데이터 초기화 (트랜잭션)
      * 1. draw_entries 하드 딜리트
      * 2. draw_options.processed 원복
-     * 3. Redis 대기열 초기화
+     * Redis 대기열 초기화는 resetQueueByPopupId() 에서 처리
      * 티켓은 auction-service의 통합 초기화 시 popupId 기준으로 한 번에 처리
      */
     @Transactional

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/InternalDrawResetService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/InternalDrawResetService.java
@@ -1,0 +1,63 @@
+// 테스트용 드로우 데이터 초기화 서비스 (내부 호출 전용)
+package com.t1.popcon.draw.service;
+
+import com.t1.popcon.common.exception.CustomException;
+import com.t1.popcon.common.exception.ErrorCode;
+import com.t1.popcon.draw.client.TicketServiceClient;
+import com.t1.popcon.draw.domain.Draw;
+import com.t1.popcon.draw.repository.DrawEntryRepository;
+import com.t1.popcon.draw.repository.DrawOptionRepository;
+import com.t1.popcon.draw.repository.DrawRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InternalDrawResetService {
+
+    private final DrawRepository drawRepository;
+    private final DrawEntryRepository drawEntryRepository;
+    private final DrawOptionRepository drawOptionRepository;
+    private final DrawQueueResetService drawQueueResetService;
+    private final TicketServiceClient ticketServiceClient;
+
+    /**
+     * popupId 기준 드로우 데이터 전체 초기화
+     * 처리 순서:
+     * 1. draw_entries 하드 딜리트
+     * 2. draw_options.processed 원복
+     * 3. Redis 대기열 초기화
+     * 티켓은 auction-service의 통합 초기화 시 popupId 기준으로 한 번에 처리
+     */
+    @Transactional
+    public void resetByPopupId(Long popupId) {
+        log.info(">>>> [TestReset] popupId={} 드로우 초기화 시작", popupId);
+
+        // popupId로 드로우 조회
+        Draw draw = drawRepository.findByPopupId(popupId)
+            .orElseThrow(() -> new CustomException(ErrorCode.DRAW_NOT_FOUND));
+
+        long drawId = draw.getId();
+
+        // 응모 내역 하드 딜리트
+        drawEntryRepository.deleteAllByDrawId(drawId);
+        log.info(">>>> [TestReset] drawId={} 응모 내역 삭제 완료", drawId);
+
+        // DrawOption processed 원복
+        int resetCount = drawOptionRepository.resetProcessedByDrawId(drawId);
+        log.info(">>>> [TestReset] drawId={} DrawOption {} 개 processed 원복 완료", drawId, resetCount);
+
+        log.info(">>>> [TestReset] popupId={} 드로우 초기화 완료", popupId);
+    }
+
+    // 대기열 Redis 초기화 (트랜잭션 밖에서 호출)
+    public void resetQueueByPopupId(Long popupId) {
+        Draw draw = drawRepository.findByPopupId(popupId)
+            .orElseThrow(() -> new CustomException(ErrorCode.DRAW_NOT_FOUND));
+
+        drawQueueResetService.reset("draw", draw.getId());
+    }
+}

--- a/ticket-service/src/main/java/com/t1/popcon/ticket/controller/AdminTicketResetController.java
+++ b/ticket-service/src/main/java/com/t1/popcon/ticket/controller/AdminTicketResetController.java
@@ -1,0 +1,26 @@
+// 테스트용 티켓 초기화 컨트롤러 (내부 호출 전용)
+package com.t1.popcon.ticket.controller;
+
+import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.ticket.service.AdminTicketResetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/admin/tickets")
+@RequiredArgsConstructor
+public class AdminTicketResetController {
+
+    private final AdminTicketResetService adminTicketResetService;
+
+    // 특정 팝업의 티켓 전체 삭제
+    @DeleteMapping("/{popupId}")
+    public ResponseEntity<ApiResponse<Void>> deleteByPopupId(@PathVariable Long popupId) {
+        adminTicketResetService.deleteByPopupId(popupId);
+        return ResponseEntity.ok(ApiResponse.ok("티켓 초기화 완료 (popupId: " + popupId + ")"));
+    }
+}

--- a/ticket-service/src/main/java/com/t1/popcon/ticket/repository/TicketRepository.java
+++ b/ticket-service/src/main/java/com/t1/popcon/ticket/repository/TicketRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -31,4 +32,9 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
         @Param("sourceType") TicketSourceType sourceType,
         @Param("sourceId") Long sourceId
     );
+
+    // 테스트 초기화용: popupId 기준 하드 딜리트
+    @Modifying
+    @Query(value = "DELETE FROM tickets WHERE popup_id = :popupId", nativeQuery = true)
+    void deleteAllByPopupId(@Param("popupId") Long popupId);
 }

--- a/ticket-service/src/main/java/com/t1/popcon/ticket/service/AdminTicketResetService.java
+++ b/ticket-service/src/main/java/com/t1/popcon/ticket/service/AdminTicketResetService.java
@@ -1,0 +1,23 @@
+// 테스트용 티켓 초기화 서비스
+package com.t1.popcon.ticket.service;
+
+import com.t1.popcon.ticket.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminTicketResetService {
+
+    private final TicketRepository ticketRepository;
+
+    // popupId에 해당하는 티켓 전체 하드 딜리트
+    @Transactional
+    public void deleteByPopupId(Long popupId) {
+        ticketRepository.deleteAllByPopupId(popupId);
+        log.info(">>>> [TestReset] popupId={} 티켓 삭제 완료", popupId);
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #246 

## 📝 작업 내용
> 반복 부하 테스트 시 데이터 리셋을 위한 단일 초기화 API를 구현했습니다.

`POST /admin/popups/{popupId}/reset (auction-service)`

- `bids`, `draw_entries` 하드 딜리트
- `auction_options.remaining_stock`, `draw_options.processed` 원복
- `auctions.status = OPEN`, `sold_at = null` 원복
- `tickets` 하드 딜리트 (ticket-service Feign)
- Redis 경매 재고 키 초기화 (`auction:option:*`)
- Redis 대기열 키 초기화 — draw/auction 양쪽 (`queue:waiting/heartbeat/active/seq/user:*/block:*`)

부수 수정: auction-service Hibernate SQL 로그 제거 (SSE 1초 반복 로그)
## ✅ 테스트 결과 
- 3개 서비스 컴파일 통과 (`./gradlew compileJava`)
- 실제 데이터 초기화 API 동작은 부하 테스트 사전 검증 시 확인 예정

## ⚠️ 주의사항
- 해당 API는 외부에 노출되지 않도록 주의 (인증 없음)
  - 현재 JWT에 role이 담기지 않는 것으로 확인되어, 우선 permitAll로 유지하겠습니다.
- 실행 시 팝업 관련 모든 데이터가 영구 삭제되므로 함부로 호출 금지
- 사용 전 반드시 팀원에게 사전 공유 후 진행

## 💬 리뷰 요구사항
- popup-service에 Redis 연결과 Feign 클라이언트가 없어서 추가 작업이 많아지기 때문에 `PopupResetService`를 auction-service에 두었습니다. 참고해주세요.
- QA 시에도 반복적인 초기화를 용이하게 하기 위해 부하테스트용 `popupId`인지 검증하는 부분은 우선 제외했습니다.