### PR TITLE
feat: anti-macro raw 시그널 S3 업로드 정렬 및 로깅 강화

### DIFF
--- a/anti-macro-service/src/config/env.ts
+++ b/anti-macro-service/src/config/env.ts
@@ -19,7 +19,10 @@ export const env = {
   DB_USERNAME: requireEnv('DB_USERNAME'),
   DB_PASSWORD: requireEnv('DB_PASSWORD'),
 
-  // S3 raw 시그널 저장 (미설정 시 업로드 no-op)
-  AWS_REGION: process.env.AWS_REGION,
-  S3_RAW_SIGNAL_BUCKET: process.env.S3_RAW_SIGNAL_BUCKET,
+  // S3 raw 시그널 저장 (S3_BUCKET/S3_ACCESS_KEY/S3_SECRET_KEY 미설정 시 업로드 no-op)
+  S3_REGION: process.env.S3_REGION || 'ap-northeast-2',
+  S3_BUCKET: process.env.S3_BUCKET,
+  S3_ACCESS_KEY: process.env.S3_ACCESS_KEY,
+  S3_SECRET_KEY: process.env.S3_SECRET_KEY,
+  S3_ENDPOINT: process.env.S3_ENDPOINT,
 } as const;

--- a/anti-macro-service/src/routes/signals.ts
+++ b/anti-macro-service/src/routes/signals.ts
@@ -85,6 +85,8 @@ router.post('/signals', async (req: Request, res: Response) => {
         },
       }).then((dbId) => {
         if (dbId) uploadRawSignal({ dbId, payload, analysis: result });
+      }).catch((err) => {
+        console.error('[anti-macro] DB 저장→S3 업로드 체인 예외:', err?.message ?? err);
       });
     }
 

--- a/anti-macro-service/src/services/raw-signal-uploader.ts
+++ b/anti-macro-service/src/services/raw-signal-uploader.ts
@@ -6,14 +6,30 @@ import type { AnalysisResult, PageSignalPayload, RawData } from '../types';
 
 const gzipAsync = promisify(gzip);
 
-const enabled = Boolean(env.AWS_REGION && env.S3_RAW_SIGNAL_BUCKET);
+const enabled = Boolean(env.S3_BUCKET && env.S3_ACCESS_KEY && env.S3_SECRET_KEY);
 
 const s3 = enabled
-  ? new S3Client({ region: env.AWS_REGION })
+  ? new S3Client({
+      region: env.S3_REGION,
+      credentials: {
+        accessKeyId: env.S3_ACCESS_KEY!,
+        secretAccessKey: env.S3_SECRET_KEY!,
+      },
+      ...(env.S3_ENDPOINT && env.S3_ENDPOINT.trim().length > 0
+        ? { endpoint: env.S3_ENDPOINT, forcePathStyle: true }
+        : {}),
+    })
   : null;
 
-if (!enabled) {
-  console.warn('[s3-raw-signal] AWS_REGION 또는 S3_RAW_SIGNAL_BUCKET 미설정 — 업로드 비활성화');
+if (enabled) {
+  console.log(
+    `[S3] 업로더 초기화 완료 - region=${env.S3_REGION} bucket=${env.S3_BUCKET}` +
+      (env.S3_ENDPOINT ? ` endpoint=${env.S3_ENDPOINT}` : ' endpoint=(AWS default)'),
+  );
+} else {
+  console.warn(
+    '[S3] 환경변수 미설정 (S3_BUCKET/S3_ACCESS_KEY/S3_SECRET_KEY) — raw 시그널 업로드 비활성화',
+  );
 }
 
 type UploadParams = {
@@ -39,18 +55,41 @@ function buildKey(dbId: number, now: Date): string {
 /**
  * Raw 시그널을 S3에 업로드 (fire-and-forget)
  * - PII 제거: userId/ip/userAgent/visitorId 전부 제외
- * - 주체 추적이 필요해지면 visitorId 해시 추가 (현재는 요청 단위 학습만 지원)
+ * - 절대 throw하지 않음 — 라우트/DB 흐름에 영향 없음
  */
 export function uploadRawSignal(params: UploadParams): void {
-  if (!enabled || !s3) return;
+  if (!enabled || !s3) {
+    console.log(`[S3] skip (비활성) - dbId=${params.dbId} page=${params.payload.page}`);
+    return;
+  }
 
-  putObject(params).catch((err) => {
-    console.error('[s3-raw-signal] 업로드 실패:', err?.message || err);
-  });
+  try {
+    putObject(params).catch((err) => {
+      console.error(
+        `[S3] 업로드 실패 - dbId=${params.dbId} page=${params.payload.page} ` +
+          `error=${err?.name ?? 'Error'} message=${err?.message ?? err}`,
+        err?.stack,
+      );
+    });
+  } catch (err: any) {
+    console.error(
+      `[S3] 업로드 진입 실패 - dbId=${params.dbId} page=${params.payload.page} ` +
+        `error=${err?.name ?? 'Error'} message=${err?.message ?? err}`,
+      err?.stack,
+    );
+  }
 }
 
 async function putObject({ dbId, payload, analysis }: UploadParams): Promise<void> {
+  const startedAt = Date.now();
   const now = new Date();
+  const key = buildKey(dbId, now);
+
+  console.log(
+    `[S3] 업로드 시작 - dbId=${dbId} page=${payload.page} key=${key} ` +
+      `clicks=${payload.rawData.clicks?.length ?? 0} movements=${payload.rawData.mouseMovements?.length ?? 0}`,
+  );
+
   const body = {
     dbId,
     page: payload.page,
@@ -60,15 +99,26 @@ async function putObject({ dbId, payload, analysis }: UploadParams): Promise<voi
     rawData: sanitizeRawData(payload.rawData),
   };
 
-  const compressed = await gzipAsync(Buffer.from(JSON.stringify(body), 'utf-8'));
+  const json = JSON.stringify(body);
+  const compressed = await gzipAsync(Buffer.from(json, 'utf-8'));
+  console.log(
+    `[S3] gzip 완료 - dbId=${dbId} key=${key} ` +
+      `rawBytes=${json.length} gzippedBytes=${compressed.length} ` +
+      `ratio=${(compressed.length / Math.max(json.length, 1)).toFixed(3)}`,
+  );
 
   await s3!.send(
     new PutObjectCommand({
-      Bucket: env.S3_RAW_SIGNAL_BUCKET!,
-      Key: buildKey(dbId, now),
+      Bucket: env.S3_BUCKET!,
+      Key: key,
       Body: compressed,
       ContentType: 'application/json',
       ContentEncoding: 'gzip',
     }),
+  );
+
+  console.log(
+    `[S3] 업로드 완료 - dbId=${dbId} page=${payload.page} key=${key} ` +
+      `bytes=${compressed.length} elapsedMs=${Date.now() - startedAt}`,
   );
 }


### PR DESCRIPTION
## Summary

- anti-macro-service의 S3 업로더를 user-service ([#262](https://github.com/kt-cloud-TECHUP-T1/pop-con-backend/pull/262)) S3 컨벤션과 정렬: `S3_BUCKET` / `S3_REGION` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` / `S3_ENDPOINT`, 명시적 static credentials, optional endpoint override
- 로컬 테스트 없이 바로 배포해서 로그로 검증할 수 있도록 단계별 `[S3]` 로그 추가 (초기화 / 시작 / gzip / 완료 / 실패, 모두 `dbId=` 로 묶임)
- `uploadRawSignal` try/catch + sync throw 차단, `routes/signals.ts` 체인 끝 `.catch` — S3 업로드 실패가 응답/DB 저장 흐름에 절대 영향 없음

PII 제거(visitorId/userAgent), gzip, 키 포맷(`signals/YYYY/MM/DD/HH/{dbId}.json.gz`), fire-and-forget 호출 패턴은 그대로 유지.

## 운영 체크리스트 (배포 전)

신규 버킷 `popcon-anti-macro-signals` 사용 예정.

- [ ] AWS 콘솔에서 `popcon-anti-macro-signals` 버킷 생성 (region `ap-northeast-2`)
- [ ] 기존 access key의 IAM 정책에 새 버킷 \`s3:PutObject\` 권한 추가
- [ ] (선택) lifecycle rule — 예: 30일 후 자동 만료
- [ ] GitOps 매니페스트의 anti-macro deployment에 env 주입:
  - \`S3_BUCKET=popcon-anti-macro-signals\`
  - \`S3_ACCESS_KEY=...\` (user-service와 동일 키 재사용 가능)
  - \`S3_SECRET_KEY=...\`
  - \`S3_REGION=ap-northeast-2\` (선택, 기본값)

세 필수 값(\`S3_BUCKET\`/\`S3_ACCESS_KEY\`/\`S3_SECRET_KEY\`)이 누락되면 부팅 시 \`[S3] 환경변수 미설정 ... 비활성화\` 로그가 떠서 즉시 인지 가능. 응답/DB 흐름은 영향 없음.

## Test plan

- [x] \`cd anti-macro-service && npx tsc --noEmit\` 통과
- [ ] 배포 후 부팅 로그 \`[S3] 업로더 초기화 완료 - region=ap-northeast-2 bucket=popcon-anti-macro-signals endpoint=(AWS default)\` 확인
- [ ] 첫 트래픽 후 4줄 로그 묶음 확인 (한 dbId 기준):
  - \`[db] 시그널 로그 저장: id=... page=... score=...\`
  - \`[S3] 업로드 시작 - dbId=... key=signals/YYYY/MM/DD/HH/...\`
  - \`[S3] gzip 완료 - dbId=... rawBytes=... gzippedBytes=... ratio=...\`
  - \`[S3] 업로드 완료 - dbId=... bytes=... elapsedMs=...\`
- [ ] \`aws s3 cp s3://popcon-anti-macro-signals/<key> /tmp/sig.json.gz && gunzip -c /tmp/sig.json.gz | jq .\` — 본문에 \`visitorId\`/\`userAgent\` 없음, \`dbId\`/\`page\`/\`pageScore\`/\`detectedSignals\` 존재
- [ ] 운영 안전성: \`[S3] 업로드 실패\` 가 떠도 \`[anti-macro] user=... page=...\` 응답 로그 정상 흐름

🤖 Generated with [Claude Code](https://claude.com/claude-code)