### PR TITLE
feat: 경매 티켓 상세에 결제 정보 노출

### DIFF
--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/client/dto/BillingKeyInternalResponse.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/client/dto/BillingKeyInternalResponse.java
@@ -1,5 +1,8 @@
 package com.t1.popcon.auction.bid.client.dto;
 
 public record BillingKeyInternalResponse(
-    String customerUid
+    String customerUid,
+    String pgProvider,
+    String cardName,
+    String cardNumber
 ) {}

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/domain/Bid.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/domain/Bid.java
@@ -55,6 +55,18 @@ public class Bid extends BaseSoftDeleteEntity {
 
     private LocalDateTime paidAt;
 
+    @Column(name = "payment_method", length = 30)
+    private String paymentMethod;
+
+    @Column(name = "pg_provider", length = 50)
+    private String pgProvider;
+
+    @Column(name = "card_name", length = 100)
+    private String cardName;
+
+    @Column(name = "card_number", length = 30)
+    private String cardNumber;
+
     @Column(name = "reservation_no", length = 20, unique = true)
     private String reservationNo;
 
@@ -127,5 +139,9 @@ public class Bid extends BaseSoftDeleteEntity {
         }
         this.status = BidStatus.FAILED;
         this.paidAt = null;
+        this.paymentMethod = null;
+        this.pgProvider = null;
+        this.cardName = null;
+        this.cardNumber = null;
     }
 }

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/dto/response/ReservationDetailResponse.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/dto/response/ReservationDetailResponse.java
@@ -9,6 +9,9 @@ import java.time.LocalTime;
 public record ReservationDetailResponse(
     Long ticketId,
     String reservationNo,
+    String paymentMethod,
+    String cardName,
+    String cardNumber,
     String popupTitle,
     String popupAddress,
     String popupThumbnail,

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/repository/BidRepository.java
@@ -17,6 +17,7 @@ import org.springframework.data.repository.query.Param;
 public interface BidRepository extends JpaRepository<Bid, Long> {
 	@Modifying
 	@Query("UPDATE Bid b SET b.status = :toStatus, b.paidAt = :paidAt, b.pgTxId = :pgTxId, " +
+		"b.paymentMethod = :paymentMethod, b.pgProvider = :pgProvider, b.cardName = :cardName, b.cardNumber = :cardNumber, " +
 		"b.reservationNo = :reservationNo, " +
 		"b.popupTitle = :popupTitle, b.popupAddress = :popupAddress, b.thumbnailUrl = :thumbnailUrl, " +
 		"b.entryDate = :entryDate, b.entryTime = :entryTime, b.startPrice = :startPrice " +
@@ -26,6 +27,10 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 		@Param("toStatus") BidStatus toStatus,
 		@Param("paidAt") LocalDateTime paidAt,
 		@Param("pgTxId") String pgTxId,
+		@Param("paymentMethod") String paymentMethod,
+		@Param("pgProvider") String pgProvider,
+		@Param("cardName") String cardName,
+		@Param("cardNumber") String cardNumber,
 		@Param("reservationNo") String reservationNo,
 		@Param("popupTitle") String popupTitle,
 		@Param("popupAddress") String popupAddress,

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -161,7 +161,7 @@ public class BidService {
                 .reservationNo(bid.getReservationNo())
                 .paymentMethod(bid.getPaymentMethod())
                 .cardName(bid.getCardName())
-                .cardNumber(bid.getCardNumber())
+                .cardNumber(maskCardNumber(bid.getCardNumber()))
                 .popupTitle(bid.getPopupTitle())
                 .popupAddress(bid.getPopupAddress())
                 .popupThumbnail(bid.getThumbnailUrl())
@@ -172,6 +172,89 @@ public class BidService {
                 .finalPrice(bidPrice)
                 .paidAt(bid.getPaidAt())
                 .build();
+    }
+
+    private String maskCardNumber(String cardNumber) {
+        if (cardNumber == null || cardNumber.isBlank()) {
+            return cardNumber;
+        }
+
+        String trimmedCardNumber = cardNumber.trim();
+        if (isSafelyMaskedCardNumber(trimmedCardNumber)) {
+            return trimmedCardNumber;
+        }
+
+        String digitsOnly = extractDigits(trimmedCardNumber);
+        if (digitsOnly.isEmpty()) {
+            return trimmedCardNumber;
+        }
+        if (digitsOnly.length() <= 4) {
+            return digitsOnly;
+        }
+
+        String lastFourDigits = digitsOnly.substring(digitsOnly.length() - 4);
+        int estimatedCardLength = Math.max(digitsOnly.length(), digitsOnly.length() + countMaskCharacters(trimmedCardNumber));
+        return formatMaskedCardNumber(lastFourDigits, estimatedCardLength - 4);
+    }
+
+    private boolean isSafelyMaskedCardNumber(String cardNumber) {
+        return cardNumber.indexOf('*') >= 0 && countDigits(cardNumber) <= 4;
+    }
+
+    private String extractDigits(String value) {
+        StringBuilder digits = new StringBuilder();
+        for (char current : value.toCharArray()) {
+            if (Character.isDigit(current)) {
+                digits.append(current);
+            }
+        }
+        return digits.toString();
+    }
+
+    private int countDigits(String value) {
+        int digitCount = 0;
+        for (char current : value.toCharArray()) {
+            if (Character.isDigit(current)) {
+                digitCount++;
+            }
+        }
+        return digitCount;
+    }
+
+    private int countMaskCharacters(String value) {
+        int maskCharacterCount = 0;
+        for (char current : value.toCharArray()) {
+            if (current == '*') {
+                maskCharacterCount++;
+            }
+        }
+        return maskCharacterCount;
+    }
+
+    private String formatMaskedCardNumber(String lastFourDigits, int maskedDigitCount) {
+        StringBuilder maskedCardNumber = new StringBuilder();
+        int remainingMaskedDigits = maskedDigitCount;
+
+        while (remainingMaskedDigits > 4) {
+            if (!maskedCardNumber.isEmpty()) {
+                maskedCardNumber.append('-');
+            }
+            maskedCardNumber.append("****");
+            remainingMaskedDigits -= 4;
+        }
+
+        if (remainingMaskedDigits > 0) {
+            if (!maskedCardNumber.isEmpty()) {
+                maskedCardNumber.append('-');
+            }
+            maskedCardNumber.append("*".repeat(remainingMaskedDigits));
+        }
+
+        if (!maskedCardNumber.isEmpty()) {
+            maskedCardNumber.append('-');
+        }
+        maskedCardNumber.append(lastFourDigits);
+        return maskedCardNumber.toString();
     }
 
     private record PriceDetails(

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidService.java
@@ -159,6 +159,9 @@ public class BidService {
         return ReservationDetailResponse.builder()
                 .ticketId(ticketId)
                 .reservationNo(bid.getReservationNo())
+                .paymentMethod(bid.getPaymentMethod())
+                .cardName(bid.getCardName())
+                .cardNumber(bid.getCardNumber())
                 .popupTitle(bid.getPopupTitle())
                 .popupAddress(bid.getPopupAddress())
                 .popupThumbnail(bid.getThumbnailUrl())
@@ -270,7 +273,8 @@ public class BidService {
                             });
                     throw new CustomException(ErrorCode.BILLING_KEY_NOT_FOUND);
                 }
-                String billingKey = billingKeyResponse.getData().customerUid();
+                BillingKeyInternalResponse billingKeyDetail = billingKeyResponse.getData();
+                String billingKey = billingKeyDetail.customerUid();
 
                 paymentAttempted = true;
                 Timer paymentTimer = Timer.builder("popcon_payment_latency")
@@ -340,6 +344,10 @@ public class BidService {
                             option.getId(),
                             pgTxId,
                             paidAt,
+                            "CARD",
+                            billingKeyDetail.pgProvider(),
+                            billingKeyDetail.cardName(),
+                            billingKeyDetail.cardNumber(),
                             currentReservationNo,
                             popupTitle,
                             popupAddress,

--- a/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidTransactionManager.java
+++ b/auction-service/src/main/java/com/t1/popcon/auction/bid/service/BidTransactionManager.java
@@ -39,12 +39,14 @@ public class BidTransactionManager {
 	// [Step 3-1] 결제 성공 시: SUCCESS 처리 및 스냅샷 기록, DB 재고 차감
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public String completeBidSuccess(Long bidId, Long optionId, String pgTxId, LocalDateTime paidAt,
+								   String paymentMethod, String pgProvider, String cardName, String cardNumber,
 								   String reservationNo, String popupTitle, String popupAddress, String thumbnailUrl,
 								   LocalDate entryDate, LocalTime entryTime, Integer startPrice) {
 
 		// 1. 상태 전이 시도 (PENDING -> SUCCESS) 및 스냅샷/예약번호 업데이트
 		int updatedRows = bidRepository.updateStatusWithCAS(
 			bidId, BidStatus.PENDING, BidStatus.SUCCESS, paidAt, pgTxId,
+			paymentMethod, pgProvider, cardName, cardNumber,
 			reservationNo, popupTitle, popupAddress, thumbnailUrl, entryDate, entryTime, startPrice
 		);
 

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -106,6 +106,21 @@ public class BidServiceTest {
 	}
 
 	@Test
+	@DisplayName("카드번호 마스킹 - raw, masked, null, short value를 안전하게 처리한다")
+	void maskCardNumber_SafelyFormatsCardNumber() {
+		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", "1234567812345678"))
+			.isEqualTo("****-****-****-5678");
+		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", "1234-****-****-5678"))
+			.isEqualTo("****-****-****-5678");
+		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", "****-****-****-5678"))
+			.isEqualTo("****-****-****-5678");
+		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", "5678"))
+			.isEqualTo("5678");
+		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", null))
+			.isNull();
+	}
+
+	@Test
 	@DisplayName("낙찰 시도 성공 - 모든 과정 정상")
 	void attemptBid_Success() {
 		// given

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -108,16 +108,20 @@ public class BidServiceTest {
 	@Test
 	@DisplayName("카드번호 마스킹 - raw, masked, null, short value를 안전하게 처리한다")
 	void maskCardNumber_SafelyFormatsCardNumber() {
-		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", "1234567812345678"))
+		assertThat(invokeMaskCardNumber("1234567812345678"))
 			.isEqualTo("****-****-****-5678");
-		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", "1234-****-****-5678"))
+		assertThat(invokeMaskCardNumber("1234-****-****-5678"))
 			.isEqualTo("****-****-****-5678");
-		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", "****-****-****-5678"))
+		assertThat(invokeMaskCardNumber("****-****-****-5678"))
 			.isEqualTo("****-****-****-5678");
-		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", "5678"))
+		assertThat(invokeMaskCardNumber("5678"))
 			.isEqualTo("5678");
-		assertThat(ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", null))
+		assertThat(invokeMaskCardNumber(null))
 			.isNull();
+	}
+
+	private String invokeMaskCardNumber(String cardNumber) {
+		return (String) ReflectionTestUtils.invokeMethod(bidService, "maskCardNumber", (Object) cardNumber);
 	}
 
 	@Test

--- a/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
+++ b/auction-service/src/test/java/com/t1/popcon/auction/bid/service/BidServiceTest.java
@@ -128,7 +128,12 @@ public class BidServiceTest {
 		ReflectionTestUtils.setField(bid, "id", 1L);
 		when(txManager.preparePendingBid(anyLong(), any(), anyInt(), anyString())).thenReturn(bid);
 
-		BillingKeyInternalResponse billingKey = new BillingKeyInternalResponse("billing_key_abc");
+		BillingKeyInternalResponse billingKey = new BillingKeyInternalResponse(
+			"billing_key_abc",
+			"KCP_V2",
+			"KB국민카드",
+			"1234-****-****-5678"
+		);
 		when(userBillingClient.getDefaultBillingKey(userId)).thenReturn(ApiResponse.ok(billingKey));
 
 		PortOnePaymentResponse.Payment paymentDetail = new PortOnePaymentResponse.Payment("pg_tx_123", "2023-11-20T15:30:00Z");
@@ -142,7 +147,23 @@ public class BidServiceTest {
 		when(option.getEntryTime()).thenReturn(LocalTime.now());
 		when(auction.getStartPrice()).thenReturn(10000);
 		when(reservationNoGenerator.generate()).thenReturn("TKT123456789012");
-		when(txManager.completeBidSuccess(anyLong(), anyLong(), anyString(), any(), anyString(), anyString(), anyString(), anyString(), any(), any(), anyInt()))
+		when(txManager.completeBidSuccess(
+			anyLong(),
+			anyLong(),
+			anyString(),
+			any(),
+			anyString(),
+			anyString(),
+			anyString(),
+			anyString(),
+			anyString(),
+			anyString(),
+			anyString(),
+			anyString(),
+			any(),
+			any(),
+			anyInt()
+		))
 			.thenReturn("TKT123456789012");
 		when(ticketServiceClient.issueTicket(any())).thenReturn(
 			ApiResponse.ok(new TicketIssueResponse(1L, "TKT00000001", "TKT123456789012", "ISSUED", "AUCTION", 1L))
@@ -155,6 +176,7 @@ public class BidServiceTest {
 		assertThat(response.status()).isEqualTo(BidStatus.SUCCESS);
 		verify(txManager).completeBidSuccess(
 			eq(bid.getId()), eq(optionId), eq("pg_tx_123"), any(LocalDateTime.class),
+			eq("CARD"), eq("KCP_V2"), eq("KB국민카드"), eq("1234-****-****-5678"),
 			eq("TKT123456789012"), eq("Pop-up Title"), eq("Location"), eq("v_thumbnail.url"),
 			any(LocalDate.class), any(LocalTime.class), eq(10000)
 		);
@@ -201,7 +223,12 @@ public class BidServiceTest {
 		ReflectionTestUtils.setField(bid, "id", 1L);
 		when(txManager.preparePendingBid(anyLong(), any(), anyInt(), anyString())).thenReturn(bid);
 
-		BillingKeyInternalResponse billingKey = new BillingKeyInternalResponse("billing_key_abc");
+		BillingKeyInternalResponse billingKey = new BillingKeyInternalResponse(
+			"billing_key_abc",
+			"KCP_V2",
+			"KB국민카드",
+			"1234-****-****-5678"
+		);
 		when(userBillingClient.getDefaultBillingKey(userId)).thenReturn(ApiResponse.ok(billingKey));
 
 		when(portOneClient.executePayment(anyString(), anyString(), anyInt(), anyString()))

--- a/user-service/src/main/java/com/t1/popcon/user/billing/controller/InternalBillingKeyController.java
+++ b/user-service/src/main/java/com/t1/popcon/user/billing/controller/InternalBillingKeyController.java
@@ -20,7 +20,7 @@ public class InternalBillingKeyController {
     public ApiResponse<BillingKeyInternalResponse> getDefaultBillingKey(
         @RequestParam("userId") Long userId
     ) {
-        String billingKey = billingKeyService.getDefaultBillingKey(userId);
-        return ApiResponse.ok(new BillingKeyInternalResponse(billingKey));
+        BillingKeyInternalResponse billingKey = billingKeyService.getDefaultBillingKeySnapshot(userId);
+        return ApiResponse.ok(billingKey);
     }
 }

--- a/user-service/src/main/java/com/t1/popcon/user/billing/dto/BillingKeyInternalResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/billing/dto/BillingKeyInternalResponse.java
@@ -1,5 +1,19 @@
 package com.t1.popcon.user.billing.dto;
 
+import com.t1.popcon.user.billing.entity.UserBillingKey;
+
 public record BillingKeyInternalResponse(
-    String customerUid
-) {}
+    String customerUid,
+    String pgProvider,
+    String cardName,
+    String cardNumber
+) {
+    public static BillingKeyInternalResponse from(UserBillingKey entity) {
+        return new BillingKeyInternalResponse(
+            entity.getCustomerUid(),
+            entity.getPgProvider(),
+            entity.getCardName(),
+            entity.getCardNumber()
+        );
+    }
+}

--- a/user-service/src/main/java/com/t1/popcon/user/billing/service/BillingKeyService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/billing/service/BillingKeyService.java
@@ -3,6 +3,7 @@ package com.t1.popcon.user.billing.service;
 import com.t1.popcon.common.exception.CustomException;
 import com.t1.popcon.common.exception.ErrorCode;
 import com.t1.popcon.user.billing.dto.BillingKeyInfoResponse;
+import com.t1.popcon.user.billing.dto.BillingKeyInternalResponse;
 import com.t1.popcon.user.billing.dto.BillingKeyRegisterRequest;
 import com.t1.popcon.common.infrastructure.dto.PortOneBillingKeyResponse;
 import com.t1.popcon.user.billing.entity.UserBillingKey;
@@ -142,6 +143,16 @@ public class BillingKeyService {
 
 		return billingKeyRepository.findByUserAndIsDefaultTrueAndIsActiveTrue(user)
 			.map(UserBillingKey::getCustomerUid)
+			.orElseThrow(() -> new CustomException(ErrorCode.BILLING_KEY_NOT_FOUND));
+	}
+
+	@Transactional(readOnly = true)
+	public BillingKeyInternalResponse getDefaultBillingKeySnapshot(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		return billingKeyRepository.findByUserAndIsDefaultTrueAndIsActiveTrue(user)
+			.map(BillingKeyInternalResponse::from)
 			.orElseThrow(() -> new CustomException(ErrorCode.BILLING_KEY_NOT_FOUND));
 	}
 

--- a/user-service/src/main/java/com/t1/popcon/user/dto/history/AuctionReservationDetailResponse.java
+++ b/user-service/src/main/java/com/t1/popcon/user/dto/history/AuctionReservationDetailResponse.java
@@ -11,6 +11,9 @@ import lombok.NoArgsConstructor;
 public class AuctionReservationDetailResponse {
 
     private String reservationNo;
+    private String paymentMethod;
+    private String cardName;
+    private String cardNumber;
     private String popupTitle;
     private String popupAddress;
     private String popupThumbnail;

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -214,9 +214,9 @@ public class UserHistoryService {
                 .entryTime(ticket.getEntryTime())
                 .issuedAt(ticket.getIssuedAt())
                 .qrValue(resolveQrValue(ticket))
-                .userName(purchaser.userName())
-                .userPhoneNumber(purchaser.userPhoneNumber())
-                .userEmail(purchaser.userEmail());
+                .userName(maskUserNameForDisplay(purchaser.userName()))
+                .userPhoneNumber(maskPhoneNumberForDisplay(purchaser.userPhoneNumber()))
+                .userEmail(maskEmailForDisplay(purchaser.userEmail()));
 
             applySourceSpecificDetail(detailBuilder, userId, ticket);
             applyPopupFallback(detailBuilder, ticket.getPopupId());
@@ -353,8 +353,8 @@ public class UserHistoryService {
                 .popupAddress(firstNonBlank(detail.getPopupAddress(), currentDetail.getPopupAddress()))
                 .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), currentDetail.getThumbnailUrl()))
                 .paidAt(detail.getPaidAt())
-                .userName(firstNonBlank(detail.getUserName(), currentDetail.getUserName()))
-                .userPhoneNumber(firstNonBlank(detail.getUserPhoneNumber(), currentDetail.getUserPhoneNumber()));
+                .userName(maskUserNameForDisplay(firstNonBlank(detail.getUserName(), currentDetail.getUserName())))
+                .userPhoneNumber(maskPhoneNumberForDisplay(firstNonBlank(detail.getUserPhoneNumber(), currentDetail.getUserPhoneNumber())));
         }
     }
 
@@ -535,6 +535,77 @@ public class UserHistoryService {
         }
         maskedCardNumber.append(lastFourDigits);
         return maskedCardNumber.toString();
+    }
+
+    private String maskUserNameForDisplay(String userName) {
+        if (userName == null || userName.isBlank()) {
+            return userName;
+        }
+
+        String trimmedUserName = userName.trim();
+        if (trimmedUserName.indexOf('*') >= 0) {
+            return trimmedUserName;
+        }
+        if (trimmedUserName.length() == 1) {
+            return trimmedUserName;
+        }
+        if (trimmedUserName.length() == 2) {
+            return trimmedUserName.charAt(0) + "*";
+        }
+
+        return trimmedUserName.charAt(0)
+            + "*".repeat(trimmedUserName.length() - 2)
+            + trimmedUserName.charAt(trimmedUserName.length() - 1);
+    }
+
+    private String maskPhoneNumberForDisplay(String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.isBlank()) {
+            return phoneNumber;
+        }
+
+        String trimmedPhoneNumber = phoneNumber.trim();
+        if (trimmedPhoneNumber.indexOf('*') >= 0) {
+            return trimmedPhoneNumber;
+        }
+
+        String digitsOnly = extractDigits(trimmedPhoneNumber);
+        if (digitsOnly.length() != 11) {
+            return trimmedPhoneNumber;
+        }
+
+        return digitsOnly.substring(0, 3)
+            + "-"
+            + digitsOnly.substring(3, 5)
+            + "**-"
+            + digitsOnly.substring(7, 9)
+            + "**";
+    }
+
+    private String maskEmailForDisplay(String userEmail) {
+        if (userEmail == null || userEmail.isBlank()) {
+            return userEmail;
+        }
+
+        String trimmedEmail = userEmail.trim();
+        int atIndex = trimmedEmail.indexOf('@');
+        if (atIndex <= 0 || atIndex != trimmedEmail.lastIndexOf('@')) {
+            return trimmedEmail;
+        }
+
+        String localPart = trimmedEmail.substring(0, atIndex);
+        String domainPart = trimmedEmail.substring(atIndex);
+
+        if (localPart.indexOf('*') >= 0) {
+            return trimmedEmail;
+        }
+        if (localPart.length() == 1) {
+            return localPart + "*" + domainPart;
+        }
+        if (localPart.length() == 2) {
+            return localPart.charAt(0) + "*" + domainPart;
+        }
+
+        return localPart.substring(0, 2) + "*".repeat(localPart.length() - 2) + domainPart;
     }
 
     private boolean isBlank(String value) {

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -214,7 +214,7 @@ public class UserHistoryService {
                 .entryTime(ticket.getEntryTime())
                 .issuedAt(ticket.getIssuedAt())
                 .qrValue(resolveQrValue(ticket))
-                .userName(maskUserNameForDisplay(purchaser.userName()))
+                .userName(purchaser.userName())
                 .userPhoneNumber(maskPhoneNumberForDisplay(purchaser.userPhoneNumber()))
                 .userEmail(maskEmailForDisplay(purchaser.userEmail()));
 
@@ -353,7 +353,7 @@ public class UserHistoryService {
                 .popupAddress(firstNonBlank(detail.getPopupAddress(), currentDetail.getPopupAddress()))
                 .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), currentDetail.getThumbnailUrl()))
                 .paidAt(detail.getPaidAt())
-                .userName(maskUserNameForDisplay(firstNonBlank(detail.getUserName(), currentDetail.getUserName())))
+                .userName(firstNonBlank(detail.getUserName(), currentDetail.getUserName()))
                 .userPhoneNumber(maskPhoneNumberForDisplay(firstNonBlank(detail.getUserPhoneNumber(), currentDetail.getUserPhoneNumber())));
         }
     }
@@ -535,27 +535,6 @@ public class UserHistoryService {
         }
         maskedCardNumber.append(lastFourDigits);
         return maskedCardNumber.toString();
-    }
-
-    private String maskUserNameForDisplay(String userName) {
-        if (userName == null || userName.isBlank()) {
-            return userName;
-        }
-
-        String trimmedUserName = userName.trim();
-        if (trimmedUserName.indexOf('*') >= 0) {
-            return trimmedUserName;
-        }
-        if (trimmedUserName.length() == 1) {
-            return trimmedUserName;
-        }
-        if (trimmedUserName.length() == 2) {
-            return trimmedUserName.charAt(0) + "*";
-        }
-
-        return trimmedUserName.charAt(0)
-            + "*".repeat(trimmedUserName.length() - 2)
-            + trimmedUserName.charAt(trimmedUserName.length() - 1);
     }
 
     private String maskPhoneNumberForDisplay(String phoneNumber) {

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -324,6 +324,9 @@ public class UserHistoryService {
             AuctionReservationDetailResponse detail = requireData(response);
 
             detailBuilder
+                .paymentMethod(detail.getPaymentMethod())
+                .cardName(detail.getCardName())
+                .cardNumber(detail.getCardNumber())
                 .popupTitle(firstNonBlank(detail.getPopupTitle(), currentDetail.getPopupTitle()))
                 .popupAddress(firstNonBlank(detail.getPopupAddress(), currentDetail.getPopupAddress()))
                 .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), currentDetail.getThumbnailUrl()))

--- a/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
+++ b/user-service/src/main/java/com/t1/popcon/user/service/UserHistoryService.java
@@ -326,7 +326,7 @@ public class UserHistoryService {
             detailBuilder
                 .paymentMethod(detail.getPaymentMethod())
                 .cardName(detail.getCardName())
-                .cardNumber(detail.getCardNumber())
+                .cardNumber(maskCardNumberForDisplay(detail.getCardNumber()))
                 .popupTitle(firstNonBlank(detail.getPopupTitle(), currentDetail.getPopupTitle()))
                 .popupAddress(firstNonBlank(detail.getPopupAddress(), currentDetail.getPopupAddress()))
                 .thumbnailUrl(firstNonBlank(detail.getPopupThumbnail(), currentDetail.getThumbnailUrl()))
@@ -452,6 +452,89 @@ public class UserHistoryService {
             return primary;
         }
         return fallback;
+    }
+
+    private String maskCardNumberForDisplay(String cardNumber) {
+        if (cardNumber == null || cardNumber.isBlank()) {
+            return cardNumber;
+        }
+
+        String trimmedCardNumber = cardNumber.trim();
+        if (isSafelyMaskedCardNumber(trimmedCardNumber)) {
+            return trimmedCardNumber;
+        }
+
+        String digitsOnly = extractDigits(trimmedCardNumber);
+        if (digitsOnly.isEmpty()) {
+            return trimmedCardNumber;
+        }
+        if (digitsOnly.length() <= 4) {
+            return digitsOnly;
+        }
+
+        String lastFourDigits = digitsOnly.substring(digitsOnly.length() - 4);
+        int estimatedCardLength = Math.max(digitsOnly.length(), digitsOnly.length() + countMaskCharacters(trimmedCardNumber));
+        return formatMaskedCardNumber(lastFourDigits, estimatedCardLength - 4);
+    }
+
+    private boolean isSafelyMaskedCardNumber(String cardNumber) {
+        return cardNumber.indexOf('*') >= 0 && countDigits(cardNumber) <= 4;
+    }
+
+    private String extractDigits(String value) {
+        StringBuilder digits = new StringBuilder();
+        for (char current : value.toCharArray()) {
+            if (Character.isDigit(current)) {
+                digits.append(current);
+            }
+        }
+        return digits.toString();
+    }
+
+    private int countDigits(String value) {
+        int digitCount = 0;
+        for (char current : value.toCharArray()) {
+            if (Character.isDigit(current)) {
+                digitCount++;
+            }
+        }
+        return digitCount;
+    }
+
+    private int countMaskCharacters(String value) {
+        int maskCharacterCount = 0;
+        for (char current : value.toCharArray()) {
+            if (current == '*') {
+                maskCharacterCount++;
+            }
+        }
+        return maskCharacterCount;
+    }
+
+    private String formatMaskedCardNumber(String lastFourDigits, int maskedDigitCount) {
+        StringBuilder maskedCardNumber = new StringBuilder();
+        int remainingMaskedDigits = maskedDigitCount;
+
+        while (remainingMaskedDigits > 4) {
+            if (!maskedCardNumber.isEmpty()) {
+                maskedCardNumber.append('-');
+            }
+            maskedCardNumber.append("****");
+            remainingMaskedDigits -= 4;
+        }
+
+        if (remainingMaskedDigits > 0) {
+            if (!maskedCardNumber.isEmpty()) {
+                maskedCardNumber.append('-');
+            }
+            maskedCardNumber.append("*".repeat(remainingMaskedDigits));
+        }
+
+        if (!maskedCardNumber.isEmpty()) {
+            maskedCardNumber.append('-');
+        }
+        maskedCardNumber.append(lastFourDigits);
+        return maskedCardNumber.toString();
     }
 
     private boolean isBlank(String value) {


### PR DESCRIPTION
[## #️⃣ 관련 이슈

> Closes #281 

## 📝 작업 내용

> 경매(AUCTION) 티켓 상세 조회 시 결제수단, 카드 정보, 결제 일시, 결제 금액 정보가 노출되도록 auction-service와 user-service 응답 조합 로직을 확장했습니다.

- user-service 내부 billing key 응답에 `pgProvider`, `cardName`, `cardNumber` 필드를 추가했습니다.
- auction-service에서 결제 성공 시 `Bid`에 `paymentMethod`, `pgProvider`, `cardName`, `cardNumber` 스냅샷을 저장하도록 확장했습니다.
- auction-service 예약 상세 응답에 결제 정보 필드를 추가했습니다.
- user-service 티켓 상세 응답 조합 로직에서 auction-service 결제 정보를 매핑하도록 수정했습니다.
- 경매 티켓 상세에서 아래 정보가 함께 노출되도록 반영했습니다.
  - `paymentMethod`
  - `cardName`
  - `cardNumber`
  - `paidAt`
  - `originalPrice`
  - `discountAmount`
  - `finalPrice`
- DRAW 결제 정보 노출은 이번 범위에서 제외했습니다.

## ✅ 테스트 결과 (선택)

> 수동 더미 데이터 기반으로 경매 낙찰 이력과 티켓 데이터를 연결한 뒤, 티켓 상세 API 응답에서 결제 정보가 정상 노출되는 것을 확인했습니다.
>
> 확인 API:
> - `GET /history/tickets/{ticketId}`
>
> 확인 필드:
> - `paymentMethod = CARD`
> - `cardName = 테스트카드`
> - `cardNumber = 4045-****-****-0000`
> - `paidAt` 존재
> - `originalPrice`, `discountAmount`, `finalPrice` 정상 노출

## 📷 스크린샷 (선택)

>
<img width="1302" height="588" alt="티켓 내역 결제 내역 추가" src="https://github.com/user-attachments/assets/91ccd5bc-d6ca-4c9f-84e9-5d501258dd80" />
<img width="688" height="762" alt="예약 번호로 조회" src="https://github.com/user-attachments/assets/4a33a433-ea6a-47a9-a7ca-864078b25293" />


## 💬 리뷰 요구사항(선택)