### PR TITLE
refactor: 팝업 초기화 API 외부 호출 지원

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/config/AuctionSecurityConfig.java
@@ -52,7 +52,7 @@ public class AuctionSecurityConfig extends CommonSecurityConfig {
                 // 2. 예약 상세 조회 제외
                 if (method.equals("GET") && path.startsWith("/auctions/reservations/")) return true;
                 // 3. 어드민 및 내부 API 제외
-                if (path.startsWith("/admin/") || path.startsWith("/internal/")) return true;
+                if (path.startsWith("/admin/") || path.startsWith("/internal/") || path.startsWith("/auctions/internal/")) return true;
                 // 4. 헬스체크 등 공용 API 제외
                 return path.equals("/health") || path.startsWith("/actuator/");
             }
@@ -62,6 +62,7 @@ public class AuctionSecurityConfig extends CommonSecurityConfig {
           .securityMatcher("/auctions/**", "/bids/**", "/admin/**", "/internal/**")
           .authorizeHttpRequests(auth -> auth
             .requestMatchers("/internal/**").permitAll()
+            .requestMatchers("/auctions/internal/**").permitAll()
             .requestMatchers(HttpMethod.GET,"/auctions/{auctionId}").permitAll()
             .requestMatchers(HttpMethod.GET,"/auctions/{auctionId}/stream").permitAll()
             .requestMatchers("/admin/**").authenticated()

--- a/auction-service/src/main/java/com/t1/popcon/auction/config/InternalApiAuthFilter.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/config/InternalApiAuthFilter.java
@@ -21,7 +21,6 @@ import java.util.List;
 @Component
 public class InternalApiAuthFilter extends OncePerRequestFilter {
 
-    private static final String INTERNAL_API_PREFIX = "/internal/";
     private static final String INTERNAL_SECRET_HEADER = "X-Internal-Secret";
 
     @Value("${internal.api-secret}")
@@ -29,7 +28,9 @@ public class InternalApiAuthFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return !request.getRequestURI().startsWith(INTERNAL_API_PREFIX);
+        String uri = request.getRequestURI();
+        // 서비스 prefix 없는 내부 경로(/internal/)와 게이트웨이 라우팅용 경로(/auctions/internal/) 모두 처리
+        return !uri.startsWith("/internal/") && !uri.startsWith("/auctions/internal/");
     }
 
     @Override

--- a/auction-service/src/main/java/com/t1/popcon/auction/controller/PopupResetController.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/controller/PopupResetController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/internal/admin/popups")
+@RequestMapping("/auctions/internal/admin/popups")
 @RequiredArgsConstructor
 public class PopupResetController {
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #이슈번호
> 
> **이슈번호를 꼭 적어주세요**

## 📝 작업 내용

> 부하 테스트용 팝업 초기화 API를 외부에서 호출할 수 있도록 경로 및 인증 방식 변경

**변경 사항**
- 경로: `/admin/popups/{popupId}/reset` → `/auctions/internal/admin/popups/{popupId}/reset`
  - 게이트웨이가 `/auctions/` prefix 기준으로 auction-service로 라우팅
- 인증: permitAll → X-Internal-Secret 헤더 검증
  - `/auctions/internal/` 경로도 InternalApiAuthFilter 적용되도록 확장

**호출 방법**
`POST /auctions/internal/admin/popups/{popupId}/reset`
`X-Internal-Secret`: `{internal.api-secret 값}`