### PR TITLE
feat: 시연용 슈퍼 계정 생성 API 구현

### DIFF
--- a/user-service/src/main/java/com/t1/popcon/user/controller/TestAccountController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/controller/TestAccountController.java
@@ -49,6 +49,25 @@ public class TestAccountController {
     }
 
     /**
+     * 시연용 슈퍼 계정 생성
+     * @param count 생성할 슈퍼 계정 수
+     */
+    @PostMapping("/super")
+    public ApiResponse<Void> generateSuperAccounts(@RequestParam(defaultValue = "100") int count) {
+        if (count < 1 || count > 1000) {
+            return ApiResponse.fail(ErrorCode.ERROR_SYSTEM.getCode(), "생성할 슈퍼 계정 수는 1개에서 1,000개 사이여야 합니다. (요청: " + count + ")", null);
+        }
+
+        try {
+            testAccountGenerator.generateSuperAccounts(count);
+            return ApiResponse.ok("성공적으로 슈퍼 계정이 생성되었습니다.", null);
+        } catch (Exception e) {
+            log.error("[SuperAccount] 슈퍼 계정 생성 중 오류 발생: ", e);
+            return ApiResponse.fail(ErrorCode.ERROR_SYSTEM.getCode(), "슈퍼 계정 생성 실패", null);
+        }
+    }
+
+    /**
      * 생성된 테스트 계정 파일 다운로드
      * @param filePath 생성 API에서 반환된 전체 파일 경로
      * @return CSV 파일 리소스

--- a/user-service/src/main/java/com/t1/popcon/user/controller/UserController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.t1.popcon.user.controller;
 
 import com.t1.popcon.common.auth.domain.AuthUser;
 import com.t1.popcon.common.response.ApiResponse;
+import com.t1.popcon.user.dto.SuperLoginResponse;
 import com.t1.popcon.user.dto.UserIdResponse;
 import com.t1.popcon.user.dto.UserProfileResponse;
 import com.t1.popcon.user.dto.UserProfileUpdateResponse;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -72,5 +74,15 @@ public class UserController {
     public ApiResponse<UserActivityStatisticsResponse> getMyStatistics(@AuthenticationPrincipal AuthUser authUser) {
         UserActivityStatisticsResponse response = userHistoryService.getMyStatistics(authUser.id());
         return ApiResponse.ok("활동 통계 조회를 완료했습니다.", response);
+    }
+
+    /**
+     * 시연용 슈퍼 계정 순차 로그인
+     * POST /users/login/super
+     */
+    @PostMapping("/login/super")
+    public ApiResponse<SuperLoginResponse> loginSuperAccount() {
+        SuperLoginResponse response = userService.loginSuperAccount();
+        return ApiResponse.ok("시연용 계정 로그인이 완료되었습니다.", response);
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/domain/Role.java
+++ b/user-service/src/main/java/com/t1/popcon/user/domain/Role.java
@@ -1,5 +1,5 @@
 package com.t1.popcon.user.domain;
 
 public enum Role {
-    USER, STAFF, ADMIN
+    USER, STAFF, ADMIN, SUPER
 }

--- a/user-service/src/main/java/com/t1/popcon/user/domain/User.java
+++ b/user-service/src/main/java/com/t1/popcon/user/domain/User.java
@@ -194,6 +194,33 @@ public class User extends BaseSoftDeleteEntity {
         return user;
     }
 
+    public static User createSuperUser(
+            String ciHash,
+            String encryptedName,
+            String encryptedPhoneNumber,
+            String phoneHash,
+            String encryptedBirthDate,
+            String encryptedGender,
+            String encryptedNationality,
+            String nickname,
+            String email
+    ) {
+        return User.builder()
+                .ciHash(ciHash)
+                .encryptedName(encryptedName)
+                .encryptedPhoneNumber(encryptedPhoneNumber)
+                .phoneHash(phoneHash)
+                .encryptedBirthDate(encryptedBirthDate)
+                .encryptedGender(encryptedGender)
+                .encryptedNationality(encryptedNationality)
+                .nickname(nickname)
+                .email(email)
+                .isMarketingAgreed(true)
+                .role(Role.SUPER)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
     public void connectKakao(String kakaoUserId, LocalDateTime connectedAt) {
         this.kakaoUserId = kakaoUserId;
         this.kakaoConnectedAt = connectedAt;

--- a/user-service/src/main/java/com/t1/popcon/user/dto/SuperLoginResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/SuperLoginResponse.java
@@ -1,0 +1,8 @@
+package com.t1.popcon.user.dto;
+
+public record SuperLoginResponse(
+    Long userId,
+    String accessToken,
+    long expiresIn
+) {
+}

--- a/user-service/src/main/java/com/t1/popcon/user/repository/UserRepository.java
+++ b/user-service/src/main/java/com/t1/popcon/user/repository/UserRepository.java
@@ -27,4 +27,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     long countByRole(Role role);
 
     Optional<User> findByNickname(String nickname);
+
+    Optional<User> findByNicknameAndRole(String nickname, Role role);
 }

--- a/user-service/src/main/java/com/t1/popcon/user/repository/UserRepository.java
+++ b/user-service/src/main/java/com/t1/popcon/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.t1.popcon.user.repository;
 
+import com.t1.popcon.user.domain.Role;
 import com.t1.popcon.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -22,4 +23,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /** 닉네임 중복 확인 - 본인 제외 (프로필 수정 시 사용) */
     boolean existsByNicknameAndIdNot(String nickname, Long id);
+
+    long countByRole(Role role);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/user-service/src/main/java/com/t1/popcon/user/service/TestAccountGenerator.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/TestAccountGenerator.java
@@ -156,7 +156,8 @@ public class TestAccountGenerator {
         log.info("[SuperAccount] 슈퍼 계정 생성 시작: 기존 {}개, 추가 {}개 예정", startOffset, count);
 
         ExecutorService executor = Executors.newFixedThreadPool(20);
-        AtomicInteger progress = new AtomicInteger(0);
+        AtomicInteger successCount = new AtomicInteger(0);
+        java.util.concurrent.ConcurrentLinkedQueue<String> errors = new java.util.concurrent.ConcurrentLinkedQueue<>();
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
         for (int i = 1; i <= count; i++) {
@@ -164,13 +165,13 @@ public class TestAccountGenerator {
             futures.add(CompletableFuture.runAsync(() -> {
                 try {
                     self.createSingleSuperAccount(index);
+                    successCount.incrementAndGet();
                 } catch (Exception e) {
-                    log.error("[SuperAccount] 슈퍼 계정 생성 실패 - index={}: {}", index, e.getMessage());
+                    String errorMsg = String.format("index=%d, error=%s", index, e.getMessage());
+                    errors.add(errorMsg);
+                    log.error("[SuperAccount] 슈퍼 계정 생성 실패 - {}", errorMsg);
                 }
-            }, executor).thenRun(() -> {
-                int current = progress.incrementAndGet();
-                if (current % 10 == 0) log.info("[SuperAccount] 진행 상황: {}/{}", current, count);
-            }));
+            }, executor));
 
             if (futures.size() >= 20 || i == count) {
                 CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
@@ -184,7 +185,13 @@ public class TestAccountGenerator {
         // 생성 완료 후 전체 슈퍼 계정 수 Redis 업데이트
         long totalCount = userRepository.countByRole(Role.SUPER);
         redisTemplate.opsForValue().set(SUPER_USER_TOTAL_COUNT_KEY, String.valueOf(totalCount));
-        log.info("[SuperAccount] 슈퍼 계정 생성 완료. 현재 총 {}개 (Redis 업데이트 완료)", totalCount);
+        
+        log.info("[SuperAccount] 슈퍼 계정 생성 작업 종료. 성공: {}, 실패: {}, 총 DB 계정: {}", 
+                 successCount.get(), errors.size(), totalCount);
+        
+        if (!errors.isEmpty()) {
+            log.warn("[SuperAccount] 생성 중 발생한 오류 목록: {}", String.join(" | ", errors));
+        }
     }
 
     private int getSuperStartOffset() {
@@ -200,13 +207,27 @@ public class TestAccountGenerator {
                 .orElse(0);
     }
 
-    @Transactional
+    /**
+     * 비트랜잭션 환경에서 유저 저장과 빌링키 등록을 순차적으로 호출 (외부 API 호출 시 커넥션 점유 방지)
+     */
     public void createSingleSuperAccount(int index) {
         String nickname = "Super_" + index;
         if (userRepository.existsByNickname(nickname)) {
             return;
         }
 
+        // 1. 유저 저장 (Transactional)
+        User user = self.saveSuperUser(index, nickname);
+
+        // 2. 안티매크로 점수 설정 (Redis)
+        setupAntiMacroScore(user.getId());
+
+        // 3. 빌링키 발급 및 저장 (외부 API + Transactional)
+        self.registerBillingKeyForSuperUser(user);
+    }
+
+    @Transactional
+    public User saveSuperUser(int index, String nickname) {
         String rawName = "슈퍼테스터_" + index;
         String rawPhone = String.format("010-9999-%04d", index % 10000);
         String ci = "super_ci_" + index;
@@ -222,22 +243,20 @@ public class TestAccountGenerator {
                 nickname,
                 "super" + index + "@popcon.store"
         );
-        userRepository.save(user);
+        return userRepository.save(user);
+    }
 
-        // 안티매크로 점수 25점 설정 (VQA 유도)
-        String redisKey = "score:" + user.getId();
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    redisTemplate.opsForHash().put(redisKey, "total", "25");
-                }
-            });
-        } else {
-            redisTemplate.opsForHash().put(redisKey, "total", "25");
-        }
+    private void setupAntiMacroScore(Long userId) {
+        String redisKey = "score:" + userId;
+        // Redis는 트랜잭션 관리가 필요 없으므로 즉시 실행
+        redisTemplate.opsForHash().put(redisKey, "total", "25");
+    }
 
-        // 포트원 빌링키 발급
+    /**
+     * 외부 API 호출 후 결과를 DB에 저장 (REQUIRES_NEW로 별도 트랜잭션 처리)
+     */
+    @Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+    public void registerBillingKeyForSuperUser(User user) {
         try {
             PortOneBillingResponse response = portOneBillingClient.issueBillingKey(
                     "PortOne " + portOneSecret,
@@ -253,8 +272,13 @@ public class TestAccountGenerator {
                             )
                     )
             );
+            
             String billingKeyId = response.billingKeyInfo().billingKey();
-            String cardName = response.billingKeyInfo().channels().get(0).name();
+            // 방어 로직: channels 리스트가 비어있을 경우 기본값 사용
+            String cardName = "KCP 테스트 카드";
+            if (response.billingKeyInfo().channels() != null && !response.billingKeyInfo().channels().isEmpty()) {
+                cardName = response.billingKeyInfo().channels().get(0).name();
+            }
 
             UserBillingKey userBillingKey = UserBillingKey.builder()
                     .user(user)
@@ -267,6 +291,7 @@ public class TestAccountGenerator {
             billingKeyRepository.save(userBillingKey);
         } catch (Exception e) {
             log.warn("[SuperAccount] 빌링키 발급 실패 (유저 ID: {}): {}", user.getId(), e.getMessage());
+            // 시연용 계정이므로 빌링키 발급에 실패해도 로그만 남기고 유저는 유지
         }
     }
 

--- a/user-service/src/main/java/com/t1/popcon/user/service/TestAccountGenerator.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/TestAccountGenerator.java
@@ -8,6 +8,7 @@ import com.t1.popcon.user.billing.client.PortOneBillingClient.PortOneBillingRequ
 import com.t1.popcon.user.billing.client.PortOneBillingClient.PortOneBillingResponse;
 import com.t1.popcon.user.billing.entity.UserBillingKey;
 import com.t1.popcon.user.billing.repository.UserBillingKeyRepository;
+import com.t1.popcon.user.domain.Role;
 import com.t1.popcon.user.domain.User;
 import com.t1.popcon.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Service
 @RequiredArgsConstructor
 public class TestAccountGenerator {
+
+    public static final String SUPER_USER_TOTAL_COUNT_KEY = "super_user_total_count";
 
     private final UserRepository userRepository;
     private final UserBillingKeyRepository billingKeyRepository;
@@ -146,6 +149,125 @@ public class TestAccountGenerator {
 
         log.info("[TestAccount] 대량 계정 생성 완료. 파일 위치: {}", fileName);
         return fileName;
+    }
+
+    public void generateSuperAccounts(int count) throws InterruptedException {
+        int startOffset = getSuperStartOffset();
+        log.info("[SuperAccount] 슈퍼 계정 생성 시작: 기존 {}개, 추가 {}개 예정", startOffset, count);
+
+        ExecutorService executor = Executors.newFixedThreadPool(20);
+        AtomicInteger progress = new AtomicInteger(0);
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (int i = 1; i <= count; i++) {
+            final int index = startOffset + i;
+            futures.add(CompletableFuture.runAsync(() -> {
+                try {
+                    self.createSingleSuperAccount(index);
+                } catch (Exception e) {
+                    log.error("[SuperAccount] 슈퍼 계정 생성 실패 - index={}: {}", index, e.getMessage());
+                }
+            }, executor).thenRun(() -> {
+                int current = progress.incrementAndGet();
+                if (current % 10 == 0) log.info("[SuperAccount] 진행 상황: {}/{}", current, count);
+            }));
+
+            if (futures.size() >= 20 || i == count) {
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+                futures.clear();
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.MINUTES);
+
+        // 생성 완료 후 전체 슈퍼 계정 수 Redis 업데이트
+        long totalCount = userRepository.countByRole(Role.SUPER);
+        redisTemplate.opsForValue().set(SUPER_USER_TOTAL_COUNT_KEY, String.valueOf(totalCount));
+        log.info("[SuperAccount] 슈퍼 계정 생성 완료. 현재 총 {}개 (Redis 업데이트 완료)", totalCount);
+    }
+
+    private int getSuperStartOffset() {
+        return userRepository.findFirstByNicknameStartingWithOrderByIdDesc("Super_")
+                .map(user -> {
+                    try {
+                        String nickname = user.getNickname();
+                        return Integer.parseInt(nickname.substring(6)); // "Super_" 이후 숫자 추출
+                    } catch (Exception e) {
+                        return 0;
+                    }
+                })
+                .orElse(0);
+    }
+
+    @Transactional
+    public void createSingleSuperAccount(int index) {
+        String nickname = "Super_" + index;
+        if (userRepository.existsByNickname(nickname)) {
+            return;
+        }
+
+        String rawName = "슈퍼테스터_" + index;
+        String rawPhone = String.format("010-9999-%04d", index % 10000);
+        String ci = "super_ci_" + index;
+
+        User user = User.createSuperUser(
+                encryptionService.generateHash(ci),
+                encryptionService.encrypt(rawName),
+                encryptionService.encrypt(rawPhone),
+                encryptionService.generateHash(rawPhone),
+                encryptionService.encrypt("1990-01-01"),
+                encryptionService.encrypt("M"),
+                encryptionService.encrypt("KOREA"),
+                nickname,
+                "super" + index + "@popcon.store"
+        );
+        userRepository.save(user);
+
+        // 안티매크로 점수 25점 설정 (VQA 유도)
+        String redisKey = "score:" + user.getId();
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    redisTemplate.opsForHash().put(redisKey, "total", "25");
+                }
+            });
+        } else {
+            redisTemplate.opsForHash().put(redisKey, "total", "25");
+        }
+
+        // 포트원 빌링키 발급
+        try {
+            PortOneBillingResponse response = portOneBillingClient.issueBillingKey(
+                    "PortOne " + portOneSecret,
+                    new PortOneBillingRequest(
+                            channelKey,
+                            new PortOneBillingRequest.Customer(String.valueOf(user.getId())),
+                            new PortOneBillingRequest.Method(
+                                    new PortOneBillingRequest.Method.Card(
+                                            new PortOneBillingRequest.Method.Card.Credential(
+                                                    testCardNumber, testCardExpiryYear, testCardExpiryMonth, testCardBirth, testCardPassword
+                                            )
+                                    )
+                            )
+                    )
+            );
+            String billingKeyId = response.billingKeyInfo().billingKey();
+            String cardName = response.billingKeyInfo().channels().get(0).name();
+
+            UserBillingKey userBillingKey = UserBillingKey.builder()
+                    .user(user)
+                    .customerUid(billingKeyId)
+                    .pgProvider("KCP_V2")
+                    .cardName(cardName)
+                    .cardNumber(testCardNumber)
+                    .isDefault(true)
+                    .build();
+            billingKeyRepository.save(userBillingKey);
+        } catch (Exception e) {
+            log.warn("[SuperAccount] 빌링키 발급 실패 (유저 ID: {}): {}", user.getId(), e.getMessage());
+        }
     }
 
     private int getStartOffset() {

--- a/user-service/src/main/java/com/t1/popcon/user/service/TestAccountGenerator.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/TestAccountGenerator.java
@@ -191,6 +191,7 @@ public class TestAccountGenerator {
         
         if (!errors.isEmpty()) {
             log.warn("[SuperAccount] 생성 중 발생한 오류 목록: {}", String.join(" | ", errors));
+            throw new IllegalStateException(String.format("슈퍼 계정 생성 부분 실패: %d건 실패 / %d건 시도", errors.size(), count));
         }
     }
 

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -27,7 +27,11 @@ import java.util.regex.Pattern;
 
 import com.t1.popcon.user.dto.UserCreateRequest;
 import com.t1.popcon.user.dto.UserCreateResponse;
+import com.t1.popcon.user.dto.SuperLoginResponse;
+import com.t1.popcon.common.auth.provider.TokenProvider;
+import com.t1.popcon.common.auth.domain.TokenType;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 
 import lombok.RequiredArgsConstructor;
 
@@ -39,6 +43,10 @@ public class UserService {
     private static final String NICKNAME_CONSTRAINT = "uk_users_nickname";
     private static final String PHONE_HASH_CONSTRAINT = "uk_users_phone_hash";
 
+    private static final String SUPER_USER_TOTAL_COUNT_KEY = "super_user_total_count";
+    private static final String SUPER_USER_CURRENT_INDEX_KEY = "super_user_current_index";
+    private static final long ONE_YEAR_MS = 365L * 24 * 60 * 60 * 1000;
+
     /** 닉네임 유효성 패턴: 한글·영문·숫자 2~20자, 언더바(_) 최대 1개 허용, 공백·기타 특수문자 불가 */
     private static final Pattern NICKNAME_PATTERN =
             Pattern.compile("^(?!.*_.*_)[가-힣a-zA-Z0-9_]{2,20}$");
@@ -47,9 +55,53 @@ public class UserService {
     private final EncryptionService encryptionService;
     private final BillingKeyService billingKeyService;
     private final S3Service s3Service;
+    private final TokenProvider tokenProvider;
+    private final StringRedisTemplate redisTemplate;
 
     @Value("${user.nickname.prefix:User}")
     private String nicknamePrefix;
+
+    /**
+     * 시연용 슈퍼 계정 순차 로그인
+     */
+    @Transactional
+    public SuperLoginResponse loginSuperAccount() {
+        // 1. 전체 슈퍼 계정 수 확인
+        String totalCountStr = redisTemplate.opsForValue().get(SUPER_USER_TOTAL_COUNT_KEY);
+        if (totalCountStr == null || "0".equals(totalCountStr)) {
+            // Redis에 없으면 DB에서 다시 조회 및 갱신
+            long dbCount = userRepository.countByRole(com.t1.popcon.user.domain.Role.SUPER);
+            if (dbCount == 0) {
+                throw new CustomException(ErrorCode.USER_NOT_FOUND, "생성된 슈퍼 계정이 없습니다.");
+            }
+            totalCountStr = String.valueOf(dbCount);
+            redisTemplate.opsForValue().set(SUPER_USER_TOTAL_COUNT_KEY, totalCountStr);
+        }
+
+        long totalCount = Long.parseLong(totalCountStr);
+
+        // 2. Redis INCR를 사용하여 다음 인덱스 결정 (순환)
+        Long currentIndex = redisTemplate.opsForValue().increment(SUPER_USER_CURRENT_INDEX_KEY);
+        if (currentIndex == null) currentIndex = 1L;
+
+        long targetIndex = (currentIndex % totalCount);
+        if (targetIndex == 0) targetIndex = totalCount;
+
+        // 3. Super_{index} 닉네임 유저 조회
+        String nickname = "Super_" + targetIndex;
+        User user = userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, nickname + " 계정을 찾을 수 없습니다."));
+
+        // 4. 긴 유효기간 액세스 토큰 생성 (리프레시는 생략)
+        String userIdStr = String.valueOf(user.getId());
+        String accessToken = tokenProvider.createToken(userIdStr, ONE_YEAR_MS, TokenType.ACCESS);
+
+        return new SuperLoginResponse(
+                user.getId(),
+                accessToken,
+                ONE_YEAR_MS / 1000
+        );
+    }
 
     /**
      * 사용자 프로필 조회 (GET /users/me)

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserService.java
@@ -34,7 +34,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -68,17 +70,18 @@ public class UserService {
     public SuperLoginResponse loginSuperAccount() {
         // 1. 전체 슈퍼 계정 수 확인
         String totalCountStr = redisTemplate.opsForValue().get(SUPER_USER_TOTAL_COUNT_KEY);
-        if (totalCountStr == null || "0".equals(totalCountStr)) {
-            // Redis에 없으면 DB에서 다시 조회 및 갱신
-            long dbCount = userRepository.countByRole(com.t1.popcon.user.domain.Role.SUPER);
-            if (dbCount == 0) {
-                throw new CustomException(ErrorCode.USER_NOT_FOUND, "생성된 슈퍼 계정이 없습니다.");
+        long totalCount;
+        
+        try {
+            if (totalCountStr == null || "0".equals(totalCountStr)) {
+                totalCount = refreshSuperUserTotalCount();
+            } else {
+                totalCount = Long.parseLong(totalCountStr);
             }
-            totalCountStr = String.valueOf(dbCount);
-            redisTemplate.opsForValue().set(SUPER_USER_TOTAL_COUNT_KEY, totalCountStr);
+        } catch (NumberFormatException e) {
+            log.warn("[SuperLogin] Redis total_count 파싱 실패: {}, DB에서 재조회합니다.", totalCountStr);
+            totalCount = refreshSuperUserTotalCount();
         }
-
-        long totalCount = Long.parseLong(totalCountStr);
 
         // 2. Redis INCR를 사용하여 다음 인덱스 결정 (순환)
         Long currentIndex = redisTemplate.opsForValue().increment(SUPER_USER_CURRENT_INDEX_KEY);
@@ -87,10 +90,10 @@ public class UserService {
         long targetIndex = (currentIndex % totalCount);
         if (targetIndex == 0) targetIndex = totalCount;
 
-        // 3. Super_{index} 닉네임 유저 조회
+        // 3. Super_{index} 닉네임 유저 조회 (Role.SUPER 조건 추가로 보안 강화)
         String nickname = "Super_" + targetIndex;
-        User user = userRepository.findByNickname(nickname)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, nickname + " 계정을 찾을 수 없습니다."));
+        User user = userRepository.findByNicknameAndRole(nickname, com.t1.popcon.user.domain.Role.SUPER)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND, nickname + " 슈퍼 계정을 찾을 수 없습니다."));
 
         // 4. 긴 유효기간 액세스 토큰 생성 (리프레시는 생략)
         String userIdStr = String.valueOf(user.getId());
@@ -101,6 +104,15 @@ public class UserService {
                 accessToken,
                 ONE_YEAR_MS / 1000
         );
+    }
+
+    private long refreshSuperUserTotalCount() {
+        long dbCount = userRepository.countByRole(com.t1.popcon.user.domain.Role.SUPER);
+        if (dbCount == 0) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND, "생성된 슈퍼 계정이 없습니다.");
+        }
+        redisTemplate.opsForValue().set(SUPER_USER_TOTAL_COUNT_KEY, String.valueOf(dbCount));
+        return dbCount;
     }
 
     /**

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -23,6 +23,17 @@ spring:
         show_sql: true
     defer-datasource-initialization: true
 
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connectTimeout: 5000
+            readTimeout: 5000
+          portOneBillingClient:
+            connectTimeout: 3000
+            readTimeout: 10000
+
 portone:
   api:
     secret: ${PORTONE_API_SECRET}


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #273 

## 📝 작업 내용

> 최종발표 시연용 슈퍼계정 생성 기능을 구현했습니다
- Role.java 에 SUPER 추가
- 슈퍼계정 생성 api 추가
  - 소셜로그인 처리, 액세스 토큰 1년 유효, 리프레시 토큰 발급 x, 빌링키 미리 등록, 보안퀴즈 체험을 위해 매크로 점수 25점 고정
- 슈퍼계정 로그인 api 추가
  - 로그인 요청시 생성되어있는 슈퍼계정에 순차적으로 배정

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> 