### PR TITLE
fix: 보안퀴즈 통과 또는 차단 시 시도횟수 오류 수정

### DIFF
--- a/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
@@ -277,6 +277,7 @@ public class VqaService {
     private void clearVqaSession(String vqaSessionId, long userId, String phaseType, long phaseId) {
         redisTemplate.delete(VQA_SESSION_KEY_PREFIX + vqaSessionId);
         redisTemplate.delete(getUserSessionKey(userId, phaseType, phaseId));
+        redisTemplate.delete(getGlobalAttemptsKey(userId, phaseType, phaseId));
     }
 
     private String getSessionDataOrThrow(String vqaSessionId) {

--- a/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
+++ b/queue-service/src/main/java/com/t1/popcon/queue/service/VqaService.java
@@ -240,9 +240,11 @@ public class VqaService {
             }
 
             if (nextAttempts >= MAX_ATTEMPTS) {
-                clearVqaSession(vqaSessionId, userId, phaseType, phaseId);
+                redisTemplate.delete(VQA_SESSION_KEY_PREFIX + vqaSessionId);
+                redisTemplate.delete(getUserSessionKey(userId, phaseType, phaseId));
                 blockRepository.block(phaseType, phaseId, userId, queueProperties.getBlockTtlSeconds());
                 cleanupRepository.cleanupUserData(phaseType, phaseId, userId, null);
+                redisTemplate.delete(getGlobalAttemptsKey(userId, phaseType, phaseId));
 
                 log.warn("[VQA] 퀴즈 최종 실패 및 차단 - userId={}, finalAttempts={}/{}", userId, nextAttempts, MAX_ATTEMPTS);
                 registry.counter("popcon_vqa_submit_total",


### PR DESCRIPTION
## #️⃣ 관련 이슈

> Closes #290 

## 📝 작업 내용

> 기존 로직에서 보안퀴즈 통과 또는 차단시 시도횟수를 초기화하지 않는 버그 수정작업 진행했습니다.

## ✅ 테스트 결과 (선택)

>

## 📷 스크린샷 (선택)

>

## 💬 리뷰 요구사항(선택)

> 