### PR TITLE
feat: 의심 시그널 감지 시 디스코드 알람 전송

### DIFF
--- a/anti-macro-service/src/routes/signals.ts
+++ b/anti-macro-service/src/routes/signals.ts
@@ -4,6 +4,7 @@ import { analyzeRawData } from '../analysis/analyze';
 import { resolveIdentityKey, updatePageScore, getTotalScore, mergeScores } from '../services/score-aggregator';
 import { saveSignalLog } from '../services/suspicious-logger';
 import { uploadRawSignal } from '../services/raw-signal-uploader';
+import { notifyDiscord } from '../services/discord-notifier';
 
 const router = Router();
 
@@ -65,7 +66,10 @@ router.post('/signals', async (req: Request, res: Response) => {
       }
     );
 
-    // 4. 시그널 로그 DB 저장 → S3 raw 데이터 업로드 (fire-and-forget)
+    // 4. 시그널 로그 DB 저장 → S3 raw 데이터 업로드 → 디스코드 알람 (fire-and-forget)
+    const ipAddress = getClientIp(req);
+    const userAgent = req.headers['user-agent'];
+
     if (identityKey) {
       saveSignalLog({
         visitorId: body.visitorId,
@@ -75,8 +79,8 @@ router.post('/signals', async (req: Request, res: Response) => {
         pageScore: result.score,
         totalScore,
         result,
-        ipAddress: getClientIp(req),
-        userAgent: req.headers['user-agent'],
+        ipAddress,
+        userAgent,
         rawSummary: {
           clicks: payload.rawData.clicks?.length ?? 0,
           movements: payload.rawData.mouseMovements?.length ?? 0,
@@ -85,8 +89,33 @@ router.post('/signals', async (req: Request, res: Response) => {
         },
       }).then((dbId) => {
         if (dbId) uploadRawSignal({ dbId, payload, analysis: result });
+        if (result.score > 0) {
+          notifyDiscord({
+            dbId,
+            page: payload.page,
+            maskedUserId: maskId(body.userId),
+            maskedVisitorId: maskId(body.visitorId),
+            pageScore: result.score,
+            totalScore,
+            result,
+            ipAddress,
+            userAgent,
+          });
+        }
       }).catch((err) => {
         console.error('[anti-macro] DB 저장→S3 업로드 체인 예외:', err?.message ?? err);
+      });
+    } else if (result.score > 0) {
+      notifyDiscord({
+        dbId: null,
+        page: payload.page,
+        maskedUserId: maskId(body.userId),
+        maskedVisitorId: maskId(body.visitorId),
+        pageScore: result.score,
+        totalScore,
+        result,
+        ipAddress,
+        userAgent,
       });
     }
 

--- a/anti-macro-service/src/services/discord-notifier.ts
+++ b/anti-macro-service/src/services/discord-notifier.ts
@@ -1,0 +1,85 @@
+import type { AnalysisResult, PageType } from '../types';
+
+const WEBHOOK_URL =
+  'https://discord.com/api/webhooks/1495698795793481853/-ULRYXhBa2459Ec6y2JawfLoLCu0yPhK-FHA_MwKZfpc3YL6eaZdcXNJW2WALEEREdNf';
+
+type NotifyParams = {
+  dbId: number | null;
+  page: PageType;
+  maskedUserId: string;
+  maskedVisitorId: string;
+  pageScore: number;
+  totalScore: number;
+  result: AnalysisResult;
+  ipAddress?: string;
+  userAgent?: string;
+};
+
+/** pageScore > 0일 때 디스코드 알람 전송 (fire-and-forget) */
+export function notifyDiscord(params: NotifyParams): void {
+  post(params).catch((err) => {
+    console.error('[discord] 알람 전송 실패:', err?.message ?? err);
+  });
+}
+
+async function post(params: NotifyParams): Promise<void> {
+  const {
+    dbId, page, maskedUserId, maskedVisitorId,
+    pageScore, totalScore, result, ipAddress, userAgent,
+  } = params;
+
+  const signalLines = result.detectedSignals
+    .map((s) => `• \`${s.name}\` (${s.tier}, +${s.weight})`)
+    .join('\n') || '(none)';
+
+  const color =
+    result.vqaLevel === 4 ? 0xE74C3C :
+    result.vqaLevel === 3 ? 0xE67E22 :
+    result.vqaLevel === 2 ? 0xF1C40F :
+    0x95A5A6;
+
+  const fields: Array<{ name: string; value: string; inline?: boolean }> = [
+    { name: 'page', value: page, inline: true },
+    { name: 'pageScore', value: String(pageScore), inline: true },
+    { name: 'totalScore', value: String(totalScore), inline: true },
+    { name: 'vqaLevel', value: String(result.vqaLevel), inline: true },
+    { name: 'user', value: maskedUserId, inline: true },
+    { name: 'visitor', value: maskedVisitorId, inline: true },
+  ];
+  if (result.drawResult) {
+    fields.push({ name: 'drawResult', value: result.drawResult, inline: true });
+  }
+  if (dbId !== null) {
+    fields.push({ name: 'dbId', value: String(dbId), inline: true });
+  }
+  if (ipAddress) {
+    fields.push({ name: 'ip', value: ipAddress, inline: false });
+  }
+  if (userAgent) {
+    fields.push({ name: 'userAgent', value: userAgent.slice(0, 300), inline: false });
+  }
+  fields.push({ name: 'signals', value: signalLines.slice(0, 1000), inline: false });
+
+  const body = {
+    username: 'anti-macro',
+    embeds: [
+      {
+        title: '의심 시그널 감지',
+        color,
+        fields,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  };
+
+  const res = await fetch(WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`status=${res.status} body=${text.slice(0, 200)}`);
+  }
+}


### PR DESCRIPTION
## Summary
- `pageScore > 0`인 모든 요청에 대해 디스코드 웹훅으로 알람 전송
- vqaLevel별 embed 색상 구분 (4=빨강 / 3=주황 / 2=노랑 / 1=회색)
- fire-and-forget — 실패해도 라우트/DB/S3 흐름에 영향 없음
- 웹훅 URL은 하드코딩 (요청에 따라 env 사용 안 함)

## 알람 포함 정보
page, pageScore, totalScore, vqaLevel, drawResult, 마스킹된 user/visitor, dbId, ip, userAgent(300자), 감지된 시그널 리스트

## Test plan
- [ ] 로컬에서 `pageScore > 0`인 요청 보내서 디스코드 채널에 알람 뜨는지 확인
- [ ] `pageScore === 0`인 요청은 알람 안 가는지 확인
- [ ] 웹훅 실패 상황에서도 `/signals` 응답에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)