### PR TITLE
feat: 예약 상세 응답에 티켓 ID 추가

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/TicketServiceClient.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/TicketServiceClient.java
@@ -1,14 +1,17 @@
 package com.t1.popcon.auction.bid.client;
 
 import com.t1.popcon.auction.bid.client.config.FeignClientConfig;
+import com.t1.popcon.auction.bid.client.dto.TicketDetailResponse;
 import com.t1.popcon.auction.bid.client.dto.TicketIssueRequest;
 import com.t1.popcon.auction.bid.client.dto.TicketIssueResponse;
 import com.t1.popcon.common.response.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
     name = "ticket-service",
@@ -19,6 +22,12 @@ public interface TicketServiceClient {
 
     @PostMapping("/internal/tickets")
     ApiResponse<TicketIssueResponse> issueTicket(@RequestBody TicketIssueRequest request);
+
+    @GetMapping("/internal/tickets/reservations/{reservationNo}")
+    ApiResponse<TicketDetailResponse> getTicketByReservationNo(
+        @PathVariable("reservationNo") String reservationNo,
+        @RequestParam("userId") Long userId
+    );
 
     // 테스트 초기화용: popupId 기준 티켓 전체 삭제
     @DeleteMapping("/internal/admin/tickets/{popupId}")

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/dto/TicketDetailResponse.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/dto/TicketDetailResponse.java
@@ -1,0 +1,9 @@
+package com.t1.popcon.auction.bid.client.dto;
+
+// 티켓 서비스로부터 받는 티켓 상세 응답 (ticketId 포함)
+public record TicketDetailResponse(
+    Long ticketId,
+    String reservationNo,
+    String status
+) {
+}

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/dto/response/ReservationDetailResponse.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/dto/response/ReservationDetailResponse.java
@@ -7,6 +7,7 @@ import java.time.LocalTime;
 
 @Builder
 public record ReservationDetailResponse(
+    Long ticketId,
     String reservationNo,
     String popupTitle,
     String popupAddress,

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -5,6 +5,7 @@ import com.t1.popcon.auction.bid.client.TicketServiceClient;
 import com.t1.popcon.auction.bid.client.UserBillingClient;
 import com.t1.popcon.auction.bid.client.dto.BillingKeyInternalResponse;
 import com.t1.popcon.auction.bid.client.dto.PopupInternalResponse;
+import com.t1.popcon.auction.bid.client.dto.TicketDetailResponse;
 import com.t1.popcon.auction.bid.client.dto.TicketIssueRequest;
 import com.t1.popcon.auction.bid.client.dto.TicketIssueResponse;
 import com.t1.popcon.auction.bid.domain.Bid;
@@ -106,11 +107,8 @@ public class BidService {
                 .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
         PriceDetails priceDetails = computePriceDetails(bid, reservationNo);
-        return buildReservationDetailResponse(
-                bid,
-                priceDetails.startPrice(),
-                priceDetails.discountAmount(),
-                priceDetails.bidPrice());
+        Long ticketId = fetchTicketId(reservationNo, userId);
+        return buildReservationDetailResponse(bid, priceDetails.startPrice(), priceDetails.discountAmount(), priceDetails.bidPrice(), ticketId);
     }
 
     public ReservationDetailResponse getBidDetail(Long userId, Long bidId) {
@@ -118,11 +116,8 @@ public class BidService {
                 .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
         PriceDetails priceDetails = computePriceDetails(bid, bid.getReservationNo());
-        return buildReservationDetailResponse(
-                bid,
-                priceDetails.startPrice(),
-                priceDetails.discountAmount(),
-                priceDetails.bidPrice());
+        Long ticketId = fetchTicketId(bid.getReservationNo(), userId);
+        return buildReservationDetailResponse(bid, priceDetails.startPrice(), priceDetails.discountAmount(), priceDetails.bidPrice(), ticketId);
     }
 
     private PriceDetails computePriceDetails(Bid bid, String reservationNo) {
@@ -143,12 +138,26 @@ public class BidService {
         return new PriceDetails(startPrice, bidPrice, discountAmount);
     }
 
+    private Long fetchTicketId(String reservationNo, Long userId) {
+        try {
+            ApiResponse<TicketDetailResponse> response = ticketServiceClient.getTicketByReservationNo(reservationNo, userId);
+            if (response != null && response.getData() != null) {
+                return response.getData().ticketId();
+            }
+        } catch (Exception e) {
+            log.warn("Ticket lookup failed. reservationNo={}, error={}", reservationNo, e.getMessage());
+        }
+        return null;
+    }
+
     private ReservationDetailResponse buildReservationDetailResponse(
             Bid bid,
             Integer startPrice,
             Integer discountAmount,
-            Integer bidPrice) {
+            Integer bidPrice,
+            Long ticketId) {
         return ReservationDetailResponse.builder()
+                .ticketId(ticketId)
                 .reservationNo(bid.getReservationNo())
                 .popupTitle(bid.getPopupTitle())
                 .popupAddress(bid.getPopupAddress())


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #269 

## 📝 작업 내용

- ReservationDetailResponse에 ticketId 필드 추가
- TicketServiceClient에 getTicketByReservationNo Feign 메서드 추가
- 예약 상세 조회 시 티켓 서비스로부터 ticketId를 조회하여 응답에 포함
- 티켓 서비스 장애 시 ticketId = null로 graceful degradation 처리

## ✅ 테스트 결과

>

## 💬 리뷰 요구사항
