### PR TITLE
fix: 부하테스트 대비 메모리 사용량 조정

### DIFF
--- a/auction-service/Dockerfile
+++ b/auction-service/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY auction-service/build/libs/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=staging
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=75.0"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0"
 
 USER appuser
 

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY auth-service/build/libs/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=staging
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=75.0"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0"
 
 USER appuser
 

--- a/draw-service/Dockerfile
+++ b/draw-service/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY draw-service/build/libs/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=staging
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=75.0"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0"
 
 USER appuser
 

--- a/popup-service/Dockerfile
+++ b/popup-service/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY popup-service/build/libs/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=staging
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=75.0"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0"
 
 USER appuser
 

--- a/queue-service/Dockerfile
+++ b/queue-service/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY queue-service/build/libs/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=staging
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=75.0"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0"
 
 USER appuser
 

--- a/queue-worker/Dockerfile
+++ b/queue-worker/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY queue-worker/build/libs/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=staging
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=75.0"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0"
 
 USER appuser
 

--- a/ticket-service/Dockerfile
+++ b/ticket-service/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY ticket-service/build/libs/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=staging
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=75.0"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0"
 
 USER appuser
 

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 COPY user-service/build/libs/*.jar app.jar
 
 ENV SPRING_PROFILES_ACTIVE=staging
-ENV JAVA_OPTS="-XX:InitialRAMPercentage=15.0 -XX:MaxRAMPercentage=75.0"
+ENV JAVA_OPTS="-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0"
 
 USER appuser
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
X

## 📝 작업 내용
기존에는 최대한 서버비 아끼려고 메모리 사용량을 낮게 잡아놨는데, 부하테스트 대비하여 수치 조정합니다.