### PR TITLE
fix: acution-service 로컬/스테이징 환경 Hibernate SQL 로그 제거

### DIFF
--- a/auction-service/src/main/resources/application-local.yml
+++ b/auction-service/src/main/resources/application-local.yml
@@ -13,7 +13,8 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
+        show_sql: false
         jdbc:
           time_zone: Asia/Seoul
     show-sql: false

--- a/auction-service/src/main/resources/application-staging.yml
+++ b/auction-service/src/main/resources/application-staging.yml
@@ -24,6 +24,7 @@ spring:
     properties:
       hibernate:
         format_sql: false
+        show_sql: false
     show-sql: false
 
   data:


### PR DESCRIPTION
## #️⃣ 관련 이슈

> x

## 📝 작업 내용

- 경매 스케줄러가 1초마다 실행되며 Hibernate SQL 로그가 반복 적재되어 다른 로그들을 확인하기 어려운 문제 수정
- `application-local.yml`과 `application-staging.yml`에 `show_sql: false` 명시하여 차단