### PR TITLE
fix: 활동 통계 드로우 당첨여부 부분 개선

### DIFF
--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
@@ -51,12 +51,12 @@ public interface DrawEntryRepository extends JpaRepository<DrawEntry, Long> {
     long countConfirmedByUserIdAndStatus(@Param("userId") Long userId, @Param("status") DrawEntryStatus status);
 
     @Query("SELECT COUNT(de) FROM DrawEntry de JOIN de.drawOption do JOIN do.draw d " +
-           "WHERE de.userId = :userId AND de.status = :status AND d.drawCloseAt > :now")
-    long countOngoingByUserId(@Param("userId") Long userId, @Param("status") DrawEntryStatus status, @Param("now") LocalDateTime now);
+           "WHERE de.userId = :userId AND (de.status = 'APPLIED' OR d.announcementAt > :now)")
+    long countOngoingByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
 
     @Query("SELECT COUNT(de) FROM DrawEntry de JOIN de.drawOption do JOIN do.draw d " +
-           "WHERE de.userId = :userId AND de.resultCheckedAt IS NULL AND d.drawCloseAt <= :now")
-    long countWaitingResultByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+           "WHERE de.userId = :userId AND de.status IN :statuses AND de.resultCheckedAt IS NULL AND d.announcementAt <= :now")
+    long countWaitingResultByUserId(@Param("userId") Long userId, @Param("statuses") List<DrawEntryStatus> statuses, @Param("now") LocalDateTime now);
   
     // 테스트 초기화용: drawId 기준 응모 내역 하드 딜리트 (소프트 딜리트된 옵션의 응모도 포함)
     @Modifying

--- a/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/repository/DrawEntryRepository.java
@@ -47,15 +47,16 @@ public interface DrawEntryRepository extends JpaRepository<DrawEntry, Long> {
 
     long countByUserId(Long userId);
 
-    long countByUserIdAndStatus(Long userId, DrawEntryStatus status);
+    @Query("SELECT COUNT(de) FROM DrawEntry de WHERE de.userId = :userId AND de.status = :status AND de.resultCheckedAt IS NOT NULL")
+    long countConfirmedByUserIdAndStatus(@Param("userId") Long userId, @Param("status") DrawEntryStatus status);
 
     @Query("SELECT COUNT(de) FROM DrawEntry de JOIN de.drawOption do JOIN do.draw d " +
            "WHERE de.userId = :userId AND de.status = :status AND d.drawCloseAt > :now")
     long countOngoingByUserId(@Param("userId") Long userId, @Param("status") DrawEntryStatus status, @Param("now") LocalDateTime now);
 
     @Query("SELECT COUNT(de) FROM DrawEntry de JOIN de.drawOption do JOIN do.draw d " +
-           "WHERE de.userId = :userId AND de.status = :status AND d.drawCloseAt <= :now")
-    long countWaitingByUserId(@Param("userId") Long userId, @Param("status") DrawEntryStatus status, @Param("now") LocalDateTime now);
+           "WHERE de.userId = :userId AND de.resultCheckedAt IS NULL AND d.drawCloseAt <= :now")
+    long countWaitingResultByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
   
     // 테스트 초기화용: drawId 기준 응모 내역 하드 딜리트 (소프트 딜리트된 옵션의 응모도 포함)
     @Modifying

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -368,8 +368,8 @@ public class DrawEntryService {
             drawEntryRepository.countByUserId(userId),
             drawEntryRepository.countConfirmedByUserIdAndStatus(userId, DrawEntryStatus.WINNER),
             drawEntryRepository.countConfirmedByUserIdAndStatus(userId, DrawEntryStatus.FAILED),
-            drawEntryRepository.countOngoingByUserId(userId, DrawEntryStatus.APPLIED, now),
-            drawEntryRepository.countWaitingResultByUserId(userId, now)
+            drawEntryRepository.countOngoingByUserId(userId, now),
+            drawEntryRepository.countWaitingResultByUserId(userId, List.of(DrawEntryStatus.WINNER, DrawEntryStatus.FAILED), now)
         );
     }
 }

--- a/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
+++ b/draw-service/src/main/java/com/t1/popcon/draw/service/DrawEntryService.java
@@ -366,10 +366,10 @@ public class DrawEntryService {
         LocalDateTime now = LocalDateTime.now(clock);
         return new DrawStatisticsResponse(
             drawEntryRepository.countByUserId(userId),
-            drawEntryRepository.countByUserIdAndStatus(userId, DrawEntryStatus.WINNER),
-            drawEntryRepository.countByUserIdAndStatus(userId, DrawEntryStatus.FAILED),
+            drawEntryRepository.countConfirmedByUserIdAndStatus(userId, DrawEntryStatus.WINNER),
+            drawEntryRepository.countConfirmedByUserIdAndStatus(userId, DrawEntryStatus.FAILED),
             drawEntryRepository.countOngoingByUserId(userId, DrawEntryStatus.APPLIED, now),
-            drawEntryRepository.countWaitingByUserId(userId, DrawEntryStatus.APPLIED, now)
+            drawEntryRepository.countWaitingResultByUserId(userId, now)
         );
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #277 

## 📝 작업 내용

> 마이페이지 활동 통계 조회 부분 드로우 당첨 결과 확인 여부에 따른 개선 작업 진행했습니다
- 드로우 당첨/미당첨 목록 조회시 결과 미확인 목록은 제외
- 당첨여부 미확인 드로우는 따로 카운트
- 결과 확인시 당첨/미당첨 카운트에 포함

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> 