### PR TITLE
feat: 드로우 응답 수정 및 응모 결과 확인 및 응모내역 수정

### DIFF
--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawResultConfirmResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawResultConfirmResponse.java
@@ -3,6 +3,7 @@ package com.t1.popcon.draw.dto.response;
 import com.t1.popcon.draw.client.dto.TicketIssueResponse;
 import com.t1.popcon.draw.domain.DrawEntryStatus;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.Builder;
 
 @Builder
@@ -25,10 +26,12 @@ public record DrawResultConfirmResponse(
         String winningRatePercent,
         TicketIssueResponse ticket
     ) {
+        DrawEntryStatus confirmedStatus = Objects.requireNonNull(status, "status must not be null");
+
         return DrawResultConfirmResponse.builder()
             .drawEntryId(drawEntryId)
             .drawId(drawId)
-            .resultType(status.name())
+            .resultType(confirmedStatus.name())
             .hasTicket(ticket != null)
             .announcementAt(announcementAt)
             .resultCheckedAt(resultCheckedAt)

--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawResultConfirmResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawResultConfirmResponse.java
@@ -1,6 +1,7 @@
 package com.t1.popcon.draw.dto.response;
 
 import com.t1.popcon.draw.client.dto.TicketIssueResponse;
+import com.t1.popcon.draw.domain.DrawEntryStatus;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
@@ -8,8 +9,31 @@ import lombok.Builder;
 public record DrawResultConfirmResponse(
     Long drawEntryId,
     Long drawId,
+    String status,
+    boolean winner,
     LocalDateTime announcementAt,
     LocalDateTime resultCheckedAt,
+    Integer topPercent,
     TicketIssueResponse ticket
 ) {
+    public static DrawResultConfirmResponse of(
+        Long drawEntryId,
+        Long drawId,
+        DrawEntryStatus status,
+        LocalDateTime announcementAt,
+        LocalDateTime resultCheckedAt,
+        Integer topPercent,
+        TicketIssueResponse ticket
+    ) {
+        return DrawResultConfirmResponse.builder()
+            .drawEntryId(drawEntryId)
+            .drawId(drawId)
+            .status(status.name())
+            .winner(status == DrawEntryStatus.WINNER)
+            .announcementAt(announcementAt)
+            .resultCheckedAt(resultCheckedAt)
+            .topPercent(topPercent)
+            .ticket(ticket)
+            .build();
+    }
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawResultConfirmResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawResultConfirmResponse.java
@@ -9,11 +9,11 @@ import lombok.Builder;
 public record DrawResultConfirmResponse(
     Long drawEntryId,
     Long drawId,
-    String status,
-    boolean winner,
+    String resultType,
+    boolean hasTicket,
     LocalDateTime announcementAt,
     LocalDateTime resultCheckedAt,
-    Integer topPercent,
+    Integer winningRatePercent,
     TicketIssueResponse ticket
 ) {
     public static DrawResultConfirmResponse of(
@@ -28,11 +28,11 @@ public record DrawResultConfirmResponse(
         return DrawResultConfirmResponse.builder()
             .drawEntryId(drawEntryId)
             .drawId(drawId)
-            .status(status.name())
-            .winner(status == DrawEntryStatus.WINNER)
+            .resultType(status.name())
+            .hasTicket(ticket != null)
             .announcementAt(announcementAt)
             .resultCheckedAt(resultCheckedAt)
-            .topPercent(topPercent)
+            .winningRatePercent(topPercent)
             .ticket(ticket)
             .build();
     }

--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawResultConfirmResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawResultConfirmResponse.java
@@ -13,7 +13,7 @@ public record DrawResultConfirmResponse(
     boolean hasTicket,
     LocalDateTime announcementAt,
     LocalDateTime resultCheckedAt,
-    Integer winningRatePercent,
+    String winningRatePercent,
     TicketIssueResponse ticket
 ) {
     public static DrawResultConfirmResponse of(
@@ -22,7 +22,7 @@ public record DrawResultConfirmResponse(
         DrawEntryStatus status,
         LocalDateTime announcementAt,
         LocalDateTime resultCheckedAt,
-        Integer topPercent,
+        String winningRatePercent,
         TicketIssueResponse ticket
     ) {
         return DrawResultConfirmResponse.builder()
@@ -32,7 +32,7 @@ public record DrawResultConfirmResponse(
             .hasTicket(ticket != null)
             .announcementAt(announcementAt)
             .resultCheckedAt(resultCheckedAt)
-            .winningRatePercent(topPercent)
+            .winningRatePercent(winningRatePercent)
             .ticket(ticket)
             .build();
     }

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
@@ -3,10 +3,12 @@ package com.t1.popcon.draw.repository;
 import com.t1.popcon.draw.domain.DrawEntry;
 import com.t1.popcon.draw.domain.DrawEntryStatus;
 
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,6 +30,16 @@ public interface DrawEntryRepository extends JpaRepository<DrawEntry, Long> {
     boolean existsByDrawOption_IdAndStatus(Long drawOptionId, DrawEntryStatus status);
 
     Optional<DrawEntry> findByIdAndUserId(Long id, Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select drawEntry
+        from DrawEntry drawEntry
+        join fetch drawEntry.drawOption drawOption
+        join fetch drawOption.draw draw
+        where drawEntry.id = :id and drawEntry.userId = :userId
+        """)
+    Optional<DrawEntry> findByIdAndUserIdForUpdate(@Param("id") Long id, @Param("userId") Long userId);
 
     long countByDrawOption_Draw_Id(Long drawId);
 

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
@@ -29,6 +29,10 @@ public interface DrawEntryRepository extends JpaRepository<DrawEntry, Long> {
 
     Optional<DrawEntry> findByIdAndUserId(Long id, Long userId);
 
+    long countByDrawOption_Draw_Id(Long drawId);
+
+    long countByDrawOption_Draw_IdAndStatus(Long drawId, DrawEntryStatus status);
+
     long countByUserId(Long userId);
 
     long countByUserIdAndStatus(Long userId, DrawEntryStatus status);

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -44,13 +44,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class DrawEntryService {
 
     private static final String SUCCESS_CODE = "SUCCESS";
-    private static final String UNKNOWN_POPUP_TITLE = "\uc54c \uc218 \uc5c6\ub294 \ud31d\uc5c5";
+    private static final String UNKNOWN_POPUP_TITLE = "알 수 없는 팝업";
     private static final long DEFAULT_PRICE = 0L;
-    private static final String DISPLAY_IN_PROGRESS = "\uc9c4\ud589 \uc911";
-    private static final String DISPLAY_DRAW_PENDING = "\ucd94\ucca8 \ub300\uae30";
-    private static final String DISPLAY_ANNOUNCEMENT_PENDING = "\uacb0\uacfc \ubc1c\ud45c \ub300\uae30";
-    private static final String DISPLAY_TICKET_ISSUED = "\ud2f0\ucf13 \ubc1c\uae09 \uc644\ub8cc";
-    private static final String DISPLAY_RESULT_CONFIRM = "\uacb0\uacfc \ud655\uc778\ud558\uae30";
+    private static final String DISPLAY_IN_PROGRESS = "진행 중";
+    private static final String DISPLAY_DRAW_PENDING = "추첨 대기";
+    private static final String DISPLAY_ANNOUNCEMENT_PENDING = "결과 발표 대기";
+    private static final String DISPLAY_TICKET_ISSUED = "티켓 발급 완료";
+    private static final String DISPLAY_RESULT_CONFIRM = "결과 확인하기";
 
     @Value("${draw.silent-drop-threshold:80}")
     private int silentDropThreshold;
@@ -148,7 +148,7 @@ public class DrawEntryService {
             .entryDate(entry.getDrawOption().getEntryDate())
             .entryTime(entry.getDrawOption().getEntryTime())
             .userName(encryptionService.decrypt(entry.getEncryptedName()))
-            // Format the decrypted phone number with hyphens for display.
+            // 복호화된 전화번호를 하이픈 형식으로 포맷
             .userPhoneNumber(formatPhone(encryptionService.decrypt(entry.getEncryptedPhoneNumber())))
             .paidAt(entry.getPaidAt())
             .status(entry.getStatus().name())
@@ -166,7 +166,7 @@ public class DrawEntryService {
             .entryDate(drawOption.getEntryDate())
             .entryTime(drawOption.getEntryTime())
             .userName(encryptionService.decrypt(userInfo.encryptedName()))
-            // Format the decrypted phone number with hyphens for display.
+            // 복호화된 전화번호를 하이픈 형식으로 포맷
             .userPhoneNumber(formatPhone(encryptionService.decrypt(userInfo.encryptedPhoneNumber())))
             .build();
     }
@@ -346,7 +346,7 @@ public class DrawEntryService {
             || message.contains(DrawEntry.DRAW_UNIQUE_CONSTRAINT_NAME));
     }
 
-    /** Format a phone number as 010-XXXX-XXXX when possible. */
+    /** 전화번호를 가능한 경우 010-XXXX-XXXX 형식으로 포맷 */
     private static String formatPhone(String phone) {
         if (phone == null || phone.isBlank()) {
             return phone;

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -44,12 +44,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class DrawEntryService {
 
     private static final String SUCCESS_CODE = "SUCCESS";
-    private static final String UNKNOWN_POPUP_TITLE = "알 수 없는 팝업";
+    private static final String UNKNOWN_POPUP_TITLE = "\uc54c \uc218 \uc5c6\ub294 \ud31d\uc5c5";
     private static final long DEFAULT_PRICE = 0L;
-    private static final String DISPLAY_IN_PROGRESS = "진행 중";
-    private static final String DISPLAY_DRAW_PENDING = "추첨 대기";
-    private static final String DISPLAY_ANNOUNCEMENT_PENDING = "결과 발표 대기";
-    private static final String DISPLAY_TICKET_ISSUED = "티켓 발급 완료";
+    private static final String DISPLAY_IN_PROGRESS = "\uc9c4\ud589 \uc911";
+    private static final String DISPLAY_DRAW_PENDING = "\ucd94\ucca8 \ub300\uae30";
+    private static final String DISPLAY_ANNOUNCEMENT_PENDING = "\uacb0\uacfc \ubc1c\ud45c \ub300\uae30";
+    private static final String DISPLAY_TICKET_ISSUED = "\ud2f0\ucf13 \ubc1c\uae09 \uc644\ub8cc";
+    private static final String DISPLAY_RESULT_CONFIRM = "\uacb0\uacfc \ud655\uc778\ud558\uae30";
 
     @Value("${draw.silent-drop-threshold:80}")
     private int silentDropThreshold;
@@ -147,7 +148,7 @@ public class DrawEntryService {
             .entryDate(entry.getDrawOption().getEntryDate())
             .entryTime(entry.getDrawOption().getEntryTime())
             .userName(encryptionService.decrypt(entry.getEncryptedName()))
-            // 복호화된 전화번호를 하이픈 형식으로 포맷
+            // Format the decrypted phone number with hyphens for display.
             .userPhoneNumber(formatPhone(encryptionService.decrypt(entry.getEncryptedPhoneNumber())))
             .paidAt(entry.getPaidAt())
             .status(entry.getStatus().name())
@@ -165,7 +166,7 @@ public class DrawEntryService {
             .entryDate(drawOption.getEntryDate())
             .entryTime(drawOption.getEntryTime())
             .userName(encryptionService.decrypt(userInfo.encryptedName()))
-            // 복호화된 전화번호를 하이픈 형식으로 포맷
+            // Format the decrypted phone number with hyphens for display.
             .userPhoneNumber(formatPhone(encryptionService.decrypt(userInfo.encryptedPhoneNumber())))
             .build();
     }
@@ -318,7 +319,7 @@ public class DrawEntryService {
         }
 
         if (entry.getResultCheckedAt() == null) {
-            return "결과 확인하기";
+            return DISPLAY_RESULT_CONFIRM;
         }
 
         if (entry.getStatus() == DrawEntryStatus.WINNER) {
@@ -331,10 +332,6 @@ public class DrawEntryService {
     }
 
     private String resolveExposedStatus(DrawEntry entry, LocalDateTime now, LocalDateTime announcementAt) {
-        if (entry.getStatus() == DrawEntryStatus.APPLIED) {
-            return DrawEntryStatus.APPLIED.name();
-        }
-
         if (now.isBefore(announcementAt) || entry.getResultCheckedAt() == null) {
             return DrawEntryStatus.APPLIED.name();
         }
@@ -349,7 +346,7 @@ public class DrawEntryService {
             || message.contains(DrawEntry.DRAW_UNIQUE_CONSTRAINT_NAME));
     }
 
-    /** 전화번호를 010-XXXX-XXXX 형식으로 변환 */
+    /** Format a phone number as 010-XXXX-XXXX when possible. */
     private static String formatPhone(String phone) {
         if (phone == null || phone.isBlank()) {
             return phone;
@@ -376,3 +373,4 @@ public class DrawEntryService {
         );
     }
 }
+

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -288,7 +288,7 @@ public class DrawEntryService {
         LocalDateTime announcementAt = draw.getAnnouncementAt();
         boolean resultChecked = entry.getResultCheckedAt() != null;
         boolean resultAvailable = !now.isBefore(announcementAt) && entry.getStatus() != DrawEntryStatus.APPLIED;
-        boolean clickable = entry.getStatus() == DrawEntryStatus.WINNER && resultAvailable && !resultChecked;
+        boolean clickable = resultAvailable && !resultChecked;
 
         return DrawEntryResponse.builder()
             .id(entry.getId())
@@ -298,7 +298,7 @@ public class DrawEntryService {
             .price(DEFAULT_PRICE)
             .paidAt(entry.getPaidAt())
             .displayStatus(resolveDisplayStatus(entry, now, announcementAt))
-            .status(entry.getStatus().name())
+            .status(resolveExposedStatus(entry, now, announcementAt))
             .announcementAt(announcementAt)
             .resultAvailable(resultAvailable)
             .resultChecked(resultChecked)
@@ -317,6 +317,10 @@ public class DrawEntryService {
             return DISPLAY_ANNOUNCEMENT_PENDING;
         }
 
+        if (entry.getResultCheckedAt() == null) {
+            return "결과 확인하기";
+        }
+
         if (entry.getStatus() == DrawEntryStatus.WINNER) {
             return entry.getTicketIssuedAt() == null
                 ? DrawEntryStatus.WINNER.getDescription()
@@ -324,6 +328,18 @@ public class DrawEntryService {
         }
 
         return entry.getStatus().getDescription();
+    }
+
+    private String resolveExposedStatus(DrawEntry entry, LocalDateTime now, LocalDateTime announcementAt) {
+        if (entry.getStatus() == DrawEntryStatus.APPLIED) {
+            return DrawEntryStatus.APPLIED.name();
+        }
+
+        if (now.isBefore(announcementAt) || entry.getResultCheckedAt() == null) {
+            return DrawEntryStatus.APPLIED.name();
+        }
+
+        return entry.getStatus().name();
     }
 
     private boolean isDuplicateEntryViolation(DataIntegrityViolationException e) {

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -299,7 +299,7 @@ public class DrawEntryService {
             .price(DEFAULT_PRICE)
             .paidAt(entry.getPaidAt())
             .displayStatus(resolveDisplayStatus(entry, now, announcementAt))
-            .status(resolveExposedStatus(entry, now, announcementAt))
+            .status(resolveExposedStatus(entry, resultAvailable, resultChecked))
             .announcementAt(announcementAt)
             .resultAvailable(resultAvailable)
             .resultChecked(resultChecked)
@@ -331,8 +331,8 @@ public class DrawEntryService {
         return entry.getStatus().getDescription();
     }
 
-    private String resolveExposedStatus(DrawEntry entry, LocalDateTime now, LocalDateTime announcementAt) {
-        if (now.isBefore(announcementAt) || entry.getResultCheckedAt() == null) {
+    private String resolveExposedStatus(DrawEntry entry, boolean resultAvailable, boolean resultChecked) {
+        if (!resultAvailable || !resultChecked) {
             return DrawEntryStatus.APPLIED.name();
         }
 

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawResultService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawResultService.java
@@ -90,8 +90,11 @@ public class DrawResultService {
         entry.markResultChecked(now);
 
         Integer topPercent = calculateTopPercent(draw.getId(), entry.getStatus());
-        TicketIssueResponse ticket = issueDrawTicket(entry, draw);
-        entry.markTicketIssued(now);
+        TicketIssueResponse ticket = null;
+        if (entry.getStatus() == DrawEntryStatus.WINNER) {
+            ticket = issueDrawTicket(entry, draw);
+            entry.markTicketIssued(now);
+        }
 
         return DrawResultConfirmResponse.of(
             entry.getId(),
@@ -147,7 +150,7 @@ public class DrawResultService {
     }
 
     private void validateConfirmable(DrawEntry entry) {
-        if (entry.getTicketIssuedAt() != null) {
+        if (entry.getStatus() == DrawEntryStatus.WINNER && entry.getTicketIssuedAt() != null) {
             throw new CustomException(ErrorCode.TICKET_ALREADY_ISSUED);
         }
 
@@ -159,10 +162,6 @@ public class DrawResultService {
         LocalDateTime now = LocalDateTime.now(clock);
         if (now.isBefore(draw.getAnnouncementAt())) {
             throw new CustomException(ErrorCode.DRAW_RESULT_NOT_ANNOUNCED);
-        }
-
-        if (entry.getStatus() != DrawEntryStatus.WINNER) {
-            throw new CustomException(ErrorCode.DRAW_NOT_WINNER);
         }
     }
 

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawResultService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawResultService.java
@@ -80,7 +80,7 @@ public class DrawResultService {
 
     @Transactional
     public DrawResultConfirmResponse confirmResult(Long userId, Long drawEntryId) {
-        DrawEntry entry = drawEntryRepository.findByIdAndUserId(drawEntryId, userId)
+        DrawEntry entry = drawEntryRepository.findByIdAndUserIdForUpdate(drawEntryId, userId)
             .orElseThrow(() -> new CustomException(ErrorCode.DRAW_ENTRY_NOT_FOUND));
 
         validateConfirmable(entry);
@@ -89,7 +89,7 @@ public class DrawResultService {
         LocalDateTime now = LocalDateTime.now(clock);
         entry.markResultChecked(now);
 
-        Integer topPercent = calculateTopPercent(draw.getId(), entry.getStatus());
+        String winningRatePercent = calculateWinningRatePercent(draw.getId(), entry.getStatus());
         TicketIssueResponse ticket = null;
         if (entry.getStatus() == DrawEntryStatus.WINNER) {
             ticket = issueDrawTicket(entry, draw);
@@ -102,7 +102,7 @@ public class DrawResultService {
             entry.getStatus(),
             draw.getAnnouncementAt(),
             entry.getResultCheckedAt(),
-            topPercent,
+            winningRatePercent,
             ticket
         );
     }
@@ -135,7 +135,7 @@ public class DrawResultService {
         return winnerCount;
     }
 
-    private Integer calculateTopPercent(Long drawId, DrawEntryStatus status) {
+    private String calculateWinningRatePercent(Long drawId, DrawEntryStatus status) {
         if (status != DrawEntryStatus.WINNER) {
             return null;
         }
@@ -146,7 +146,19 @@ public class DrawResultService {
         }
 
         long totalWinnerCount = drawEntryRepository.countByDrawOption_Draw_IdAndStatus(drawId, DrawEntryStatus.WINNER);
-        return (int) ((totalWinnerCount * 100) / totalParticipantCount);
+        double winningRatePercent = (double) totalWinnerCount * 100.0d / totalParticipantCount;
+
+        if (winningRatePercent > 50.0d) {
+            return null;
+        }
+        if (winningRatePercent == 0.0d) {
+            return "0%";
+        }
+        if (winningRatePercent < 1.0d) {
+            return "<1%";
+        }
+
+        return (long) Math.floor(winningRatePercent) + "%";
     }
 
     private void validateConfirmable(DrawEntry entry) {

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawResultService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawResultService.java
@@ -89,6 +89,7 @@ public class DrawResultService {
         LocalDateTime now = LocalDateTime.now(clock);
         entry.markResultChecked(now);
 
+        Integer topPercent = calculateTopPercent(draw.getId(), entry.getStatus());
         TicketIssueResponse ticket = issueDrawTicket(entry, draw);
         entry.markTicketIssued(now);
 
@@ -98,7 +99,7 @@ public class DrawResultService {
             entry.getStatus(),
             draw.getAnnouncementAt(),
             entry.getResultCheckedAt(),
-            null,
+            topPercent,
             ticket
         );
     }
@@ -129,6 +130,20 @@ public class DrawResultService {
         }
 
         return winnerCount;
+    }
+
+    private Integer calculateTopPercent(Long drawId, DrawEntryStatus status) {
+        if (status != DrawEntryStatus.WINNER) {
+            return null;
+        }
+
+        long totalParticipantCount = drawEntryRepository.countByDrawOption_Draw_Id(drawId);
+        if (totalParticipantCount <= 0) {
+            return null;
+        }
+
+        long totalWinnerCount = drawEntryRepository.countByDrawOption_Draw_IdAndStatus(drawId, DrawEntryStatus.WINNER);
+        return (int) ((totalWinnerCount * 100) / totalParticipantCount);
     }
 
     private void validateConfirmable(DrawEntry entry) {

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawResultService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawResultService.java
@@ -92,13 +92,15 @@ public class DrawResultService {
         TicketIssueResponse ticket = issueDrawTicket(entry, draw);
         entry.markTicketIssued(now);
 
-        return DrawResultConfirmResponse.builder()
-            .drawEntryId(entry.getId())
-            .drawId(draw.getId())
-            .announcementAt(draw.getAnnouncementAt())
-            .resultCheckedAt(entry.getResultCheckedAt())
-            .ticket(ticket)
-            .build();
+        return DrawResultConfirmResponse.of(
+            entry.getId(),
+            draw.getId(),
+            entry.getStatus(),
+            draw.getAnnouncementAt(),
+            entry.getResultCheckedAt(),
+            null,
+            ticket
+        );
     }
 
     private void validateDrawReady(Draw draw) {

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/DrawHistoryResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/DrawHistoryResponse.java
@@ -15,4 +15,8 @@ public class DrawHistoryResponse {
     private LocalDateTime paidAt;
     private String displayStatus;
     private String status;
+    private LocalDateTime announcementAt;
+    private boolean resultAvailable;
+    private boolean resultChecked;
+    private boolean clickable;
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #266 

## 📝 작업 내용

> 드로우 결과 확인 플로우를 기획 기준에 맞게 정리했습니다.
- 드로우 결과 확인 API 응답 구조를 확장했습니다.
- 결과 확인 응답에 resultType, hasTicket, winningRatePercent, ticket 정보를 포함하도록 변경했습니다.
- 당첨 확률은 전체 당첨자 수 / 전체 참여자 수 * 100 기준으로 계산되도록 구현했습니다.
- 결과 확인 API가 미당첨자도 처리할 수 있도록 수정했습니다.
- 당첨자는 결과 확인 시 티켓이 함께 발급되고, 미당첨자는 결과만 확인되도록 분기했습니다.
- 드로우 내역 조회 시 결과 발표 후에도 확인 전에는 실제 당첨/미당첨을 숨기도록 변경했습니다.
- 결과 확인 전 내역은 displayStatus = 결과 확인하기, status = APPLIED 형태로 내려가도록 정리했습니다.
- 결과 확인 후에는 실제 결과(WINNER / FAILED)가 내역에 반영되도록 수정했습니다.

## ✅ 테스트 결과 (선택)

>로컬 환경에서 아래 시나리오를 확인했습니다.
- 드로우 응모 내역 조회 시 결과 확인 전에는 실제 결과가 숨겨지는지 확인
- 결과 확인 API 호출 시 당첨자의 경우 티켓이 발급되고 확률 정보가 내려오는지 확인
- 결과 확인 후 응모 내역 조회 시 실제 결과와 상태값이 반영되는지 확인
- 
## 📷 스크린샷 (선택)

>
<img width="1402" height="900" alt="드로우 응모내역 조회 성공응답" src="https://github.com/user-attachments/assets/a68f6c07-6fe5-40eb-ad03-ba172c34ddc5" />
<img width="1045" height="905" alt="드로우 응모 결과확인하기 응답" src="https://github.com/user-attachments/assets/894bcfb8-b9b6-4397-ae04-8e3c270553e2" />
<img width="687" height="747" alt="결과 확인 후 응모내역 조회" src="https://github.com/user-attachments/assets/d7186062-4894-4646-afb4-323ca95ea752" />



## 💬 리뷰 요구사항(선택)