### PR TITLE
feat: 부하테스트 모니터링을 위한 측정 지표 추가

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -36,6 +36,8 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -65,6 +67,7 @@ public class BidService {
     private final ReservationNoGenerator reservationNoGenerator;
     private final RedissonClient redissonClient;
     private final MeterRegistry registry;
+    private final ObservationRegistry observationRegistry;
 
     public Long getAuctionIdByOptionId(Long optionId) {
         return auctionOptionRepository.findByIdWithAuction(optionId)
@@ -200,17 +203,23 @@ public class BidService {
             );
             
             if (!request.bidPrice().equals(currentServerPrice)) {
-                registry.counter("popcon_bid_total",
-                        "auction_id", String.valueOf(auctionId),
-                        "outcome", "price_mismatch").increment();
+                Observation.createNotStarted("popcon_bid", observationRegistry)
+                        .lowCardinalityKeyValue("outcome", "price_mismatch")
+                        .highCardinalityKeyValue("auction_id", String.valueOf(auctionId))
+                        .observe(() -> {
+                            registry.counter("popcon_bid_total", "outcome", "price_mismatch").increment();
+                        });
                 throw new CustomException(ErrorCode.AUCTION_PRICE_MISMATCH);
             }
 
             Long remainingStock = bidRedisRepository.decrementStock(option.getId());
             if (remainingStock < 0) {
-                registry.counter("popcon_bid_total",
-                        "auction_id", String.valueOf(auctionId),
-                        "outcome", "sold_out").increment();
+                Observation.createNotStarted("popcon_bid", observationRegistry)
+                        .lowCardinalityKeyValue("outcome", "sold_out")
+                        .highCardinalityKeyValue("auction_id", String.valueOf(auctionId))
+                        .observe(() -> {
+                            registry.counter("popcon_bid_total", "outcome", "sold_out").increment();
+                        });
                 throw new CustomException(ErrorCode.AUCTION_OPTION_SOLD_OUT);
             }
             if (remainingStock == 0 && !auctionStockService.hasAvailableStock(auctionId)) {
@@ -232,9 +241,12 @@ public class BidService {
 
                 ApiResponse<BillingKeyInternalResponse> billingKeyResponse = userBillingClient.getDefaultBillingKey(userId);
                 if (billingKeyResponse == null || billingKeyResponse.getData() == null) {
-                    registry.counter("popcon_bid_total",
-                            "auction_id", String.valueOf(auctionId),
-                            "outcome", "no_billing_key").increment();
+                    Observation.createNotStarted("popcon_bid", observationRegistry)
+                            .lowCardinalityKeyValue("outcome", "no_billing_key")
+                            .highCardinalityKeyValue("auction_id", String.valueOf(auctionId))
+                            .observe(() -> {
+                                registry.counter("popcon_bid_total", "outcome", "no_billing_key").increment();
+                            });
                     throw new CustomException(ErrorCode.BILLING_KEY_NOT_FOUND);
                 }
                 String billingKey = billingKeyResponse.getData().customerUid();
@@ -258,18 +270,12 @@ public class BidService {
 
                 if (!paymentResponse.isPaid()) {
                     log.error("Payment execution failed because paidAt is missing. merchantUid={}", bid.getMerchantUid());
-                    registry.counter("popcon_bid_total",
-                            "auction_id", String.valueOf(auctionId),
-                            "outcome", "payment_failed").increment();
                     throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment was not completed.");
                 }
 
                 String pgTxId = paymentResponse.getPgTxId();
                 if (pgTxId == null || pgTxId.isBlank()) {
                     log.error("Payment response is missing pgTxId. merchantUid={}", bid.getMerchantUid());
-                    registry.counter("popcon_bid_total",
-                            "auction_id", String.valueOf(auctionId),
-                            "outcome", "payment_failed").increment();
                     throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment transaction id is missing.");
                 }
 
@@ -340,14 +346,26 @@ public class BidService {
 
                 issueAuctionWinTicket(bid, option, reservationNo);
                 
-                registry.counter("popcon_bid_total",
-                        "auction_id", String.valueOf(auctionId),
-                        "outcome", "success").increment();
+                Observation.createNotStarted("popcon_bid", observationRegistry)
+                        .lowCardinalityKeyValue("outcome", "success")
+                        .highCardinalityKeyValue("auction_id", String.valueOf(auctionId))
+                        .observe(() -> {
+                            registry.counter("popcon_bid_total", "outcome", "success").increment();
+                        });
                         
                 return new BidResponse(bid.getId(), BidStatus.SUCCESS, "Bid completed successfully.", reservationNo);
 
             } catch (Exception e) {
                 log.error("Bid processing failed. userId={}, optionId={}, error={}", userId, option.getId(), e.getMessage());
+
+                if (paymentAttempted) {
+                    Observation.createNotStarted("popcon_bid", observationRegistry)
+                            .lowCardinalityKeyValue("outcome", "payment_failed")
+                            .highCardinalityKeyValue("auction_id", String.valueOf(auctionId))
+                            .observe(() -> {
+                                registry.counter("popcon_bid_total", "outcome", "payment_failed").increment();
+                            });
+                }
 
                 if (!paymentAttempted) {
                     bidRedisRepository.incrementAvailableStock(option.getId(), 1L);

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -34,6 +34,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -62,51 +64,50 @@ public class BidService {
     private final TicketServiceClient ticketServiceClient;
     private final ReservationNoGenerator reservationNoGenerator;
     private final RedissonClient redissonClient;
+    private final MeterRegistry registry;
 
     public Long getAuctionIdByOptionId(Long optionId) {
         return auctionOptionRepository.findByIdWithAuction(optionId)
-            .map(option -> option.getAuction().getId())
-            .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_OPTION_NOT_FOUND));
+                .map(option -> option.getAuction().getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_OPTION_NOT_FOUND));
     }
 
     public Long getAuctionIdByReservationNo(String reservationNo) {
         return bidRepository.findByReservationNo(reservationNo)
-            .map(Bid::getAuctionId)
-            .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
+                .map(Bid::getAuctionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
     }
 
     public List<BidHistoryResponse> getBidHistory(Long userId) {
         List<Bid> bids = bidRepository.findAllByUserIdAndStatusOrderByCreatedAtDesc(userId, BidStatus.SUCCESS);
 
         return bids.stream()
-            .map(this::convertToHistoryResponse)
-            .toList();
+                .map(this::convertToHistoryResponse)
+                .toList();
     }
 
     public ReservationDetailResponse getReservationDetail(Long userId, String reservationNo) {
         Bid bid = bidRepository.findByReservationNoAndUserId(reservationNo, userId)
-            .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
         PriceDetails priceDetails = computePriceDetails(bid, reservationNo);
         return buildReservationDetailResponse(
-            bid,
-            priceDetails.startPrice(),
-            priceDetails.discountAmount(),
-            priceDetails.bidPrice()
-        );
+                bid,
+                priceDetails.startPrice(),
+                priceDetails.discountAmount(),
+                priceDetails.bidPrice());
     }
 
     public ReservationDetailResponse getBidDetail(Long userId, Long bidId) {
         Bid bid = bidRepository.findByIdAndUserIdAndStatus(bidId, userId, BidStatus.SUCCESS)
-            .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
         PriceDetails priceDetails = computePriceDetails(bid, bid.getReservationNo());
         return buildReservationDetailResponse(
-            bid,
-            priceDetails.startPrice(),
-            priceDetails.discountAmount(),
-            priceDetails.bidPrice()
-        );
+                bid,
+                priceDetails.startPrice(),
+                priceDetails.discountAmount(),
+                priceDetails.bidPrice());
     }
 
     private PriceDetails computePriceDetails(Bid bid, String reservationNo) {
@@ -119,7 +120,7 @@ public class BidService {
         }
         if (bidPrice == null) {
             log.warn("Bid price is null for reservationNo={}, bidId={}, startPrice={}",
-                reservationNo, bid.getId(), bid.getStartPrice());
+                    reservationNo, bid.getId(), bid.getStartPrice());
             bidPrice = 0;
         }
 
@@ -128,41 +129,39 @@ public class BidService {
     }
 
     private ReservationDetailResponse buildReservationDetailResponse(
-        Bid bid,
-        Integer startPrice,
-        Integer discountAmount,
-        Integer bidPrice
-    ) {
+            Bid bid,
+            Integer startPrice,
+            Integer discountAmount,
+            Integer bidPrice) {
         return ReservationDetailResponse.builder()
-            .reservationNo(bid.getReservationNo())
-            .popupTitle(bid.getPopupTitle())
-            .popupAddress(bid.getPopupAddress())
-            .popupThumbnail(bid.getThumbnailUrl())
-            .entryDate(bid.getEntryDate())
-            .entryTime(bid.getEntryTime())
-            .startPrice(startPrice)
-            .discountAmount(discountAmount)
-            .finalPrice(bidPrice)
-            .paidAt(bid.getPaidAt())
-            .build();
+                .reservationNo(bid.getReservationNo())
+                .popupTitle(bid.getPopupTitle())
+                .popupAddress(bid.getPopupAddress())
+                .popupThumbnail(bid.getThumbnailUrl())
+                .entryDate(bid.getEntryDate())
+                .entryTime(bid.getEntryTime())
+                .startPrice(startPrice)
+                .discountAmount(discountAmount)
+                .finalPrice(bidPrice)
+                .paidAt(bid.getPaidAt())
+                .build();
     }
 
     private record PriceDetails(
-        Integer startPrice,
-        Integer bidPrice,
-        Integer discountAmount
-    ) {
+            Integer startPrice,
+            Integer bidPrice,
+            Integer discountAmount) {
     }
 
     private BidHistoryResponse convertToHistoryResponse(Bid bid) {
         return BidHistoryResponse.builder()
-            .id(bid.getId())
-            .thumbnailUrl(bid.getThumbnailUrl())
-            .popupTitle(bid.getPopupTitle())
-            .bidPrice(bid.getBidPrice())
-            .paidAt(bid.getPaidAt())
-            .displayStatus(bid.getStatus().getDescription())
-            .build();
+                .id(bid.getId())
+                .thumbnailUrl(bid.getThumbnailUrl())
+                .popupTitle(bid.getPopupTitle())
+                .bidPrice(bid.getBidPrice())
+                .paidAt(bid.getPaidAt())
+                .displayStatus(bid.getStatus().getDescription())
+                .build();
     }
 
     public BidResponse attemptBid(Long userId, BidRequest request) {
@@ -199,12 +198,19 @@ public class BidService {
                 priceAnchor.soldOutPrice(),
                 priceAnchor.restockAnchorAt()
             );
+            
             if (!request.bidPrice().equals(currentServerPrice)) {
+                registry.counter("popcon_bid_total",
+                        "auction_id", String.valueOf(auctionId),
+                        "outcome", "price_mismatch").increment();
                 throw new CustomException(ErrorCode.AUCTION_PRICE_MISMATCH);
             }
 
             Long remainingStock = bidRedisRepository.decrementStock(option.getId());
             if (remainingStock < 0) {
+                registry.counter("popcon_bid_total",
+                        "auction_id", String.valueOf(auctionId),
+                        "outcome", "sold_out").increment();
                 throw new CustomException(ErrorCode.AUCTION_OPTION_SOLD_OUT);
             }
             if (remainingStock == 0 && !auctionStockService.hasAvailableStock(auctionId)) {
@@ -226,26 +232,43 @@ public class BidService {
 
                 ApiResponse<BillingKeyInternalResponse> billingKeyResponse = userBillingClient.getDefaultBillingKey(userId);
                 if (billingKeyResponse == null || billingKeyResponse.getData() == null) {
+                    registry.counter("popcon_bid_total",
+                            "auction_id", String.valueOf(auctionId),
+                            "outcome", "no_billing_key").increment();
                     throw new CustomException(ErrorCode.BILLING_KEY_NOT_FOUND);
                 }
                 String billingKey = billingKeyResponse.getData().customerUid();
 
                 paymentAttempted = true;
-                PortOnePaymentResponse paymentResponse = portOneClient.executePayment(
-                    billingKey,
-                    bid.getMerchantUid(),
-                    bid.getBidPrice(),
-                    PAYMENT_PRODUCT_NAME
-                );
+                Timer.Sample paymentSample = Timer.start(registry);
+                PortOnePaymentResponse paymentResponse;
+                try {
+                    paymentResponse = portOneClient.executePayment(
+                        billingKey,
+                        bid.getMerchantUid(),
+                        bid.getBidPrice(),
+                        PAYMENT_PRODUCT_NAME
+                    );
+                } finally {
+                    paymentSample.stop(Timer.builder("popcon_payment_latency")
+                            .tag("auction_id", String.valueOf(auctionId))
+                            .register(registry));
+                }
 
                 if (!paymentResponse.isPaid()) {
                     log.error("Payment execution failed because paidAt is missing. merchantUid={}", bid.getMerchantUid());
+                    registry.counter("popcon_bid_total",
+                            "auction_id", String.valueOf(auctionId),
+                            "outcome", "payment_failed").increment();
                     throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment was not completed.");
                 }
 
                 String pgTxId = paymentResponse.getPgTxId();
                 if (pgTxId == null || pgTxId.isBlank()) {
                     log.error("Payment response is missing pgTxId. merchantUid={}", bid.getMerchantUid());
+                    registry.counter("popcon_bid_total",
+                            "auction_id", String.valueOf(auctionId),
+                            "outcome", "payment_failed").increment();
                     throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Payment transaction id is missing.");
                 }
 
@@ -315,6 +338,11 @@ public class BidService {
                 }
 
                 issueAuctionWinTicket(bid, option, reservationNo);
+                
+                registry.counter("popcon_bid_total",
+                        "auction_id", String.valueOf(auctionId),
+                        "outcome", "success").increment();
+                        
                 return new BidResponse(bid.getId(), BidStatus.SUCCESS, "Bid completed successfully.", reservationNo);
 
             } catch (Exception e) {
@@ -379,10 +407,9 @@ public class BidService {
 
     private void validateAuctionOpen(Auction auction, LocalDateTime now) {
         AuctionStatus auctionStatus = auctionPriceService.calculateStatus(
-            auction,
-            now,
-            auctionStockService.hasAvailableStock(auction.getId())
-        );
+                auction,
+                now,
+                auctionStockService.hasAvailableStock(auction.getId()));
 
         if (auctionStatus != AuctionStatus.OPEN) {
             throw new CustomException(ErrorCode.AUCTION_NOT_OPEN);
@@ -395,25 +422,25 @@ public class BidService {
         }
         try {
             return OffsetDateTime.parse(paidAtStr)
-                .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
-                .toLocalDateTime();
+                    .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                    .toLocalDateTime();
         } catch (Exception e) {
             log.warn("Failed to parse paidAt value: {}", paidAtStr, e);
-            throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED, "Failed to parse payment completion timestamp.");
+            throw new CustomException(ErrorCode.PAYMENT_EXECUTION_FAILED,
+                    "Failed to parse payment completion timestamp.");
         }
     }
 
     private void issueAuctionWinTicket(Bid bid, AuctionOption option, String reservationNo) {
         try {
             ApiResponse<TicketIssueResponse> response = ticketServiceClient.issueTicket(
-                buildTicketIssueRequest(bid, option, reservationNo)
-            );
+                    buildTicketIssueRequest(bid, option, reservationNo));
             if (response == null || response.getData() == null) {
                 throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
             }
         } catch (Exception e) {
             log.error("Ticket service integration failed. bidId={}, optionId={}, error={}",
-                bid.getId(), option.getId(), e.getMessage());
+                    bid.getId(), option.getId(), e.getMessage());
             if (e instanceof CustomException customException) {
                 throw customException;
             }
@@ -423,13 +450,12 @@ public class BidService {
 
     private TicketIssueRequest buildTicketIssueRequest(Bid bid, AuctionOption option, String reservationNo) {
         return new TicketIssueRequest(
-            bid.getUserId(),
-            option.getAuction().getPopupId(),
-            "AUCTION",
-            bid.getId(),
-            reservationNo,
-            option.getEntryDate(),
-            option.getEntryTime()
-        );
+                bid.getUserId(),
+                option.getAuction().getPopupId(),
+                "AUCTION",
+                bid.getId(),
+                reservationNo,
+                option.getEntryDate(),
+                option.getEntryTime());
     }
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -240,6 +240,9 @@ public class BidService {
                 String billingKey = billingKeyResponse.getData().customerUid();
 
                 paymentAttempted = true;
+                Timer paymentTimer = Timer.builder("popcon_payment_latency")
+                        .tag("auction_id", String.valueOf(auctionId))
+                        .register(registry);
                 Timer.Sample paymentSample = Timer.start(registry);
                 PortOnePaymentResponse paymentResponse;
                 try {
@@ -250,9 +253,7 @@ public class BidService {
                         PAYMENT_PRODUCT_NAME
                     );
                 } finally {
-                    paymentSample.stop(Timer.builder("popcon_payment_latency")
-                            .tag("auction_id", String.valueOf(auctionId))
-                            .register(registry));
+                    paymentSample.stop(paymentTimer);
                 }
 
                 if (!paymentResponse.isPaid()) {

--- a/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionSseService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/service/AuctionSseService.java
@@ -1,5 +1,9 @@
 package com.t1.popcon.auction.service;
 
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -12,9 +16,20 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class AuctionSseService {
 
+    private final MeterRegistry registry;
+
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    private void registerSseTotalGauge() {
+        Gauge.builder("popcon_sse_active_connections", emitters,
+                        m -> m.values().stream().mapToInt(List::size).sum())
+                .description("경매 SSE 총 활성 연결 수")
+                .register(registry);
+    }
 
     public SseEmitter subscribe(Long auctionId) {
         SseEmitter emitter = new SseEmitter(60L * 60 * 1000); // 1시간
@@ -22,9 +37,24 @@ public class AuctionSseService {
         emitters.computeIfAbsent(auctionId, key -> new CopyOnWriteArrayList<>())
                 .add(emitter);
 
-        emitter.onCompletion(() -> removeEmitter(auctionId, emitter));
-        emitter.onTimeout(() -> removeEmitter(auctionId, emitter));
-        emitter.onError(e -> removeEmitter(auctionId, emitter));
+        registry.counter("popcon_sse_event_total",
+                "auction_id", String.valueOf(auctionId), "type", "subscribe").increment();
+
+        emitter.onCompletion(() -> {
+            removeEmitter(auctionId, emitter);
+            registry.counter("popcon_sse_event_total",
+                    "auction_id", String.valueOf(auctionId), "type", "complete").increment();
+        });
+        emitter.onTimeout(() -> {
+            removeEmitter(auctionId, emitter);
+            registry.counter("popcon_sse_event_total",
+                    "auction_id", String.valueOf(auctionId), "type", "timeout").increment();
+        });
+        emitter.onError(e -> {
+            removeEmitter(auctionId, emitter);
+            registry.counter("popcon_sse_event_total",
+                    "auction_id", String.valueOf(auctionId), "type", "error").increment();
+        });
 
         return emitter;
     }
@@ -37,6 +67,8 @@ public class AuctionSseService {
                 emitter.send(SseEmitter.event()
                         .name("auction-price")
                         .data(payload));
+                registry.counter("popcon_sse_event_total",
+                        "auction_id", String.valueOf(auctionId), "type", "send").increment();
             } catch (IOException e) {
                 log.warn("SSE 전송 실패 - auctionId={}", auctionId, e);
                 removeEmitter(auctionId, emitter);
@@ -52,6 +84,8 @@ public class AuctionSseService {
                 emitter.send(SseEmitter.event()
                         .name("ping")
                         .data("keep-alive"));
+                registry.counter("popcon_sse_event_total",
+                        "auction_id", String.valueOf(auctionId), "type", "heartbeat").increment();
             } catch (IOException e) {
                 log.warn("SSE heartbeat 전송 실패 - auctionId={}", auctionId, e);
                 removeEmitter(auctionId, emitter);

--- a/auction-service/src/main/resources/application-staging.yml
+++ b/auction-service/src/main/resources/application-staging.yml
@@ -76,3 +76,8 @@ management:
   metrics:
     tags:
       application: auction-service
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s

--- a/auction-service/src/main/resources/application-staging.yml
+++ b/auction-service/src/main/resources/application-staging.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:application-metrics-slo.yml
   mvc:
     async:
       request-timeout: 3600000
@@ -61,7 +63,6 @@ services:
   draw-service:
     url: ${DRAW_SERVICE_URL:http://backend-draw-svc:8080}
 
-
 management:
   endpoints:
     web:
@@ -76,8 +77,3 @@ management:
   metrics:
     tags:
       application: auction-service
-    distribution:
-      percentiles-histogram:
-        "[http.server.requests]": true
-      slo:
-        "[http.server.requests]": 100ms,300ms,500ms,1s,2s

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
@@ -74,6 +75,9 @@ public class BidServiceTest {
 	private RedissonClient redissonClient;
 	@Mock
 	private RLock lock;
+
+	@Spy
+	private io.micrometer.core.instrument.MeterRegistry registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
 
 	@InjectMocks
 	private BidService bidService;

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -79,6 +79,9 @@ public class BidServiceTest {
 	@Spy
 	private io.micrometer.core.instrument.MeterRegistry registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
 
+	@Spy
+	private io.micrometer.observation.ObservationRegistry observationRegistry = io.micrometer.observation.ObservationRegistry.create();
+
 	@InjectMocks
 	private BidService bidService;
 

--- a/auth-service/src/main/resources/application-staging.yml
+++ b/auth-service/src/main/resources/application-staging.yml
@@ -40,6 +40,8 @@ services:
     url: ${USER_SERVICE_URL:http://backend-user-svc:8080}
 
 spring:
+  config:
+    import: classpath:application-metrics-slo.yml
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -88,7 +90,6 @@ server:
   port: 8080
   shutdown: graceful
 
-
 management:
   endpoints:
     web:
@@ -103,8 +104,3 @@ management:
   metrics:
     tags:
       application: auth-service
-    distribution:
-      percentiles-histogram:
-        "[http.server.requests]": true
-      slo:
-        "[http.server.requests]": 100ms,300ms,500ms,1s,2s

--- a/auth-service/src/main/resources/application-staging.yml
+++ b/auth-service/src/main/resources/application-staging.yml
@@ -103,3 +103,8 @@ management:
   metrics:
     tags:
       application: auth-service
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s

--- a/common/src/main/resources/application-metrics-slo.yml
+++ b/common/src/main/resources/application-metrics-slo.yml
@@ -1,0 +1,7 @@
+management:
+  metrics:
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -63,7 +63,7 @@ public class DrawEntryService {
         DrawOption drawOption = drawOptionRepository.findById(drawOptionId)
             .orElseThrow(() -> new CustomException(ErrorCode.DRAW_OPTION_NOT_FOUND));
         validateDrawOption(drawId, drawOption);
-        validateEntryWindow(drawOption.getDraw());
+        validateEntryWindow(drawOption);
 
         if (drawEntryRepository.existsByUserIdAndDrawId(userId, drawId)) {
             registry.counter("popcon_draw_entry_total",
@@ -163,17 +163,18 @@ public class DrawEntryService {
         }
     }
 
-    private void validateEntryWindow(Draw draw) {
+    private void validateEntryWindow(DrawOption drawOption) {
+        Draw draw = drawOption.getDraw();
         LocalDateTime now = LocalDateTime.now(clock);
         if (now.isBefore(draw.getDrawOpenAt())) {
             registry.counter("popcon_draw_entry_total",
-                    "draw_id", String.valueOf(draw.getId()), "option_id", "unknown",
+                    "draw_id", String.valueOf(draw.getId()), "option_id", String.valueOf(drawOption.getId()),
                     "outcome", "not_open").increment();
             throw new CustomException(ErrorCode.DRAW_NOT_OPEN);
         }
         if (now.isAfter(draw.getDrawCloseAt())) {
             registry.counter("popcon_draw_entry_total",
-                    "draw_id", String.valueOf(draw.getId()), "option_id", "unknown",
+                    "draw_id", String.valueOf(draw.getId()), "option_id", String.valueOf(drawOption.getId()),
                     "outcome", "closed").increment();
             throw new CustomException(ErrorCode.DRAW_ALREADY_CLOSED);
         }

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -53,6 +54,7 @@ public class DrawEntryService {
     private final UserServiceClient userServiceClient;
     private final EncryptionService encryptionService;
     private final Clock clock;
+    private final MeterRegistry registry;
 
     @Transactional
     public DrawEntryResultResponse applyForDraw(Long userId, Long drawId, Long drawOptionId, DrawEntryRequest request) {
@@ -64,6 +66,9 @@ public class DrawEntryService {
         validateEntryWindow(drawOption.getDraw());
 
         if (drawEntryRepository.existsByUserIdAndDrawId(userId, drawId)) {
+            registry.counter("popcon_draw_entry_total",
+                    "draw_id", String.valueOf(drawId), "option_id", String.valueOf(drawOptionId),
+                    "outcome", "duplicate").increment();
             throw new CustomException(ErrorCode.DRAW_ALREADY_APPLIED);
         }
 
@@ -82,11 +87,17 @@ public class DrawEntryService {
             drawEntryRepository.saveAndFlush(entry);
         } catch (DataIntegrityViolationException e) {
             if (isDuplicateEntryViolation(e)) {
+                registry.counter("popcon_draw_entry_total",
+                        "draw_id", String.valueOf(drawId), "option_id", String.valueOf(drawOptionId),
+                        "outcome", "duplicate").increment();
                 throw new CustomException(ErrorCode.DRAW_ALREADY_APPLIED);
             }
             throw e;
         }
 
+        registry.counter("popcon_draw_entry_total",
+                "draw_id", String.valueOf(drawId), "option_id", String.valueOf(drawOptionId),
+                "outcome", "success").increment();
         return buildApplyResult(drawOption, userInfo);
     }
 
@@ -155,9 +166,15 @@ public class DrawEntryService {
     private void validateEntryWindow(Draw draw) {
         LocalDateTime now = LocalDateTime.now(clock);
         if (now.isBefore(draw.getDrawOpenAt())) {
+            registry.counter("popcon_draw_entry_total",
+                    "draw_id", String.valueOf(draw.getId()), "option_id", "unknown",
+                    "outcome", "not_open").increment();
             throw new CustomException(ErrorCode.DRAW_NOT_OPEN);
         }
         if (now.isAfter(draw.getDrawCloseAt())) {
+            registry.counter("popcon_draw_entry_total",
+                    "draw_id", String.valueOf(draw.getId()), "option_id", "unknown",
+                    "outcome", "closed").increment();
             throw new CustomException(ErrorCode.DRAW_ALREADY_CLOSED);
         }
     }

--- a/draw-service/src/main/resources/application-staging.yml
+++ b/draw-service/src/main/resources/application-staging.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:application-metrics-slo.yml
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -62,12 +64,6 @@ management:
   metrics:
     tags:
       application: draw-service
-    distribution:
-      percentiles-histogram:
-        "[http.server.requests]": true
-      slo:
-        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
-
 services:
   user-service:
     url: ${USER_SERVICE_URL:http://backend-user-svc:8080}

--- a/draw-service/src/main/resources/application-staging.yml
+++ b/draw-service/src/main/resources/application-staging.yml
@@ -62,6 +62,11 @@ management:
   metrics:
     tags:
       application: draw-service
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
 
 services:
   user-service:

--- a/popup-service/src/main/resources/application-staging.yml
+++ b/popup-service/src/main/resources/application-staging.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:application-metrics-slo.yml
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -33,8 +35,6 @@ spring:
       ssl:
         enabled: true
 
-
-
 server:
   port: 8080
   shutdown: graceful
@@ -48,7 +48,6 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 1800000
   refresh-token-expiration: 604800000
-
 
 management:
   endpoints:
@@ -64,8 +63,3 @@ management:
   metrics:
     tags:
       application: popup-service
-    distribution:
-      percentiles-histogram:
-        "[http.server.requests]": true
-      slo:
-        "[http.server.requests]": 100ms,300ms,500ms,1s,2s

--- a/popup-service/src/main/resources/application-staging.yml
+++ b/popup-service/src/main/resources/application-staging.yml
@@ -64,3 +64,8 @@ management:
   metrics:
     tags:
       application: popup-service
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s

--- a/queue-common/src/main/java/com/t1/popcon/queue/common/redis/QueueWaitingRepository.java
+++ b/queue-common/src/main/java/com/t1/popcon/queue/common/redis/QueueWaitingRepository.java
@@ -98,8 +98,13 @@ public class QueueWaitingRepository {
 
     /** 대기 인원 수 조회 */
     public long getWaitingCount(String phaseType, long phaseId) {
-        Long count = redisTemplate.opsForZSet().zCard(QueueRedisKeys.waiting(phaseType, phaseId));
-        return count != null ? count : 0L;
+        String key = QueueRedisKeys.waiting(phaseType, phaseId);
+        Long count = redisTemplate.opsForZSet().zCard(key);
+        if (count == null) {
+            log.error("Redis zCard returned null for key: {}, phaseType: {}, phaseId: {}", key, phaseType, phaseId);
+            return 0L;
+        }
+        return count;
     }
 
     /** 대기 순위 조회 (0-based, null이면 목록에 없음) */

--- a/queue-common/src/main/java/com/t1/popcon/queue/common/redis/QueueWaitingRepository.java
+++ b/queue-common/src/main/java/com/t1/popcon/queue/common/redis/QueueWaitingRepository.java
@@ -96,6 +96,12 @@ public class QueueWaitingRepository {
         );
     }
 
+    /** 대기 인원 수 조회 */
+    public long getWaitingCount(String phaseType, long phaseId) {
+        Long count = redisTemplate.opsForZSet().zCard(QueueRedisKeys.waiting(phaseType, phaseId));
+        return count != null ? count : 0L;
+    }
+
     /** 대기 순위 조회 (0-based, null이면 목록에 없음) */
     public Long getWaitingRank(String phaseType, long phaseId, long userId) {
         return redisTemplate.opsForZSet().rank(

--- a/queue-service/src/main/java/com/t1/popcon/queue/config/QueueServiceConfig.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/config/QueueServiceConfig.java
@@ -3,6 +3,7 @@ package com.t1.popcon.queue.config;
 import com.t1.popcon.queue.common.config.QueueProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * queue-service 설정
@@ -10,5 +11,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableConfigurationProperties(QueueProperties.class)
+@EnableScheduling
 public class QueueServiceConfig {
 }

--- a/queue-service/src/main/java/com/t1/popcon/queue/config/QueueSizeMetrics.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/config/QueueSizeMetrics.java
@@ -39,50 +39,54 @@ public class QueueSizeMetrics {
 
     @Scheduled(fixedRateString = "${queue.metrics.update-interval-ms:5000}")
     public void updateQueueSizeMetrics() {
-        Set<QueuePhaseScanner.PhaseKey> phases = phaseScanner.scanActivePhases();
-        
-        Set<String> activeKeys = phases.stream()
-                .map(p -> p.phaseType() + ":" + p.phaseId())
-                .collect(Collectors.toSet());
-
-        cleanupStaleMetrics(activeKeys);
-
-        for (QueuePhaseScanner.PhaseKey phase : phases) {
-            String key = phase.phaseType() + ":" + phase.phaseId();
+        try {
+            Set<QueuePhaseScanner.PhaseKey> phases = phaseScanner.scanActivePhases();
             
-            try {
-                AtomicLong waiting = waitingCounts.computeIfAbsent(key, k -> {
-                    AtomicLong gaugeNum = new AtomicLong(0);
-                    Gauge gauge = Gauge.builder("popcon_queue_waiting_size", gaugeNum, AtomicLong::get)
-                            .tag("phase", phase.phaseType())
-                            .tag("phase_id", String.valueOf(phase.phaseId()))
-                            .description("대기열 WAITING 인원 수")
-                            .register(registry);
-                    registeredWaitingGauges.put(k, gauge);
-                    return gaugeNum;
-                });
-                waiting.set(waitingRepository.getWaitingCount(phase.phaseType(), phase.phaseId()));
-                
-            } catch (Exception e) {
-                log.error("Failed to update waiting queue size metric for phase {}:{}", phase.phaseType(), phase.phaseId(), e);
-            }
+            Set<String> activeKeys = phases.stream()
+                    .map(p -> p.phaseType() + ":" + p.phaseId())
+                    .collect(Collectors.toSet());
 
-            try {
-                AtomicLong active = activeCounts.computeIfAbsent(key, k -> {
-                    AtomicLong gaugeNum = new AtomicLong(0);
-                    Gauge gauge = Gauge.builder("popcon_queue_active_size", gaugeNum, AtomicLong::get)
-                            .tag("phase", phase.phaseType())
-                            .tag("phase_id", String.valueOf(phase.phaseId()))
-                            .description("대기열 ACTIVE 인원 수")
-                            .register(registry);
-                    registeredActiveGauges.put(k, gauge);
-                    return gaugeNum;
-                });
-                active.set(activeRepository.getActiveCount(phase.phaseType(), phase.phaseId()));
+            cleanupStaleMetrics(activeKeys);
+
+            for (QueuePhaseScanner.PhaseKey phase : phases) {
+                String key = phase.phaseType() + ":" + phase.phaseId();
                 
-            } catch (Exception e) {
-                log.error("Failed to update active queue size metric for phase {}:{}", phase.phaseType(), phase.phaseId(), e);
+                try {
+                    AtomicLong waiting = waitingCounts.computeIfAbsent(key, k -> {
+                        AtomicLong gaugeNum = new AtomicLong(0);
+                        Gauge gauge = Gauge.builder("popcon_queue_waiting_size", gaugeNum, AtomicLong::get)
+                                .tag("phase", phase.phaseType())
+                                .tag("phase_id", String.valueOf(phase.phaseId()))
+                                .description("대기열 WAITING 인원 수")
+                                .register(registry);
+                        registeredWaitingGauges.put(k, gauge);
+                        return gaugeNum;
+                    });
+                    waiting.set(waitingRepository.getWaitingCount(phase.phaseType(), phase.phaseId()));
+                    
+                } catch (Exception e) {
+                    log.error("Failed to update waiting queue size metric for phase {}:{}", phase.phaseType(), phase.phaseId(), e);
+                }
+
+                try {
+                    AtomicLong active = activeCounts.computeIfAbsent(key, k -> {
+                        AtomicLong gaugeNum = new AtomicLong(0);
+                        Gauge gauge = Gauge.builder("popcon_queue_active_size", gaugeNum, AtomicLong::get)
+                                .tag("phase", phase.phaseType())
+                                .tag("phase_id", String.valueOf(phase.phaseId()))
+                                .description("대기열 ACTIVE 인원 수")
+                                .register(registry);
+                        registeredActiveGauges.put(k, gauge);
+                        return gaugeNum;
+                    });
+                    active.set(activeRepository.getActiveCount(phase.phaseType(), phase.phaseId()));
+                    
+                } catch (Exception e) {
+                    log.error("Failed to update active queue size metric for phase {}:{}", phase.phaseType(), phase.phaseId(), e);
+                }
             }
+        } catch (Exception e) {
+            log.error("updateQueueSizeMetrics failed", e);
         }
     }
 

--- a/queue-service/src/main/java/com/t1/popcon/queue/config/QueueSizeMetrics.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/config/QueueSizeMetrics.java
@@ -1,0 +1,63 @@
+package com.t1.popcon.queue.config;
+
+import com.t1.popcon.queue.common.redis.QueueActiveRepository;
+import com.t1.popcon.queue.common.redis.QueuePhaseScanner;
+import com.t1.popcon.queue.common.redis.QueueWaitingRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 대기열 사이즈 게이지 — 부하테스트 모니터링용
+ * - 5초 주기로 활성 phase를 스캔하여 waiting/active 인원 수를 Gauge로 expose
+ * - 새 phase가 발견될 때 동적으로 Gauge 등록 (phaseType + phase_id 태그)
+ */
+@Component
+@RequiredArgsConstructor
+public class QueueSizeMetrics {
+
+    private final QueueWaitingRepository waitingRepository;
+    private final QueueActiveRepository activeRepository;
+    private final QueuePhaseScanner phaseScanner;
+    private final MeterRegistry registry;
+
+    private final Map<String, AtomicLong> waitingCounts = new ConcurrentHashMap<>();
+    private final Map<String, AtomicLong> activeCounts = new ConcurrentHashMap<>();
+
+    @Scheduled(fixedRate = 5000)
+    public void updateQueueSizeMetrics() {
+        Set<QueuePhaseScanner.PhaseKey> phases = phaseScanner.scanActivePhases();
+        for (QueuePhaseScanner.PhaseKey phase : phases) {
+            String key = phase.phaseType() + ":" + phase.phaseId();
+
+            AtomicLong waiting = waitingCounts.computeIfAbsent(key, k -> {
+                AtomicLong gauge = new AtomicLong(0);
+                Gauge.builder("popcon_queue_waiting_size", gauge, AtomicLong::get)
+                        .tag("phase", phase.phaseType())
+                        .tag("phase_id", String.valueOf(phase.phaseId()))
+                        .description("대기열 WAITING 인원 수")
+                        .register(registry);
+                return gauge;
+            });
+            waiting.set(waitingRepository.getWaitingCount(phase.phaseType(), phase.phaseId()));
+
+            AtomicLong active = activeCounts.computeIfAbsent(key, k -> {
+                AtomicLong gauge = new AtomicLong(0);
+                Gauge.builder("popcon_queue_active_size", gauge, AtomicLong::get)
+                        .tag("phase", phase.phaseType())
+                        .tag("phase_id", String.valueOf(phase.phaseId()))
+                        .description("대기열 ACTIVE 인원 수")
+                        .register(registry);
+                return gauge;
+            });
+            active.set(activeRepository.getActiveCount(phase.phaseType(), phase.phaseId()));
+        }
+    }
+}

--- a/queue-service/src/main/java/com/t1/popcon/queue/config/QueueSizeMetrics.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/config/QueueSizeMetrics.java
@@ -6,6 +6,7 @@ import com.t1.popcon.queue.common.redis.QueueWaitingRepository;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -13,12 +14,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 /**
  * 대기열 사이즈 게이지 — 부하테스트 모니터링용
- * - 5초 주기로 활성 phase를 스캔하여 waiting/active 인원 수를 Gauge로 expose
+ * - 지정된 주기(기본 5초)로 활성 phase를 스캔하여 waiting/active 인원 수를 Gauge로 expose
  * - 새 phase가 발견될 때 동적으로 Gauge 등록 (phaseType + phase_id 태그)
+ * - 활성 상태가 끝난 phase는 주기적으로 정리하여 메모리 누수 방지
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class QueueSizeMetrics {
@@ -30,34 +34,79 @@ public class QueueSizeMetrics {
 
     private final Map<String, AtomicLong> waitingCounts = new ConcurrentHashMap<>();
     private final Map<String, AtomicLong> activeCounts = new ConcurrentHashMap<>();
+    private final Map<String, Gauge> registeredWaitingGauges = new ConcurrentHashMap<>();
+    private final Map<String, Gauge> registeredActiveGauges = new ConcurrentHashMap<>();
 
-    @Scheduled(fixedRate = 5000)
+    @Scheduled(fixedRateString = "${queue.metrics.update-interval-ms:5000}")
     public void updateQueueSizeMetrics() {
         Set<QueuePhaseScanner.PhaseKey> phases = phaseScanner.scanActivePhases();
+        
+        Set<String> activeKeys = phases.stream()
+                .map(p -> p.phaseType() + ":" + p.phaseId())
+                .collect(Collectors.toSet());
+
+        cleanupStaleMetrics(activeKeys);
+
         for (QueuePhaseScanner.PhaseKey phase : phases) {
             String key = phase.phaseType() + ":" + phase.phaseId();
+            
+            try {
+                AtomicLong waiting = waitingCounts.computeIfAbsent(key, k -> {
+                    AtomicLong gaugeNum = new AtomicLong(0);
+                    Gauge gauge = Gauge.builder("popcon_queue_waiting_size", gaugeNum, AtomicLong::get)
+                            .tag("phase", phase.phaseType())
+                            .tag("phase_id", String.valueOf(phase.phaseId()))
+                            .description("대기열 WAITING 인원 수")
+                            .register(registry);
+                    registeredWaitingGauges.put(k, gauge);
+                    return gaugeNum;
+                });
+                waiting.set(waitingRepository.getWaitingCount(phase.phaseType(), phase.phaseId()));
+                
+            } catch (Exception e) {
+                log.error("Failed to update waiting queue size metric for phase {}:{}", phase.phaseType(), phase.phaseId(), e);
+            }
 
-            AtomicLong waiting = waitingCounts.computeIfAbsent(key, k -> {
-                AtomicLong gauge = new AtomicLong(0);
-                Gauge.builder("popcon_queue_waiting_size", gauge, AtomicLong::get)
-                        .tag("phase", phase.phaseType())
-                        .tag("phase_id", String.valueOf(phase.phaseId()))
-                        .description("대기열 WAITING 인원 수")
-                        .register(registry);
-                return gauge;
-            });
-            waiting.set(waitingRepository.getWaitingCount(phase.phaseType(), phase.phaseId()));
-
-            AtomicLong active = activeCounts.computeIfAbsent(key, k -> {
-                AtomicLong gauge = new AtomicLong(0);
-                Gauge.builder("popcon_queue_active_size", gauge, AtomicLong::get)
-                        .tag("phase", phase.phaseType())
-                        .tag("phase_id", String.valueOf(phase.phaseId()))
-                        .description("대기열 ACTIVE 인원 수")
-                        .register(registry);
-                return gauge;
-            });
-            active.set(activeRepository.getActiveCount(phase.phaseType(), phase.phaseId()));
+            try {
+                AtomicLong active = activeCounts.computeIfAbsent(key, k -> {
+                    AtomicLong gaugeNum = new AtomicLong(0);
+                    Gauge gauge = Gauge.builder("popcon_queue_active_size", gaugeNum, AtomicLong::get)
+                            .tag("phase", phase.phaseType())
+                            .tag("phase_id", String.valueOf(phase.phaseId()))
+                            .description("대기열 ACTIVE 인원 수")
+                            .register(registry);
+                    registeredActiveGauges.put(k, gauge);
+                    return gaugeNum;
+                });
+                active.set(activeRepository.getActiveCount(phase.phaseType(), phase.phaseId()));
+                
+            } catch (Exception e) {
+                log.error("Failed to update active queue size metric for phase {}:{}", phase.phaseType(), phase.phaseId(), e);
+            }
         }
+    }
+
+    private void cleanupStaleMetrics(Set<String> activeKeys) {
+        waitingCounts.keySet().removeIf(key -> {
+            if (!activeKeys.contains(key)) {
+                Gauge gauge = registeredWaitingGauges.remove(key);
+                if (gauge != null) {
+                    registry.remove(gauge.getId());
+                }
+                return true;
+            }
+            return false;
+        });
+
+        activeCounts.keySet().removeIf(key -> {
+            if (!activeKeys.contains(key)) {
+                Gauge gauge = registeredActiveGauges.remove(key);
+                if (gauge != null) {
+                    registry.remove(gauge.getId());
+                }
+                return true;
+            }
+            return false;
+        });
     }
 }

--- a/queue-service/src/main/java/com/t1/popcon/queue/service/QueueEntryService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/QueueEntryService.java
@@ -11,6 +11,7 @@ import com.t1.popcon.queue.common.redis.QueueRedisKeys;
 import com.t1.popcon.queue.common.redis.QueueWaitingRepository;
 import com.t1.popcon.queue.dto.response.QueueBlockedResponse;
 import com.t1.popcon.queue.dto.response.QueueEntryResponse;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -42,6 +43,7 @@ public class QueueEntryService {
     private final QueueBlockRepository blockRepository;
     private final QueueProperties properties;
     private final RedissonClient redissonClient;
+    private final MeterRegistry registry;
 
     /**
      * 대기열 진입 처리
@@ -102,6 +104,9 @@ public class QueueEntryService {
                 .toString();
             log.info("[Queue] 차단된 사용자 진입 시도 - phaseType={}, phaseId={}, userId={}",
                 phaseType, phaseId, userId % 1000);
+            registry.counter("popcon_queue_enter_total",
+                    "phase", phaseType, "phase_id", String.valueOf(phaseId), "result", "blocked")
+                    .increment();
             throw new CustomException(ErrorCode.QUEUE_BLOCKED,
                 new QueueBlockedResponse("BLOCKED", blockedUntil));
         }
@@ -150,6 +155,9 @@ public class QueueEntryService {
 
         log.info("[Queue] 즉시 입장 - phaseType={}, phaseId={}, userId={}",
             phaseType, phaseId, userId % 1000);
+        registry.counter("popcon_queue_enter_total",
+                "phase", phaseType, "phase_id", String.valueOf(phaseId), "result", "active")
+                .increment();
         return QueueEntryResponse.active(queueToken);
     }
 
@@ -174,6 +182,9 @@ public class QueueEntryService {
 
         log.info("[Queue] 대기열 등록 - phaseType={}, phaseId={}, userId={}, position={}",
             phaseType, phaseId, userId % 1000, position);
+        registry.counter("popcon_queue_enter_total",
+                "phase", phaseType, "phase_id", String.valueOf(phaseId), "result", "waiting")
+                .increment();
         return QueueEntryResponse.waiting(queueToken, position, estimatedWaitSeconds,
             properties.getPollingDefaultMs());
     }

--- a/queue-service/src/main/java/com/t1/popcon/queue/service/QueuePollingService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/QueuePollingService.java
@@ -10,6 +10,7 @@ import com.t1.popcon.queue.common.redis.QueueCleanupRepository;
 import com.t1.popcon.queue.common.redis.QueueWaitingRepository;
 import com.t1.popcon.queue.dto.response.QueueStatusResponse;
 import com.t1.popcon.queue.service.QueueTokenResolver.TokenInfo;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,7 @@ public class QueuePollingService {
     private final QueueCleanupRepository cleanupRepository;
     private final QueueProperties properties;
     private final QueueTokenResolver tokenResolver;
+    private final MeterRegistry registry;
 
     /**
      * 대기열 상태 조회
@@ -86,6 +88,10 @@ public class QueuePollingService {
             info.phaseType(), info.phaseId(), info.userId(), queueToken);
         log.info("[Queue] 자진 이탈 완료 - phaseType={}, phaseId={}, userId={}",
             info.phaseType(), info.phaseId(), info.userId() % 1000);
+        registry.counter("popcon_queue_leave_total",
+                "phase", info.phaseType(), "phase_id", String.valueOf(info.phaseId()),
+                "reason", "voluntary")
+                .increment();
     }
 
     // ── 내부 메서드 ────────────────────────────────────────────

--- a/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
@@ -8,6 +8,7 @@ import com.t1.popcon.queue.common.redis.*;
 import com.t1.popcon.queue.dto.response.VqaStartResponse;
 import com.t1.popcon.queue.dto.response.VqaSubmitResult;
 import com.t1.popcon.queue.dto.vqa.*;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -35,6 +36,7 @@ public class VqaService {
     private final QueueTokenResolver tokenResolver;
     private final StringRedisTemplate redisTemplate;
     private final RedissonClient redissonClient;
+    private final MeterRegistry registry;
 
     private static final String VQA_SESSION_KEY_PREFIX = "vqa:session:";
     private static final String VQA_USER_SESSION_KEY_PREFIX = "vqa:session:user:";
@@ -85,6 +87,9 @@ public class VqaService {
             int globalAttempts = (attemptsStr != null) ? Integer.parseInt(attemptsStr) : 0;
 
             if (globalAttempts >= MAX_ATTEMPTS) {
+                registry.counter("popcon_vqa_start_total",
+                        "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                        "outcome", "attempts_exceeded").increment();
                 throw new CustomException(ErrorCode.QUIZ_ATTEMPTS_EXCEEDED);
             }
 
@@ -105,6 +110,9 @@ public class VqaService {
 
             // 4. 레벨 0 (0~20점): 면제 (단, 경매의 경우 점수가 낮아도 면제 없이 퀴즈를 진행함)
             if (totalScore <= 20 && !"auction".equals(phaseType)) {
+                registry.counter("popcon_vqa_start_total",
+                        "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                        "outcome", "exempt").increment();
                 String quizPassedToken = generateAndSaveQuizPassedToken(tokenInfo);
                 return VqaStartResponse.exempt(quizPassedToken);
             }
@@ -115,6 +123,9 @@ public class VqaService {
             VqaNextQuestionResponse firstQuestion = vqaClient.getNextQuestion(pythonSessionId, totalScore);
 
             if (Boolean.TRUE.equals(firstQuestion.isExempt())) {
+                registry.counter("popcon_vqa_start_total",
+                        "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                        "outcome", "exempt").increment();
                 String quizPassedToken = generateAndSaveQuizPassedToken(tokenInfo);
                 return VqaStartResponse.exempt(quizPassedToken);
             }
@@ -125,6 +136,9 @@ public class VqaService {
             redisTemplate.opsForValue().set(userSessionKey, vqaSessionId, Duration.ofSeconds(VQA_SESSION_TTL_SECONDS));
 
             log.info("[VQA] 퀴즈 세션 생성 완료 - userId={}, vqaSessionId={}", userId, vqaSessionId);
+            registry.counter("popcon_vqa_start_total",
+                    "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                    "outcome", "session_created").increment();
             return VqaStartResponse.session(vqaSessionId, firstQuestion);
 
         } catch (InterruptedException e) {
@@ -197,9 +211,12 @@ public class VqaService {
             if (Boolean.TRUE.equals(response.isCorrect())) {
                 QueueTokenResolver.TokenInfo tokenInfo = new QueueTokenResolver.TokenInfo(phaseType, phaseId, userId);
                 String quizPassedToken = generateAndSaveQuizPassedToken(tokenInfo);
-                
+
                 clearVqaSession(vqaSessionId, userId, phaseType, phaseId);
                 log.info("[VQA] 퀴즈 통과 - userId={}", userId);
+                registry.counter("popcon_vqa_submit_total",
+                        "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                        "outcome", "pass").increment();
                 return VqaSubmitResult.success(response.similarityScore(), quizPassedToken);
             }
 
@@ -219,10 +236,16 @@ public class VqaService {
                 cleanupRepository.cleanupUserData(phaseType, phaseId, userId, null);
 
                 log.warn("[VQA] 퀴즈 최종 실패 - userId={}", userId);
+                registry.counter("popcon_vqa_submit_total",
+                        "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                        "outcome", "blocked").increment();
                 return VqaSubmitResult.fail(response.similarityScore(), 0);
             }
 
             saveVqaSession(vqaSessionId, pythonSessionId, new QueueTokenResolver.TokenInfo(phaseType, phaseId, userId), nextAttempts, score);
+            registry.counter("popcon_vqa_submit_total",
+                    "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                    "outcome", "fail").increment();
             return VqaSubmitResult.fail(response.similarityScore(), MAX_ATTEMPTS - nextAttempts);
 
         } catch (InterruptedException e) {

--- a/queue-service/src/main/resources/application-staging.yml
+++ b/queue-service/src/main/resources/application-staging.yml
@@ -38,6 +38,11 @@ management:
   metrics:
     tags:
       application: queue-service
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
 
 
 

--- a/queue-service/src/main/resources/application-staging.yml
+++ b/queue-service/src/main/resources/application-staging.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:application-metrics-slo.yml
   data:
     redis:
       host: ${REDIS_HOST}
@@ -38,11 +40,4 @@ management:
   metrics:
     tags:
       application: queue-service
-    distribution:
-      percentiles-histogram:
-        "[http.server.requests]": true
-      slo:
-        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
-
-
 

--- a/queue-worker/src/main/java/com/t1/popcon/worker/service/WorkerService.java
+++ b/queue-worker/src/main/java/com/t1/popcon/worker/service/WorkerService.java
@@ -7,6 +7,7 @@ import com.t1.popcon.queue.common.redis.QueueActiveRepository;
 import com.t1.popcon.queue.common.redis.QueueCleanupRepository;
 import com.t1.popcon.queue.common.redis.QueueRedisKeys;
 import com.t1.popcon.queue.common.redis.QueueWaitingRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class WorkerService {
     private final QueueActiveRepository activeRepository;
     private final QueueCleanupRepository cleanupRepository;
     private final QueueProperties queueProperties;
+    private final MeterRegistry registry;
 
     /**
      * WAITING → ACTIVE 승격
@@ -80,17 +82,29 @@ public class WorkerService {
                     log.warn("[Worker] heartbeat 만료 사용자 승격 스킵 - phaseType={}, phaseId={}, userId={}",
                         phaseType, phaseId, userId % 1000);
                     cleanupRepository.cleanupWaitingUserData(phaseType, phaseId, userId, null);
+                    registry.counter("popcon_worker_promote_total",
+                            "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                            "outcome", "heartbeat_expired").increment();
                     continue;
                 }
 
                 promoteUser(phaseType, phaseId, userId, expireAtMillis, activeTtlSeconds);
                 promotedSuccessCount++;
+                registry.counter("popcon_worker_promote_total",
+                        "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                        "outcome", "success").increment();
             } catch (NumberFormatException e) {
                 log.error("[Worker] userId 파싱 실패 - phaseType={}, phaseId={}, raw={}",
                     phaseType, phaseId, userIdStr, e);
+                registry.counter("popcon_worker_promote_total",
+                        "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                        "outcome", "error").increment();
             } catch (Exception e) {
                 log.error("[Worker] 승격 실패 - phaseType={}, phaseId={}, userId={}",
                     phaseType, phaseId, userIdStr, e);
+                registry.counter("popcon_worker_promote_total",
+                        "phase", phaseType, "phase_id", String.valueOf(phaseId),
+                        "outcome", "error").increment();
             }
         }
 
@@ -163,6 +177,9 @@ public class WorkerService {
 
         log.info("[Worker] heartbeat 만료 정리 - phaseType={}, phaseId={}, removed={}",
             phaseType, phaseId, expiredUserIds.size());
+        registry.counter("popcon_worker_heartbeat_cleanup_total",
+                "phase", phaseType, "phase_id", String.valueOf(phaseId))
+                .increment(expiredUserIds.size());
     }
 
     /** phaseType별 ACTIVE TTL(초) 반환 */

--- a/queue-worker/src/main/resources/application-staging.yml
+++ b/queue-worker/src/main/resources/application-staging.yml
@@ -40,6 +40,11 @@ management:
   metrics:
     tags:
       application: queue-worker
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
 
 
 server:

--- a/queue-worker/src/main/resources/application-staging.yml
+++ b/queue-worker/src/main/resources/application-staging.yml
@@ -1,5 +1,6 @@
 spring:
-
+  config:
+    import: classpath:application-metrics-slo.yml
   data:
     redis:
       host: ${REDIS_HOST}
@@ -40,12 +41,6 @@ management:
   metrics:
     tags:
       application: queue-worker
-    distribution:
-      percentiles-histogram:
-        "[http.server.requests]": true
-      slo:
-        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
-
-
 server:
   port: 8080
+

--- a/queue-worker/src/test/java/com/t1/popcon/worker/service/WorkerServiceTest.java
+++ b/queue-worker/src/test/java/com/t1/popcon/worker/service/WorkerServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -43,6 +44,9 @@ class WorkerServiceTest {
 
     @Mock
     private QueueProperties.ActiveTtl activeTtl;
+
+    @Spy
+    private io.micrometer.core.instrument.MeterRegistry registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
 
     @InjectMocks
     private WorkerService workerService;

--- a/ticket-service/src/main/resources/application-staging.yml
+++ b/ticket-service/src/main/resources/application-staging.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:application-metrics-slo.yml
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -44,8 +46,4 @@ management:
   metrics:
     tags:
       application: ticket-service
-    distribution:
-      percentiles-histogram:
-        "[http.server.requests]": true
-      slo:
-        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
+

--- a/ticket-service/src/main/resources/application-staging.yml
+++ b/ticket-service/src/main/resources/application-staging.yml
@@ -44,3 +44,8 @@ management:
   metrics:
     tags:
       application: ticket-service
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s

--- a/user-service/src/main/resources/application-staging.yml
+++ b/user-service/src/main/resources/application-staging.yml
@@ -63,6 +63,11 @@ management:
   metrics:
     tags:
       application: user-service
+    distribution:
+      percentiles-histogram:
+        "[http.server.requests]": true
+      slo:
+        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
 
 services:
   draw-service:

--- a/user-service/src/main/resources/application-staging.yml
+++ b/user-service/src/main/resources/application-staging.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: classpath:application-metrics-slo.yml
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -48,7 +50,6 @@ jwt:
   access-token-expiration: 1800000
   refresh-token-expiration: 604800000
 
-
 management:
   endpoints:
     web:
@@ -63,12 +64,6 @@ management:
   metrics:
     tags:
       application: user-service
-    distribution:
-      percentiles-histogram:
-        "[http.server.requests]": true
-      slo:
-        "[http.server.requests]": 100ms,300ms,500ms,1s,2s
-
 services:
   draw-service:
     url: ${DRAW_SERVICE_URL:http://backend-draw-svc:8080}


### PR DESCRIPTION
## #️⃣ 관련 이슈

X

## 📝 작업 내용

서비스 내 여러가지 상황 모니터링을 위한 측정 지표를 추가했습니다.
추가된 사항은 다음과 같습니다.

| Metric Name | 설명 | 관련 파일 |
| :--- | :--- | :--- |
| **`http.server.requests`**<br>(Histogram + SLO 버킷) | **[고객 체감 성능(P95) 및 목표(SLO) 달성 현황 파악]**<br>전체 웹 요청의 응답 속도 분포(100ms, 300ms, 500ms, 1s, 2s)를 시각화합니다. 하위 95% 유저의 인내심이 바닥나기 전(예: 1초 이내)에 페이지가 정상적으로 뜨고 있는지, 즉 **실제 고객의 체감 로딩 지수**를 직관적으로 확인합니다. | `application-staging.yml` |
| **`popcon_queue_waiting_size`**<br>(Gauge) | **[실시간 대기 인원 볼륨 파악]**<br>현재 접속 대기 창에서 기다리고 있는 총인원수입니다. 오픈런 이벤트 시 얼마나 많은 수요가 몰렸는지 트래픽 과열 상태를 실시간으로 확인할 수 있습니다. | `QueueSizeMetrics.java`<br>`QueueWaitingRepository.java` |
| **`popcon_queue_active_size`**<br>(Gauge) | **[동시 접속 허용량 유지 상태 파악]**<br>대기열을 통과해 안정적으로 결제/응모를 진행 중인 유저수입니다. 우리가 의도한 적정 동시 진입 인원(예: 1,000명)이 서버 폭주 없이 쾌적하게 잘 유지되고 있는지 모니터링합니다. | `QueueSizeMetrics.java`<br>`QueueActiveRepository.java` |
| **`popcon_queue_leave_total`**<br>(Counter) | **[고객 이탈률 측정]**<br>대기 중 지루함 등으로 인해 유저가 중간에 스스로 이탈(포기)한 횟수입니다. 대기 시간 대비 이탈률을 분석하여, 향후 대기 UI 개선이나 통과 속도 조절의 기획적 근거로 활용할 수 있습니다. | `QueuePollingService.java` |
| **`popcon_queue_enter_total`**<br>(Counter) | **[총 수요 트래픽 파악]**<br>시스템 진입을 시도한 전체 횟수(성공/대기/차단 포함)입니다. 이벤트 오픈 최초 1분간 얼마나 많은 "새로고침/클릭" 수요가 발생했는지 파악합니다. | `QueueEntryService.java` |
| **`popcon_worker_heartbeat_cleanup_total`**<br>(Counter) | **[네트워크 끊김 / 강제 종료(비정상 이탈) 감지]**<br>앱을 끄고 도망갔거나 네트워크가 끊겨 응답이 없는 **좀비 세션**을 서버가 치워버린(청소한) 횟수입니다. 이 수치가 치솟으면 클라이언트 측에 대규모 장애나 튕김 현상이 없는지 의심해 볼 수 있으며, 대기열 회전율이 낭비되지 않는지 방어 상태를 확인합니다. | `WorkerService.java` |
| **`popcon_vqa_start_total`<br>`popcon_vqa_submit_total`**<br>(Counter) | **[매크로 방어율 검증]**<br>매크로 방지 퀴즈(VQA)의 패스, 실패, 진행 면제 수치입니다. 매크로 의심 봇들이 대량 차단(실패) 당하는 비율과, 정상 유저가 퀴즈를 무사히 통과하는 비율을 비교해 도입된 보안 체계의 실효성을 검증합니다. | `VqaService.java` |
| **`popcon_bid_total`**<br>(Counter) | **[결제 퍼널(Funnel) 병목 파악]**<br>경매 입찰 클릭 시 결과(성공, 재고 소진, 결제 실패 등) 누적 횟수입니다. 유저가 '입찰' 버튼을 누른 후 결제 모듈 장벽 등에 막히지 않고 안착하는지, 품절로 튕겨 나가는 건수가 얼마나 되는지 비즈니스 핵심 흐름을 파악합니다. | `BidService.java` |
| **`popcon_draw_entry_total`**<br>(Counter) | **[이벤트 응모 실적 누적]**<br>드로우(추첨) 성공 및 중복 응모 거절 횟수입니다. 특정 드로우 상품별로 얼마나 많은 화제성(응모 수)이 몰렸는지 이벤트 단위의 흥행 정도를 파악합니다. | `DrawEntryService.java` |
| **`popcon_payment_latency`**<br>(Timer) | **[결제 품질 및 지연 현상 감지]**<br>실제 돈이 오가는 PG사(포트원) 연동 처리 소요 시간입니다. 평소엔 0.1초 만에 끝나던 결제가 트래픽 폭주 시 1~2초 이상 지연되어 고객 불편을 초래하고 있지 않은지 결제 품질 저하 여부를 감지합니다. | `BidService.java` |
| **`popcon_sse_active_connections`<br>`popcon_sse_events_total`**<br>(Gauge/Counter) | **[실시간 브로드캐스팅 안정성 파악]**<br>수만 명이 열어둔 경매 페이지와 맺어진 실시간 연결(Websocket/SSE) 상태입니다. 서버가 수만 명에게 동시에 화면 갱신 정보(서버 호가 상승 등)를 안 끊기고 잘 쏴주고 있는지 확인합니다. | `AuctionSseService.java` |
| **`popcon_worker_promote_total`**<br>(Counter) | **[대기열 순환 건강도 체크]**<br>백그라운드에서 유저를 대기열에서 메인 서비스로 빠르게 밀어 넣어주는(승격) 횟수입니다. 대기 시스템이 먹통이 되지 않고 사람들을 제때 들여보내고 있는지 시스템의 혈액순환 여부를 보여줍니다. | `WorkerService.java` |

당장 필요하진 않지만 이런 거 세팅했다고 자료 뽑을만한 지표도 같이 추가해뒀습니다....
배포 되면 해당 지표 기반으로 대시보드 만들어서 공유드리겠습니다.

---

## 확인 필요한 항목
단순 지표 추가가 아니라 로직 상 수정이 있는 부분을 따로 기입해둡니다. 참고해서 확인 부탁드립니다.

### queue-service
- 대기열 상태를 시각화하기 위해 Redis ZSET에 담긴 대기열 인원(WAITING)과 진입 인원(ACTIVE) 숫자를 주기적으로 읽어오는 스케줄러 로직 추가
  - 5초 주기로 auction 및 draw 큐 사이즈 수집
  - 대기열 사이즈 계산을 위해 QueueWaitingRepository, QueueActiveRepository에 신규 메서드 추가
 - QueueServiceConfig.java(수정), QueueSizeMetrics.java(추가)

### draw-service
- DrawEntryService.java, validateEntryWindow 메서드 부분
  - 데이터 기록 시 drawid와 함께 draw option id도 함께 기록하기 위해 인자를 drawOption 자체로 받는 것으로 변경

