### PR TITLE
fix: internal 경로 /admin 제거

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/DrawServiceClient.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/DrawServiceClient.java
@@ -15,6 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 public interface DrawServiceClient {
 
     // 테스트 초기화용: popupId 기준 드로우 데이터 + 대기열 Redis 초기화
-    @PostMapping("/internal/admin/draws/reset/{popupId}")
+    @PostMapping("/internal/draws/reset/{popupId}")
     ApiResponse<Void> resetDraw(@PathVariable("popupId") Long popupId);
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/controller/InternalDrawResetController.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/controller/InternalDrawResetController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/internal/admin/draws")
+@RequestMapping("/internal/draws")
 @RequiredArgsConstructor
 public class InternalDrawResetController {
 


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #243 

## 📝 작업 내용
- auction→draw 서비스 간 Feign 호출 시 RBAC: access denied 발생
- /admin 포함 경로가 Istio AuthorizationPolicy에 의해 차단된 것으로 추정
- `/internal/admin/draws/reset` → `/internal/draws/reset` 으로 변경

## ✅ 테스트 결과

> 배포 후 에러 여부 확인 예정