### PR TITLE
fix: draw 초기화 트랜잭션 오류 및 Feign 에러 메시지 수정

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/config/FeignClientConfig.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/config/FeignClientConfig.java
@@ -35,10 +35,10 @@ public class FeignClientConfig {
             int status = response.status();
 
             if (status >= 500) {
-                return new CustomException(ErrorCode.ERROR_SYSTEM, "user-service 호출에 실패했습니다.");
+                return new CustomException(ErrorCode.ERROR_SYSTEM, "내부 서비스 호출에 실패했습니다. [" + methodKey + "]");
             }
             if (status == 400) {
-                return new CustomException(ErrorCode.INVALID_INPUT, "user-service 요청 값 오류");
+                return new CustomException(ErrorCode.INVALID_INPUT, "내부 서비스 요청 값 오류 [" + methodKey + "]");
             }
             if (status == 401) {
                 return new CustomException(ErrorCode.ERROR_SYSTEM, "내부 API 인증에 실패했습니다.");

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/InternalDrawResetService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/InternalDrawResetService.java
@@ -61,6 +61,7 @@ public class InternalDrawResetService {
     }
 
     // DB 초기화 + Redis 대기열 초기화를 단일 진입점으로 묶어 컨트롤러 단순화
+    @Transactional
     public void resetAllByPopupId(Long popupId) {
         resetByPopupId(popupId);
         resetQueueByPopupId(popupId);


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #243 

## 📝 작업 내용

- `draw-service`: `resetAllByPopupId()`에 `@Transactional 누락` → self-invocation으로 트랜잭션 미적용, `deleteAllByDrawId` 실행 시 `TransactionRequiredException` 발생하던 문제 수정
- `auction-service`: `FeignErrorDecoder` 에러 메시지가 "user-service 호출에 실패했습니다."로 하드코딩되어 draw-service 등 다른 서비스 호출 실패 시에도 동일하게 찍히던 문제 수정 → `methodKey` 포함하도록 변경