### PR TITLE
fix: 대기열 진입 차단 해제 시간 UTC → KST 변환 수정

### DIFF
--- a/queue-service/src/main/java/com/t1/popcon/queue/service/QueueEntryService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/QueueEntryService.java
@@ -19,7 +19,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -100,7 +100,8 @@ public class QueueEntryService {
         Optional<Long> blockedUntilEpoch = blockRepository.getBlockedUntilEpoch(phaseType, phaseId, userId);
         if (blockedUntilEpoch.isPresent()) {
             String blockedUntil = Instant.ofEpochSecond(blockedUntilEpoch.get())
-                .atOffset(ZoneOffset.UTC)
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .toLocalDateTime()
                 .toString();
             log.info("[Queue] 차단된 사용자 진입 시도 - phaseType={}, phaseId={}, userId={}",
                 phaseType, phaseId, userId % 1000);


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #271 

## 📝 작업 내용

- QueueEntryService.checkBlocked()에서 차단 해제 시간 변환 시
  ZoneOffset.UTC → ZoneId.of("Asia/Seoul") 로 수정
- 클라이언트에 반환되는 blockedUntil 시간이 KST 기준으로 표시됨