### PR TITLE
refactor: 팝업 초기화 API를 /admin에서 /internal/admin으로 변경

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
@@ -64,7 +64,6 @@ public class AuctionSecurityConfig extends CommonSecurityConfig {
             .requestMatchers("/internal/**").permitAll()
             .requestMatchers(HttpMethod.GET,"/auctions/{auctionId}").permitAll()
             .requestMatchers(HttpMethod.GET,"/auctions/{auctionId}/stream").permitAll()
-            .requestMatchers("/admin/popups/*/reset").permitAll()
             .requestMatchers("/admin/**").authenticated()
             .requestMatchers("/auctions/**", "/bids/**").authenticated() // 나머지는 퀴즈 토큰 필요
             .anyRequest().authenticated()

--- a/auction-service/src/main/java/com/t1/popcon/auction/controller/PopupResetController.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/controller/PopupResetController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/admin/popups")
+@RequestMapping("/internal/admin/popups")
 @RequiredArgsConstructor
 public class PopupResetController {
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Related to #246, #247 

## 📝 작업 내용

- `POST /admin/popups/{popupId}/reset` → `POST /internal/admin/popups/{popupId}/reset`
- `X-Internal-Secret` 헤더 인증으로 교체 (기존 `permitAll`)

**이동 이유**
- 기존 `/admin/popups/*/reset`은 JWT 없이 `permitAll`로 열려 있어 외부에서 누구나 호출 가능
- `/internal/` 경로는 `InternalApiAuthFilter`가 `X-Internal-Secret` 헤더를 검증하여 미리 공유된 시크릿 없이는 접근 불가
- 부하 테스트용 초기화 API는 내부 호출 전용이므로 `/internal/` 패턴이 의미적으로도 적합