### PR TITLE
fix: auction→draw 서비스 호출 URL 설정 누락 추가

### DIFF
--- a/auction-service/src/main/resources/application-local.yml
+++ b/auction-service/src/main/resources/application-local.yml
@@ -50,3 +50,5 @@ services:
     url: ${TICKET_SERVICE_URL:http://localhost:8086}
   popup-service:
     url: ${POPUP_SERVICE_URL:http://localhost:8082}
+  draw-service:
+    url: ${DRAW_SERVICE_URL:http://localhost:8084}

--- a/auction-service/src/main/resources/application-staging.yml
+++ b/auction-service/src/main/resources/application-staging.yml
@@ -58,6 +58,8 @@ services:
     url: ${TICKET_SERVICE_URL:http://backend-ticket-svc:8080}
   popup-service:
     url: ${POPUP_SERVICE_URL:http://backend-popup-svc:8080}
+  draw-service:
+    url: ${DRAW_SERVICE_URL:http://backend-draw-svc:8080}
 
 
 management:


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Related to #246 

## 📝 작업 내용
- DrawServiceClient URL이 설정되지 않아 localhost로 fallback되어 Connection refused 발생
- application-staging.yml, application-local.yml에 draw-service URL 추가