### PR TITLE
fix: Cloudflare WAF 차단으로 인한 초기화 API 경로 변경

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/controller/PopupResetController.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/controller/PopupResetController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/auctions/internal/admin/popups")
+@RequestMapping("/auctions/internal/popups")
 @RequiredArgsConstructor
 public class PopupResetController {
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Related to #246 

## 📝 작업 내용

> `/admin` 포함 경로가 Cloudflare WAF에 의해 외부에서 차단되는 문제 수정

- 변경: `/auctions/internal/admin/popups/{popupId}/reset`
   → `/auctions/internal/popups/{popupId}/reset`

- 인증은 X-Internal-Secret 헤더로 동일하게 유지