### PR TITLE
fix: vThumbnailUrl/hThumbnailUrl 필드명을 thumbnailUrl로 통일

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/dto/PopupInternalResponse.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/dto/PopupInternalResponse.java
@@ -7,7 +7,6 @@ public record PopupInternalResponse(
 	Long popupId,
 	String title,
 	String location,
-	String hThumbnailUrl,
-	String vThumbnailUrl
+	String thumbnailUrl
 ) {
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -317,8 +317,8 @@ public class BidService {
                         if (popupInfo.location() != null) {
                             popupAddress = popupInfo.location();
                         }
-                        if (popupInfo.vThumbnailUrl() != null) {
-                            thumbnailUrl = popupInfo.vThumbnailUrl();
+                        if (popupInfo.thumbnailUrl() != null) {
+                            thumbnailUrl = popupInfo.thumbnailUrl();
                         }
                     } else {
                         log.warn("Popup detail response is empty. popupId={}", option.getAuction().getPopupId());

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -135,7 +135,7 @@ public class BidServiceTest {
 		PortOnePaymentResponse paymentResponse = new PortOnePaymentResponse(paymentDetail);
 		when(portOneClient.executePayment(anyString(), anyString(), anyInt(), anyString())).thenReturn(paymentResponse);
 
-		PopupInternalResponse popupInfo = new PopupInternalResponse(1L, "Pop-up Title", "Location", "h_thumbnail.url", "v_thumbnail.url");
+		PopupInternalResponse popupInfo = new PopupInternalResponse(1L, "Pop-up Title", "Location", "v_thumbnail.url");
 		when(auction.getPopupId()).thenReturn(1L);
 		when(popupServiceClient.getPopupDetail(anyLong())).thenReturn(ApiResponse.ok(popupInfo));
 		when(option.getEntryDate()).thenReturn(LocalDate.now());

--- a/draw-service/src/main/java/com/t1/popcon/draw/client/dto/PopupInternalResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/client/dto/PopupInternalResponse.java
@@ -6,8 +6,7 @@ import lombok.Builder;
 public record PopupInternalResponse(
 	Long popupId,
 	String title,
-	String hThumbnailUrl,
-	String vThumbnailUrl,
+	String thumbnailUrl,
 	String location
 ) {
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawEntryResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawEntryResponse.java
@@ -10,7 +10,7 @@ public class DrawEntryResponse {
 
     private Long id;
     private Long drawId;
-    private String vThumbnailUrl;
+    private String thumbnailUrl;
     private String title;
     private Long price;
     private LocalDateTime paidAt;

--- a/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawEntryResultResponse.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/dto/response/DrawEntryResultResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record DrawEntryResultResponse(
-    String vThumbnailUrl,
+    String thumbnailUrl,
     String popupTitle,
     String popupAddress,
     LocalDate entryDate,

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -144,7 +144,7 @@ public class DrawEntryService {
             .drawId(entry.getDrawOption().getDraw().getId())
             .popupTitle(popupInfo != null ? popupInfo.title() : UNKNOWN_POPUP_TITLE)
             .popupAddress(popupInfo != null ? popupInfo.location() : null)
-            .popupThumbnail(popupInfo != null ? popupInfo.vThumbnailUrl() : null)
+            .popupThumbnail(popupInfo != null ? popupInfo.thumbnailUrl() : null)
             .entryDate(entry.getDrawOption().getEntryDate())
             .entryTime(entry.getDrawOption().getEntryTime())
             .userName(encryptionService.decrypt(entry.getEncryptedName()))
@@ -160,7 +160,7 @@ public class DrawEntryService {
         PopupInternalResponse popupInfo = fetchPopupInfo(drawOption.getDraw().getPopupId(), null);
 
         return DrawEntryResultResponse.builder()
-            .vThumbnailUrl(popupInfo != null ? popupInfo.vThumbnailUrl() : null)
+            .thumbnailUrl(popupInfo != null ? popupInfo.thumbnailUrl() : null)
             .popupTitle(popupInfo != null ? popupInfo.title() : UNKNOWN_POPUP_TITLE)
             .popupAddress(popupInfo != null ? popupInfo.location() : null)
             .entryDate(drawOption.getEntryDate())
@@ -294,7 +294,7 @@ public class DrawEntryService {
         return DrawEntryResponse.builder()
             .id(entry.getId())
             .drawId(draw.getId())
-            .vThumbnailUrl(popupInfo != null ? popupInfo.vThumbnailUrl() : null)
+            .thumbnailUrl(popupInfo != null ? popupInfo.thumbnailUrl() : null)
             .title(popupInfo != null ? popupInfo.title() : UNKNOWN_POPUP_TITLE)
             .price(DEFAULT_PRICE)
             .paidAt(entry.getPaidAt())

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/dto/InternalPopupResponse.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/dto/InternalPopupResponse.java
@@ -1,14 +1,12 @@
 package com.t1.popcon.popup.detail.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 @Builder
 public record InternalPopupResponse(
     Long popupId,
     String title,
-    String hThumbnailUrl,
-    String vThumbnailUrl,
+    String thumbnailUrl,
     String location
 ) {
 }

--- a/popup-service/src/main/java/com/t1/popcon/popup/detail/service/PopupDetailService.java
+++ b/popup-service/src/main/java/com/t1/popcon/popup/detail/service/PopupDetailService.java
@@ -64,7 +64,7 @@ public class PopupDetailService {
             .popupId(popup.getId())
             .title(popup.getTitle())
             .location(popup.getLocation())
-            .vThumbnailUrl(popup.getVThumbUrl())
+            .thumbnailUrl(popup.getVThumbUrl())
             .build();
     }
 
@@ -74,7 +74,7 @@ public class PopupDetailService {
                 .popupId(popup.getId())
                 .title(popup.getTitle())
                 .location(popup.getLocation())
-                .vThumbnailUrl(popup.getVThumbUrl())
+                .thumbnailUrl(popup.getVThumbUrl())
                 .build())
             .toList();
     }

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/DrawHistoryResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/DrawHistoryResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class DrawHistoryResponse {
     private Long id;
     private Long drawId;
-    private String vThumbnailUrl;
+    private String thumbnailUrl;
     private String title;
     private Long price;
     private LocalDateTime paidAt;

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/PopupInternalResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/PopupInternalResponse.java
@@ -3,8 +3,7 @@ package com.t1.popcon.user.dto.history;
 public record PopupInternalResponse(
     Long popupId,
     String title,
-    String hThumbnailUrl,
-    String vThumbnailUrl,
+    String thumbnailUrl,
     String location
 ) {
 }

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -277,7 +277,7 @@ public class UserHistoryService {
             .issuedAt(ticket.getIssuedAt())
             .popupTitle(firstNonBlank(popup != null ? popup.title() : null, ticket.getPopupTitle()))
             .popupAddress(firstNonBlank(popup != null ? popup.location() : null, ticket.getPopupAddress()))
-            .thumbnailUrl(firstNonBlank(popup != null ? popup.vThumbnailUrl() : null, ticket.getThumbnailUrl()))
+            .thumbnailUrl(firstNonBlank(popup != null ? popup.thumbnailUrl() : null, ticket.getThumbnailUrl()))
             .displayStatus(resolveDisplayStatus(ticket.getDisplayStatus(), ticket.getStatus()))
             .build();
     }
@@ -297,7 +297,7 @@ public class UserHistoryService {
             .issuedAt(ticket.getIssuedAt())
             .popupTitle(popup != null ? popup.title() : null)
             .popupAddress(popup != null ? popup.location() : null)
-            .thumbnailUrl(popup != null ? popup.vThumbnailUrl() : null)
+            .thumbnailUrl(popup != null ? popup.thumbnailUrl() : null)
             .displayStatus(resolveDisplayStatus(null, ticket.getStatus()))
             .build();
     }
@@ -369,7 +369,7 @@ public class UserHistoryService {
         detailBuilder
             .popupTitle(firstNonBlank(currentDetail.getPopupTitle(), popup.title()))
             .popupAddress(firstNonBlank(currentDetail.getPopupAddress(), popup.location()))
-            .thumbnailUrl(firstNonBlank(currentDetail.getThumbnailUrl(), popup.vThumbnailUrl()));
+            .thumbnailUrl(firstNonBlank(currentDetail.getThumbnailUrl(), popup.thumbnailUrl()));
     }
 
     private boolean needsPopupFallback(TicketDetailViewResponse detail) {


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #274 

## 📝 작업 내용
- `vThumbnailUrl` / `hThumbnailUrl` 필드명을 `thumbnailUrl`로 통일
- Lombok + Jackson 직렬화 충돌로 인한 서비스 간 Feign 역직렬화 키 불일치 해소

## ✅ 테스트 결과
테스트 예정
- `GET /history/draws` 응답에서 `thumbnailUrl` 정상 반환 확인
- `GET /history/auctions` 응답에서 `thumbnailUrl` 정상 반환 확인